### PR TITLE
Synchronous addTranslations/addTranslation API

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -20,7 +20,6 @@ const {
   makeArray,
   get,
   set,
-  RSVP,
   Service,
   Evented,
   deprecate
@@ -209,15 +208,11 @@ const IntlService = Service.extend(Evented, {
   },
 
   addTranslation(localeName, key, value) {
-    return this.localeFactory(localeName).then((locale) => {
-      return locale.addTranslation(key, value);
-    });
+    this.localeFactory(localeName).addTranslation(key, value);
   },
 
-  addTranslations(localeName, payload) {
-    return this.localeFactory(localeName).then((locale) => {
-      return locale.addTranslations(payload);
-    });
+  addTranslations(localeName, hash) {
+    this.localeFactory(localeName).addTranslations(hash);
   },
 
   setLocale(localeName) {
@@ -245,7 +240,7 @@ const IntlService = Service.extend(Evented, {
   },
 
   localeFactory(localeName) {
-    return RSVP.cast(get(this, 'adapter').localeFactory(normalizeLocale(localeName), true));
+    return get(this, 'adapter').localeFactory(normalizeLocale(localeName), true);
   },
 
   createLocale(localeName, payload) {

--- a/tests/dummy/app/formats.js
+++ b/tests/dummy/app/formats.js
@@ -6,7 +6,13 @@ const hhmmss = {
 
 export default {
   date: {
-    hhmmss: hhmmss
+    hhmmss: hhmmss,
+    shortWeekDay: {
+      timeZone: 'UTC',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    }
   },
   time: {
     hhmmss: hhmmss

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -52,7 +52,6 @@ test('`t` can be passed a null options hash', function(assert) {
 });
 
 test('`t` can be passed a no options argument and no warning should be emitted', function(assert) {
-  const done = assert.async();
   service.setLocale('en');
 
   let invokedWarn = false;
@@ -62,16 +61,13 @@ test('`t` can be passed a no options argument and no warning should be emitted',
     invokedWarn = true;
   };
 
-  service.addTranslation('en', 'foo', 'FOO').then(function() {
-    service.t('foo');
-    assert.ok(!invokedWarn, 'Warning was not raised');
-    Ember.warn = originalWarn;
-    done();
-  });
+  service.addTranslation('en', 'foo', 'FOO');
+  service.t('foo');
+  assert.ok(!invokedWarn, 'Warning was not raised');
+  Ember.warn = originalWarn;
 });
 
 test('`t` can not pass options as undefined with a warning being emitted', function(assert) {
-  const done = assert.async();
   service.setLocale('en');
 
   let invokedWarn = false;
@@ -81,10 +77,8 @@ test('`t` can not pass options as undefined with a warning being emitted', funct
     invokedWarn = true;
   };
 
-  service.addTranslation('en', 'foo', 'FOO').then(function() {
-    service.t('foo', null);
-    assert.ok(invokedWarn, 'Warning was raised');
-    Ember.warn = originalWarn;
-    done();
-  });
+  service.addTranslation('en', 'foo', 'FOO');
+  service.t('foo', null);
+  assert.ok(invokedWarn, 'Warning was raised');
+  Ember.warn = originalWarn;
 });


### PR DESCRIPTION
This is a breaking change to convert addTranslation/addTranslations to being synchronous.  Simplifies the API and aligns with ember-i18n's API.