### PR TITLE
Show emoji flags for log lines with locales

### DIFF
--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -55,6 +55,10 @@ class TranslationReducer extends CachingWriter {
     return locale;
   }
 
+  _logLocale(locale, message, options) {
+    this._log(`${locale}: ${message}`, options);
+  }
+
   _log(msg, options) {
     if (this.options.log) {
       return this.options.log.apply(undefined, arguments);
@@ -66,7 +70,7 @@ class TranslationReducer extends CachingWriter {
 
     defaultTranslationKeys.forEach(property => {
       if (targetProps.indexOf(property) === -1) {
-        this._log(`${locale}: "${property}" message is missing`);
+        this._logLocale(locale, `"${property}" message is missing`);
       }
     });
   }
@@ -162,7 +166,7 @@ class TranslationReducer extends CachingWriter {
       try {
         validateMessage(message, locale);
       } catch (error) {
-        this._log(`${locale}: "${key}" message can not be parsed: ${error.message}`, { warning: true });
+        this._logLocale(locale, `"${key}" message can not be parsed: ${error.message}`, { warning: true });
       }
     });
   }

--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -14,6 +14,8 @@ let extend = require('extend');
 let yaml = require('js-yaml');
 let path = require('path');
 let fs = require('fs');
+let hasUnicode = require('has-unicode');
+let localeEmoji = require('locale-emoji');
 
 let propKeys = require('../utils/prop-keys');
 let forEachMessage = require('../utils/for-each-message');
@@ -45,6 +47,8 @@ class TranslationReducer extends CachingWriter {
     this.options = Object.assign({
       log() {}
     }, options);
+
+    this._supportsUnicode = hasUnicode();
   }
 
   normalizeLocale(locale) {
@@ -56,7 +60,15 @@ class TranslationReducer extends CachingWriter {
   }
 
   _logLocale(locale, message, options) {
-    this._log(`${locale}: ${message}`, options);
+    let fullMessage = `${locale}: ${message}`;
+    if (this._supportsUnicode) {
+      let emoji = localeEmoji(locale.replace(/-([a-z]{2})$/, (match, it) => `-${it.toUpperCase()}`));
+      if (emoji) {
+        fullMessage = `${emoji}  ${fullMessage}`;
+      }
+    }
+
+    this._log(fullMessage, options);
   }
 
   _log(msg, options) {

--- a/package.json
+++ b/package.json
@@ -72,10 +72,12 @@
     "ember-intl-relativeformat": "^2.4.0",
     "exists-sync": "0.0.3",
     "extend": "^3.0.0",
+    "has-unicode": "^2.0.1",
     "intl": "1.0.1",
     "intl-messageformat-parser": "^1.2.0",
     "js-yaml": "^3.3.1",
     "json-stable-stringify": "^1.0.0",
+    "locale-emoji": "^0.1.0",
     "mkdirp": "^0.5.0",
     "silent-error": "^1.0.0",
     "walk-sync": "^0.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,7 +2737,7 @@ has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
 
-has-unicode@^2.0.0, has-unicode@~2.0.1:
+has-unicode@^2.0.0, has-unicode@^2.0.1, has-unicode@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
@@ -3308,6 +3308,10 @@ livereload-js@^2.2.2:
 loader.js@^4.0.10:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.1.0.tgz#1d0897a62f8b7375d3d9cd1ae6acf798c36c1ffe"
+
+locale-emoji@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/locale-emoji/-/locale-emoji-0.1.0.tgz#f4cb8ae5bfac3e60e8ae188fbf9eb6b48d9a7124"
 
 lockfile@~1.0.1:
   version "1.0.3"


### PR DESCRIPTION
<img width="1074" alt="bildschirmfoto 2017-02-27 um 22 10 42" src="https://cloud.githubusercontent.com/assets/141300/23380232/3a58302c-fd3a-11e6-945b-277468fb7ada.png">

this is using:

- https://github.com/iarna/has-unicode to figure out if the terminal supports unicode (and possibly emojis)
- https://github.com/10xjs/locale-emoji to turn locale string to emoji

/cc @jasonmit 