### PR TITLE
Getvalue to lookup

### DIFF
--- a/addon/adapters/default.js
+++ b/addon/adapters/default.js
@@ -65,8 +65,12 @@ const DefaultTranslationAdapter = Ember.Object.extend({
       const localeName = localeNames[i];
       const model = this.lookupLocale(localeName);
 
-      if (model && model.has(translationKey)) {
-        return model.getValue(translationKey);
+      if (model) {
+        const translation = model.lookup(translationKey);
+
+        if (translation) {
+          return translation;
+        }
       }
     }
   },

--- a/addon/models/translation.js
+++ b/addon/models/translation.js
@@ -39,7 +39,7 @@ const TranslationModel = Ember.Object.extend({
    * This would enable consumers that have dot notated strings
    * to implement this function as `return this[key];`
    */
-  getValue(key) {
+  lookup(key) {
     return get(this.translations, key);
   },
 
@@ -47,7 +47,7 @@ const TranslationModel = Ember.Object.extend({
    * Determines if the translation model contains a key
    */
   has(key) {
-    return typeof this.getValue(key) === 'string';
+    return typeof this.lookup(key) === 'string';
   }
 });
 

--- a/blueprints/ember-intl-dot-notation/files/app/models/ember-intl-translation.js
+++ b/blueprints/ember-intl-dot-notation/files/app/models/ember-intl-translation.js
@@ -5,7 +5,7 @@ export default TranslationModel.extend({
     this.translations[key] = value;
   },
 
-  getValue(key) {
+  lookup(key) {
     return this.translations[key];
   }
 });

--- a/tests/unit/models/translation-test.js
+++ b/tests/unit/models/translation-test.js
@@ -16,7 +16,7 @@ test('can handle deeply nested object passed into addTranslations', function(ass
     }
   });
 
-  assert.equal(this.model.getValue('foo.bar.baz'), 'BAZ WORKZ');
+  assert.equal(this.model.lookup('foo.bar.baz'), 'BAZ WORKZ');
 });
 
 test('can handle flat object shape passed into addTranslations', function(assert) {
@@ -24,5 +24,5 @@ test('can handle flat object shape passed into addTranslations', function(assert
     baz: 'BAZZZ'
   });
 
-  assert.equal(this.model.getValue('baz'), 'BAZZZ');
+  assert.equal(this.model.lookup('baz'), 'BAZZZ');
 });


### PR DESCRIPTION
Migration path: For most, nothing will be needed.  For users of the dot notation blueprint, they'll need to rerun `ember g ember-intl-dot-notation` as part of the upgrade process to 3.0.