### PR TITLE
Remove translationsFor

### DIFF
--- a/addon/adapters/default.js
+++ b/addon/adapters/default.js
@@ -71,10 +71,6 @@ const DefaultTranslationAdapter = Ember.Object.extend({
     }
   },
 
-  translationsFor(localeName) {
-    return this.localeFactory(localeName);
-  },
-
   findTranslationByKey(localeNames, translationKey) {
     return this.lookup(localeNames, translationKey);
   }

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -253,10 +253,6 @@ const IntlService = Service.extend(Evented, {
 
   findTranslationByKey(key, localeName, options) {
     return this.lookup(key, localeName, options);
-  },
-
-  translationsFor(localeName) {
-    return this.localeFactory(localeName);
   }
 });
 


### PR DESCRIPTION
The method name did not properly reflect that it returns the locale model.

Migration path: use `localeFactory` instead.  Same method signature as `translationsFor`