### PR TITLE
Listing translation files 

### DIFF
--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -124,7 +124,7 @@ class TranslationReducer extends CachingWriter {
   build() {
     let outputPath = `${this.outputPath}/${this.options.outputPath}`;
     let baseLocale = this.options.baseLocale;
-    let translations = this.readDirectory(this.inputPaths[0], this.listFiles());
+    let translations = this.readDirectory(this.inputPaths[0], this.listFiles().filter(file => file.endsWith('.yaml') || file.endsWith('.json')));
     let defaultTranslationKeys, defaultTranslation, translation;
     mkdirp.sync(outputPath);
 

--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -124,8 +124,8 @@ class TranslationReducer extends CachingWriter {
   build() {
     let outputPath = `${this.outputPath}/${this.options.outputPath}`;
     let baseLocale = this.options.baseLocale;
-    let translations = this.readDirectory(this.inputPaths[0], this.listFiles().filter(file => file.endsWith('.yaml') || file.endsWith('.json')));
-    let defaultTranslationKeys, defaultTranslation, translation;
+    let translations = this.readDirectory(this.inputPaths[0], this.listFiles().filter(file => file.endsWith('.yaml') || file.endsWith('.yml') || file.endsWith('.json')));
+    let defaultTranslationKeys, defaultTranslation, translation
     mkdirp.sync(outputPath);
 
     if (baseLocale) {


### PR DESCRIPTION
Fixing listing translation files so only `.json` and `.yaml` would be considered as valid translation files.

I need that because I am keeping my translations inside pods directory and now it's trying to find translations inside `.js` files which is wrong for sure.  It might be also useful for performance reason.
