### PR TITLE
Remove assertion of what the formatter expected, let Intl constructor…

### DIFF
--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -36,9 +36,12 @@ const FormatterBase = EmberObject.extend({
   * @return {Object} Options object containing just whitelisted options
   * @private
   */
-  filterSupporedOptions(input = {}) {
-    const out = {};
+  filterSupporedOptions(input) {
+    if (!input) {
+      return {};
+    }
 
+    let out = {};
     let foundMatch = false;
     let camelizedKey;
 

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -18,12 +18,8 @@ const FormatMessage = Formatter.extend({
     }
   }).readOnly(),
 
-  format(value, options = {}, ctx = {}) {
-    const { formats, locale } = ctx;
-    const formatter = get(this, 'formatter');
-
-    /* locale can be a locale string or an array of locale strings */
-    return formatter(value, locale, formats).format(options);
+  format(value, options, { formats, locale }) {
+    return get(this, 'formatter')(value, locale, formats).format(options);
   }
 });
 

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -36,17 +36,7 @@ const assign = Ember.assign || Ember.merge;
 
 function formatterProxy(ctr) {
   return function(value, options, formats) {
-    if (!options) {
-      if (arguments.length > 1) {
-        Ember.warn(`[ember-intl] expected object for formatter ${ctr.formatType} but received ${typeof options}`, false, {
-          id: 'ember-intl-missing-formatter-args'
-        });
-      }
-
-      options = {};
-    }
-
-    if (typeof options.format === 'string') {
+    if (options && typeof options.format === 'string') {
       options = assign(assign({}, this.getFormat(ctr.formatType, options.format)), options);
     }
 
@@ -58,7 +48,7 @@ function formatterProxy(ctr) {
 
     return formatter.format(value, options, {
       formats: formats || get(this, 'formats'),
-      locale: this._localeWithDefault(options.locale)
+      locale: this._localeWithDefault(options && options.locale)
     });
   };
 }

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -69,22 +69,3 @@ test('`t` can be passed a no options argument and no warning should be emitted',
     done();
   });
 });
-
-test('`t` can not pass options as undefined with a warning being emitted', function(assert) {
-  const done = assert.async();
-  service.setLocale('en');
-
-  let invokedWarn = false;
-  const originalWarn = Ember.warn;
-
-  Ember.warn = function() {
-    invokedWarn = true;
-  };
-
-  service.addTranslation('en', 'foo', 'FOO').then(function() {
-    service.t('foo', null);
-    assert.ok(invokedWarn, 'Warning was raised');
-    Ember.warn = originalWarn;
-    done();
-  });
-});


### PR DESCRIPTION
The reason behind this is `new Intl.DateTimeFormat().format()` is valid -- returns the current date/time.  The helpers currently have this concept of `allowEmpty` which in order to remove would be a breaking change so I'm holding off on the next phase of this until 3.0.