### PR TITLE
Avoids having to `needs` formatters within testing

### DIFF
--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -15,8 +15,6 @@ function assertIsDate(date, errMsg) {
 }
 
 const FormatDate = Formatter.extend({
-  formatType: 'date',
-
   formatter: computed({
     get() {
       return createFormatCache(Intl.DateTimeFormat);
@@ -34,6 +32,7 @@ const FormatDate = Formatter.extend({
 });
 
 FormatDate.reopenClass({
+  formatType: 'date',
   supportedOptions: [
     'localeMatcher', 'timeZone', 'hour12', 'formatMatcher', 'weekday',
     'era', 'year', 'month', 'day', 'hour', 'minute', 'second',

--- a/addon/formatters/format-html-message.js
+++ b/addon/formatters/format-html-message.js
@@ -31,4 +31,8 @@ const FormatHtmlMessage = FormatterMessage.extend({
   }
 });
 
+FormatHtmlMessage.reopenClass({
+  formatType: 'html-message'
+});
+
 export default FormatHtmlMessage;

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -27,4 +27,8 @@ const FormatMessage = Formatter.extend({
   }
 });
 
+FormatMessage.reopenClass({
+  formatType: 'message'
+});
+
 export default FormatMessage;

--- a/addon/formatters/format-number.js
+++ b/addon/formatters/format-number.js
@@ -11,8 +11,6 @@ import Formatter from './-base';
 const { computed } = Ember;
 
 const FormatNumber = Formatter.extend({
-  formatType: 'number',
-
   formatter: computed({
     get() {
       return createFormatCache(Intl.NumberFormat);
@@ -25,6 +23,7 @@ const FormatNumber = Formatter.extend({
 });
 
 FormatNumber.reopenClass({
+  formatType: 'number',
   supportedOptions: [
     'localeMatcher', 'style', 'currency', 'currencyDisplay',
     'useGrouping', 'minimumIntegerDigits', 'minimumFractionDigits',

--- a/addon/formatters/format-relative.js
+++ b/addon/formatters/format-relative.js
@@ -16,8 +16,6 @@ function assertIsDate(date, errMsg) {
 }
 
 const FormatRelative = Formatter.extend({
-  formatType: 'relative',
-
   formatter: computed({
     get() {
       return createFormatCache(IntlRelativeFormat);
@@ -36,6 +34,7 @@ const FormatRelative = Formatter.extend({
 });
 
 FormatRelative.reopenClass({
+  formatType: 'relative',
   supportedOptions: ['style', 'units']
 });
 

--- a/addon/formatters/format-time.js
+++ b/addon/formatters/format-time.js
@@ -5,7 +5,9 @@
 
 import FormatDateFormatter from './format-date';
 
-const FormatTime = FormatDateFormatter.extend({
+const FormatTime = FormatDateFormatter.extend();
+
+FormatTime.reopenClass({
   formatType: 'time'
 });
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -26,12 +26,6 @@ moduleForComponent('x-product', 'XProductComponent', {
      * Below are optional.  You only need to include to formatters and helpers
      * that are utilized within your test.
      */
-    'ember-intl@formatter:format-message',
-    'ember-intl@formatter:format-html-message',
-    'ember-intl@formatter:format-date',
-    'ember-intl@formatter:format-time',
-    'ember-intl@formatter:format-number',
-    'ember-intl@formatter:format-relative',
     'helper:intl-get',
     'helper:t',
     'helper:t-html',


### PR DESCRIPTION
I'd prefer to keep testing as simple as possible, since formatters to not rely on injections and are stateless objects we can reuse them but we also can avoid going through the owner API to resolve them.

The formatter API is private and current tests will continue to work just fine w/o changes.. so this is fine to version in the next minor.