### PR TITLE
Removing `getLocalesByTranslations` in favor of `locales`

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -21,8 +21,7 @@ const {
   get,
   set,
   Service,
-  Evented,
-  deprecate
+  Evented
 } = Ember;
 const assign = Ember.assign || Ember.merge;
 
@@ -183,14 +182,6 @@ const IntlService = Service.extend(Evented, {
     return localeNames.some((localeName) => {
       return adapter.has(localeName, key);
     });
-  },
-
-  getLocalesByTranslations() {
-    deprecate('[ember-intl] `getLocalesByTranslations` is deprecated, use `locales` computed property', false, {
-      id: 'ember-intl-locales-cp'
-    });
-
-    return get(this, 'locales');
   },
 
   /**

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -176,10 +176,9 @@ test('exists returns true when key found', function(assert) {
 });
 
 test('able to discover all register translations', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
   this.intl.addTranslation('es_MX', 'foo', 'bar'); /* tests that the locale name becomes normalized to es-mx */
   this.intl.exists('test', 'fr-ca');
-  assert.equal(this.intl.getLocalesByTranslations().join('; '), 'en-us; es-es; fr-fr; es-mx');
   assert.equal(this.intl.get('locales').join('; '), 'en-us; es-es; fr-fr; es-mx');
 });
 


### PR DESCRIPTION
Migration path: Use `locales` instead of `getLocalesByTranslations`