### PR TITLE
Fixing failing tests

### DIFF
--- a/tests/helpers/expect-error.js
+++ b/tests/helpers/expect-error.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+const { assert, Test, run } = Ember;
+
+export default function expectError(fn, handler) {
+  assert('Error handler must be provided to expectError', typeof handler === 'function');
+
+  let lastError = null;
+  let adapter = Test.adapter;
+
+  let TestAdapter = Test.adapter.constructor.extend({
+    exception(error) {
+      lastError = error;
+    }
+  });
+
+  run(() => Test.adapter = TestAdapter.create());
+
+  try { fn(); } catch(error) {
+    lastError = error;
+  }
+
+  run(Test.adapter, 'destroy');
+  Test.adapter = adapter;
+
+  if (lastError) {
+    return handler(lastError);
+  }
+
+  throw new Error(`No error was thrown from within "${fn}"`);
+}

--- a/tests/unit/helpers/format-html-message-test.js
+++ b/tests/unit/helpers/format-html-message-test.js
@@ -1,6 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatHtmlHelper from 'ember-intl/helpers/format-html-message';
+import expectError from '../../helpers/expect-error';
 
 let service, registry;
 
@@ -45,11 +46,9 @@ test('message is formatted correctly with argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
   assert.expect(1);
 
-  try {
-    this.render(hbs`{{format-html-message}}`);
-  } catch(ex) {
-    assert.ok(ex, 'raised error when not value is passed to format-html-message');
-  }
+  expectError(() => this.render(hbs`{{format-html-message}}`), (ex) => {
+    assert.ok(ex.message.match(/Assertion Failed: \[ember-intl\] translation lookup attempted but no translation key was provided\./));
+  });
 });
 
 test('should allow for inlined html in the value', function(assert) {

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatMessageHelper from 'ember-intl/helpers/format-message';
+import expectError from '../../helpers/expect-error';
 
 const { get, set, computed, run, A:emberArray, Object:EmberObject } = Ember;
 
@@ -66,11 +67,9 @@ test('message is formatted correctly with argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
   assert.expect(1);
 
-  try {
-    this.render(hbs`{{format-message}}`);
-  } catch(ex) {
-    assert.ok(ex, 'raised error when not value is passed to format-message');
-  }
+  expectError(() => this.render(hbs`{{format-message}}`), (ex) => {
+    assert.ok(ex.message.match(/Assertion Failed: \[ember-intl\] translation lookup attempted but no translation key was provided\./));
+  });
 });
 
 test('should return nothing if key does not exist and allowEmpty is set to true', function(assert) {

--- a/tests/unit/helpers/format-number-test.js
+++ b/tests/unit/helpers/format-number-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatNumberHelper from 'ember-intl/helpers/format-number';
+import expectError from '../../helpers/expect-error';
 
 let service, registry;
 
@@ -54,11 +55,7 @@ test('number is formatted correctly with locale argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
   assert.expect(1);
 
-  try {
-    this.render(hbs`{{format-number}}`);
-  } catch(ex) {
-    assert.ok(ex, 'raised error when not value is passed to format-number');
-  }
+  expectError(() => this.render(hbs`{{format-number}}`), (ex) => assert.ok(ex));
 });
 
 test('should return a string', function(assert) {

--- a/tests/unit/helpers/format-relative-test.js
+++ b/tests/unit/helpers/format-relative-test.js
@@ -1,6 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import formatRelativehelper from 'ember-intl/helpers/format-relative';
+import expectError from '../../helpers/expect-error';
 
 let service, registry;
 
@@ -40,11 +41,7 @@ test('invoke the formatRelative directly', function(assert) {
 test('should throw if called with out a value', function(assert) {
   assert.expect(1);
 
-  try {
-    this.render(hbs`{{format-relative}}`);
-  } catch(ex) {
-    assert.ok(ex, 'raised error when not value is passed to format-relative');
-  }
+  expectError(() => this.render(hbs`{{format-relative}}`), (ex) => assert.ok(ex));
 });
 
 test('can specify a `value` and `now` on the options hash', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,7 +694,7 @@ broccoli-kitchen-sink-helpers@^0.3.1:
     glob "^5.0.10"
     mkdirp "^0.5.1"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.3:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.1.tgz#16a7494ed56dbe61611f6c2d4817cfbaad2a3055"
   dependencies:
@@ -706,6 +706,13 @@ broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
+
+broccoli-merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz#10aea46dd5cebcc8b8f7d5a54f0a84a4f0bb90b9"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^1.0.1"
 
 broccoli-middleware@^0.18.1:
   version "0.18.1"
@@ -3675,6 +3682,17 @@ memory-streams@^0.1.0:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge-trees@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-1.0.1.tgz#ccbe674569787f9def17fd46e6525f5700bbd23e"
+  dependencies:
+    can-symlink "^1.0.0"
+    fs-tree-diff "^0.5.4"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
 
 merge@^1.1.3, merge@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Recent changes within Ember changed the behavior of how Ember handles errors within testing.  This corrects the behavior until the fix lands either within Ember or ember-mocha.