### PR TITLE
deprecate current use of {{format-message}} and {{format-html-message}}

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Recompute the relative timestamp on an interval by passing an `interval` argumen
 [List of supported format date options](https://github.com/ember-intl/ember-intl/blob/master/docs/format-relative-options.md)
 
 ### Format Message
-Formats [ICU Message][ICU] strings with the given values supplied as the hash arguments.  A short-hand form of the `{{format-message}}` is `{{t}}`.
+Formats [ICU Message][ICU] strings with the given values supplied as the hash arguments.
 
 ```
 You have {numPhotos, plural,
@@ -238,23 +238,23 @@ export default Ember.Component.extend({
 This is done by using the `{{l}}` (lowercase L) helper as a subexpression.  This is useful for computed properties where you are programmatically constructing a translation string.
 
 ```hbs
-{{t (l '{name} took {numPhotos, plural,\n  =0 {no photos}\n  =1 {one photo}\n  other {# photos}\n} on {takenDate, date, long}')
+{{format-message (l '{name} took {numPhotos, plural,\n  =0 {no photos}\n  =1 {one photo}\n  other {# photos}\n} on {takenDate, date, long}')
     name='Jason'
     numPhotos=num
     takenDate=yesterday}}
 ```
 
 ### Format HTML Message
-This delegates to the `{{t}}` helper, but will first HTML-escape all of the hash argument values. This allows the `message` string to contain HTML and it will be considered safe since it's part of the template and not user-supplied data.
+Escapes all hash arguments and returns as an htmlSafe String which renders an ElementNode.  To enable rendering HTML within translations, pass an `htmlSafe` attribute to the `t` helper.
 
 ```hbs
-{{t-html 'product.html.info'
+{{t 'product.html.info'
+  htmlSafe=true
   product='Apple watch'
   price=200
   deadline=yesterday}}
 
-{{t-html (l '<strong>{numPhotos}</strong>')
-  numPhotos=(format-number num)}}
+{{format-html-message (l '<strong>{numPhotos}</strong>') numPhotos=(format-number num)}}
 ```
 
 ## Named Formats

--- a/addon/helpers/format-html-message.js
+++ b/addon/helpers/format-html-message.js
@@ -8,6 +8,7 @@ import { getValue } from './format-message';
 
 export default BaseHelper.extend({
   getValue,
+  helperType: 'format-html-message',
 
   format(value, options) {
     return this.intl.formatHtmlMessage(value, options);

--- a/addon/helpers/format-message.js
+++ b/addon/helpers/format-message.js
@@ -8,7 +8,7 @@ import Ember from 'ember';
 import { LiteralWrapper } from './l';
 import BaseHelper from './-format-base';
 
-const { assert } = Ember;
+const { assert, deprecate } = Ember;
 
 export function getValue([key], options) {
   if (key && key instanceof LiteralWrapper) {
@@ -16,6 +16,15 @@ export function getValue([key], options) {
   }
 
   assert('[ember-intl] translation lookup attempted but no translation key was provided.', key);
+
+  deprecate(
+    `[ember-intl] {{${this.helperType}}} only accepts translation strings as the first parameter.  You likely want to use the {{t}} helper instead.`,
+    false,
+    {
+      id: `ember-intl-${this.helperType}-string-literals-only`,
+      until: '3.0.0'
+    }
+  );
 
   const {
     fallback,
@@ -35,6 +44,7 @@ export function getValue([key], options) {
 
 export default BaseHelper.extend({
   getValue,
+  helperType: 'format-message',
 
   format(value, options) {
     return this.intl.formatMessage(value, options);

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -15,13 +15,10 @@ const IntlGetHelper = Helper.extend({
   init() {
     this._super();
 
-    deprecate(
-      `[ember-int] intl-get is deprecated, use {{t 'translation.key'}} or {{format-message 'translation.key'}}`,
-      false,
-      {
-        id: 'ember-intl-t-helper'
-      }
-    );
+    deprecate(`[ember-int] intl-get is deprecated, use {{t 'translation.key'}}`, false, {
+      id: 'ember-intl-t-helper',
+      until: '3.0.0'
+    });
 
     get(this, 'intl').on('localeChanged', this, this.recompute);
   },

--- a/addon/helpers/t.js
+++ b/addon/helpers/t.js
@@ -1,1 +1,41 @@
-export { default } from './format-message';
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import Ember from 'ember';
+
+import BaseHelper from './-format-base';
+
+const { assert } = Ember;
+
+export function getValue([translationKey], options) {
+  assert('[ember-intl] translation lookup attempted but no translation key was provided.', translationKey);
+
+  const {
+    fallback,
+    allowEmpty,
+    defaultMessage,
+    locale: optionalLocale
+  } = options;
+
+  const fallbackTranslation = defaultMessage || fallback;
+
+  const translation = this.intl.lookup(translationKey, optionalLocale, {
+    resilient: allowEmpty || typeof fallbackTranslation === 'string'
+  });
+
+  return typeof translation === 'string' ? translation : fallbackTranslation;
+}
+
+export default BaseHelper.extend({
+  getValue,
+
+  format(value, options) {
+    if (options && options.htmlSafe === true) {
+      return this.intl.formatHtmlMessage(value, options);
+    }
+
+    return this.intl.formatMessage(value, options);
+  }
+});

--- a/addon/models/translation.js
+++ b/addon/models/translation.js
@@ -50,7 +50,8 @@ const TranslationModel = Ember.Object.extend({
 
     if (typeof translation === 'string') {
       deprecate('[ember-intl] translations should be added via the `addTranslations`/`addTranslation` API.', false, {
-        id: 'ember-intl-add-translation'
+        id: 'ember-intl-add-translation',
+        until: '3.0.0'
       });
 
       return translation;

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -195,7 +195,8 @@ const IntlService = Service.extend(Evented, {
 
   getLocalesByTranslations() {
     deprecate('[ember-intl] `getLocalesByTranslations` is deprecated, use `locales` computed property', false, {
-      id: 'ember-intl-locales-cp'
+      id: 'ember-intl-locales-cp',
+      until: '3.0.0'
     });
 
     return get(this, 'locales');
@@ -259,7 +260,8 @@ const IntlService = Service.extend(Evented, {
 
   createLocale(localeName, payload) {
     deprecate('[ember-intl] `createLocale` is deprecated, use `addTranslations`', false, {
-      id: 'ember-intl-create-locale'
+      id: 'ember-intl-create-locale',
+      until: '3.0.0'
     });
 
     return this.addTranslations(localeName, payload);

--- a/app/instance-initializers/ember-intl.js
+++ b/app/instance-initializers/ember-intl.js
@@ -5,9 +5,12 @@
 
 import Ember from 'ember';
 
+const { deprecate } = Ember;
+
 export function instanceInitializer(instance) {
-  Ember.deprecate('[ember-intl] instance initializer is deprecated, no longer necessary to call in testing.', false, {
-    id: 'ember-intl-instance-initalizer'
+  deprecate('[ember-intl] instance initializer is deprecated, no longer necessary to call in testing.', false, {
+    id: 'ember-intl-instance-initalizer',
+    until: '3.0.0'
   });
 }
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -29,7 +29,8 @@ moduleForComponent('x-product', 'XProductComponent', {
      */
     'helper:intl-get',
     'helper:t',
-    'helper:t-html',
+    'helper:format-message',
+    'helper:format-html-message',
     'helper:format-date',
     'helper:format-time',
     'helper:format-relative',

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "http://jasonmit.github.io/ember-intl-example/"
+    "demoURL": "https://ember-intl.github.io/"
   },
   "greenkeeper": {
     "ignore": [

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -49,7 +49,8 @@
 
 <h3>Format HTML Message</h3>
 <div>
-  {{format-html-message 'product.html.info'
+  {{t 'product.html.info'
+    htmlSafe=true
     product='Apple watch'
     price=200
     deadline=yesterday}}

--- a/tests/dummy/snippets/format-html-message.hbs
+++ b/tests/dummy/snippets/format-html-message.hbs
@@ -1,4 +1,5 @@
-{{format-html-message 'product.html.info'
+{{t 'product.html.info'
+  htmlSafe=true
   product='Apple watch'
   price=200
   deadline=yesterday}}

--- a/tests/unit/helpers/format-html-message-test.js
+++ b/tests/unit/helpers/format-html-message-test.js
@@ -3,14 +3,12 @@ import { moduleForComponent, test } from 'ember-qunit';
 import formatHtmlHelper from 'ember-intl/helpers/format-html-message';
 import expectError from '../../helpers/expect-error';
 
-let service;
-
 moduleForComponent('format-html-message', {
   integration: true,
   beforeEach() {
-    service = this.container.lookup('service:intl');
-    service.addTranslations('en-us', { foo: { bar: 'foo bar baz', baz: 'baz baz baz' } });
-    service.setLocale('en-us');
+    this.inject.service('intl');
+    this.intl.addTranslations('en-us', { foo: { bar: 'foo bar baz', baz: 'baz baz baz' } });
+    this.intl.setLocale('en-us');
   }
 });
 
@@ -22,7 +20,7 @@ test('exists', function(assert) {
 test('invoke the formatHTMLMessage directly', function(assert) {
   assert.expect(1);
   assert.equal(
-    service.formatHtmlMessage('<strong>Hello {name} {count, number}</strong>', {
+    this.intl.formatHtmlMessage('<strong>Hello {name} {count, number}</strong>', {
       name: '<em>Jason</em>',
       count: 42000
     }).string,
@@ -33,7 +31,7 @@ test('invoke the formatHTMLMessage directly', function(assert) {
 test('invoke the formatHTMLMessage directly with inlined locale', function(assert) {
   assert.expect(1);
 
-  let output = service.formatHtmlMessage('<strong>Hello {name} {count, number}</strong>', {
+  let output = this.intl.formatHtmlMessage('<strong>Hello {name} {count, number}</strong>', {
     name: '<em>Jason</em>',
     count: 42000,
     locale: 'fr-fr'

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -79,12 +79,6 @@ test('should throw if called with out a value', function(assert) {
   );
 });
 
-test('should return nothing if key does not exist and allowEmpty is set to true', function(assert) {
-  assert.expect(1);
-  this.render(hbs`{{t 'does.not.exist' allowEmpty=true}}`);
-  assert.equal(this.$().text(), '');
-});
-
 test('should return a formatted string', function(assert) {
   assert.expect(1);
 
@@ -150,68 +144,6 @@ test('should return a formatted string with an `each` block', function(assert) {
   assert.equal(this.$().text().trim(), 'Allison harvested 10 apples.Jeremy harvested 60 apples.');
 });
 
-test('locale can add message to intl service and read it', function(assert) {
-  assert.expect(1);
-
-  run(() => {
-    this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'oh', 'hai!').then(() => {
-      this.render(hbs`{{t 'oh'}}`);
-      assert.equal(this.$().text(), 'hai!');
-    });
-  });
-});
-
-test('translation value can be an empty string', function(assert) {
-  assert.expect(1);
-
-  run(() => {
-    this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'empty_translation', '').then(() => {
-      this.render(hbs`{{t 'empty_translation'}}`);
-      assert.equal(this.$().text(), '');
-    });
-  });
-});
-
-test('locale can add messages object and can read it', function(assert) {
-  assert.expect(1);
-
-  return this.intl
-    .addTranslations(DEFAULT_LOCALE_NAME, {
-      'bulk-add': 'bulk add works'
-    })
-    .then(() => {
-      this.render(hbs`{{t 'bulk-add'}}`);
-      assert.equal(this.$().text(), 'bulk add works');
-    });
-});
-
-test('can inline locale for missing locale', function(assert) {
-  assert.expect(1);
-  this.render(hbs`{{t 'foo.bar' locale='xx-xx'}}`);
-  assert.equal(this.$().text(), `Missing translation: foo.bar`);
-});
-
-test('exists returns false when key not found', function(assert) {
-  assert.expect(1);
-  assert.equal(this.intl.exists('bar'), false);
-});
-
-test('exists returns true when key found', function(assert) {
-  assert.expect(1);
-
-  return this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'hello', 'world').then(() => {
-    assert.equal(this.intl.exists('hello'), true);
-  });
-});
-
-test('translations that are empty strings are valid', function(assert) {
-  assert.expect(1);
-
-  return this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'empty_string', '').then(() => {
-    assert.equal(this.intl.t('empty_string'), '');
-  });
-});
-
 test('able to discover all register translations', function(assert) {
   assert.expect(2);
   this.intl.addTranslation('es_MX', 'foo', 'bar');
@@ -250,18 +182,6 @@ test('intl-get returns message for key that is a literal string (not an object p
     // reset the function back
     translation.getValue = fn;
   }
-});
-
-test('should fallback to with defaultMessage when key not found', function(assert) {
-  assert.expect(1);
-  this.render(hbs`{{t 'app.sale_begins' defaultMessage='Sale begins {day, date, shortWeekDay}' day=1390518044403}}`);
-  assert.equal(this.$().text(), 'Sale begins January 23, 2014');
-});
-
-test('should fallback to with fallback when key not found', function(assert) {
-  assert.expect(1);
-  this.render(hbs`{{t 'app.sale_begins' fallback='Sale begins {day, date, shortWeekDay}' day=1390518044403}}`);
-  assert.equal(this.$().text(), 'Sale begins January 23, 2014');
 });
 
 test('l helper handles bound computed property', function(assert) {

--- a/tests/unit/helpers/t-test.js
+++ b/tests/unit/helpers/t-test.js
@@ -1,0 +1,101 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import tHelper from 'ember-intl/helpers/t';
+
+const { run } = Ember;
+
+const DEFAULT_LOCALE_NAME = 'en-us';
+
+moduleForComponent('t', {
+  integration: true,
+  beforeEach() {
+    let registry = this.registry || this.container;
+
+    this.inject.service('intl');
+
+    this.intl.addTranslations(DEFAULT_LOCALE_NAME, {
+      foo: {
+        bar: 'foo bar baz',
+        baz: 'baz baz baz'
+      }
+    });
+
+    registry.register('formats:main', {
+      date: {
+        shortWeekDay: {
+          timeZone: 'UTC',
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric'
+        }
+      }
+    });
+
+    this.intl.setLocale(DEFAULT_LOCALE_NAME);
+  }
+});
+
+test('exists', function(assert) {
+  assert.expect(1);
+  assert.ok(tHelper);
+});
+
+test('should return nothing if key does not exist and allowEmpty is set to true', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{t 'does.not.exist' allowEmpty=true}}`);
+  assert.equal(this.$().text(), '');
+});
+
+test('locale can add message to intl service and read it', function(assert) {
+  assert.expect(1);
+
+  run(() => {
+    this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'oh', 'hai!').then(() => {
+      this.render(hbs`{{t 'oh'}}`);
+      assert.equal(this.$().text(), 'hai!');
+    });
+  });
+});
+
+test('translation value can be an empty string', function(assert) {
+  assert.expect(1);
+
+  run(() => {
+    this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'empty_translation', '').then(() => {
+      this.render(hbs`{{t 'empty_translation'}}`);
+      assert.equal(this.$().text(), '');
+    });
+  });
+});
+
+test('locale can add messages object and can read it', function(assert) {
+  assert.expect(1);
+
+  return this.intl
+    .addTranslations(DEFAULT_LOCALE_NAME, {
+      'bulk-add': 'bulk add works'
+    })
+    .then(() => {
+      this.render(hbs`{{t 'bulk-add'}}`);
+      assert.equal(this.$().text(), 'bulk add works');
+    });
+});
+
+test('can inline locale for missing locale', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{t 'foo.bar' locale='xx-xx'}}`);
+  assert.equal(this.$().text(), `Missing translation: foo.bar`);
+});
+
+test('should fallback to with defaultMessage when key not found', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{t 'app.sale_begins' defaultMessage='Sale begins {day, date, shortWeekDay}' day=1390518044403}}`);
+  assert.equal(this.$().text(), 'Sale begins January 23, 2014');
+});
+
+test('should fallback to with fallback when key not found', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{t 'app.sale_begins' fallback='Sale begins {day, date, shortWeekDay}' day=1390518044403}}`);
+  assert.equal(this.$().text(), 'Sale begins January 23, 2014');
+});

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -2,17 +2,18 @@ import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 import { moduleFor, test } from 'ember-qunit';
 
-let service;
+const DEFAULT_LOCALE_NAME = 'en';
 
 moduleFor('service:intl', 'Unit | Service | intl', {
   integration: true,
-  setup() {
-    service = this.subject();
+  beforeEach() {
+    this.inject.service('intl');
+    this.intl.setLocale(DEFAULT_LOCALE_NAME);
   }
 });
 
 test('can access formatMessage without a locale set', function(assert) {
-  service.t('does.not.exist');
+  this.intl.t('does.not.exist');
   assert.ok(true, 'Exception was not raised');
 });
 
@@ -23,40 +24,40 @@ test('triggers notifyPropertyChange only when locale changes', function(assert) 
     ++count;
   }
 
-  service.addObserver('locale', service, increment);
-  service.setLocale('en');
-  service.setLocale('en');
-  service.setLocale(['en']);
-  service.setLocale('fr');
+  this.intl.addObserver('locale', this.intl, increment);
+  this.intl.setLocale('es');
+  this.intl.setLocale('es');
+  this.intl.setLocale(['es']);
+  this.intl.setLocale('fr');
   assert.equal(count, 2);
-  assert.equal(service.get('locale'), 'fr');
-  service.removeObserver('locale', service, increment);
+  assert.equal(this.intl.get('locale'), 'fr');
+  this.intl.removeObserver('locale', this.intl, increment);
 });
 
 test('waits for translations to load', function(assert) {
   assert.expect(1);
 
   return wait().then(() => {
-    assert.equal(service.t('product.title', { locale: 'en-us' }), 'Hello world!');
+    assert.equal(this.intl.t('product.title', { locale: 'en-us' }), 'Hello world!');
   });
 });
 
 test('it does not mutate t options hash', function(assert) {
-  service.setLocale('en');
+  this.intl.setLocale(DEFAULT_LOCALE_NAME);
   const obj = { bar: 'bar' };
-  service.t('foo', obj);
+  this.intl.t('foo', obj);
   assert.ok(typeof obj.locale === 'undefined');
 });
 
 test('`t` can be passed a null options hash', function(assert) {
-  service.setLocale('en');
-  service.t('foo', undefined);
+  this.intl.setLocale(DEFAULT_LOCALE_NAME);
+  this.intl.t('foo', undefined);
   assert.ok(true, 'Exception was not raised');
 });
 
 test('`t` can be passed a no options argument and no warning should be emitted', function(assert) {
   const done = assert.async();
-  service.setLocale('en');
+  this.intl.setLocale(DEFAULT_LOCALE_NAME);
 
   let invokedWarn = false;
   const originalWarn = Ember.warn;
@@ -65,10 +66,31 @@ test('`t` can be passed a no options argument and no warning should be emitted',
     invokedWarn = true;
   };
 
-  service.addTranslation('en', 'foo', 'FOO').then(function() {
-    service.t('foo');
+  this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'foo', 'FOO').then(() => {
+    this.intl.t('foo');
     assert.ok(!invokedWarn, 'Warning was not raised');
     Ember.warn = originalWarn;
     done();
   });
+});
+
+test('translations that are empty strings are valid', function(assert) {
+  assert.expect(1);
+
+  return this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'empty_string', '').then(() => {
+    assert.equal(this.intl.t('empty_string'), '');
+  });
+});
+
+test('exists returns true when key found', function(assert) {
+  assert.expect(1);
+
+  return this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'hello', 'world').then(() => {
+    assert.equal(this.intl.exists('hello'), true);
+  });
+});
+
+test('exists returns false when key not found', function(assert) {
+  assert.expect(1);
+  assert.equal(this.intl.exists('bar'), false);
 });


### PR DESCRIPTION
This is to deprecate the translation lookup behavior with `{{format-message}}` in favor of using the `{{t}}` helper for lookups & compiling.

This PR also introduces `htmlSafe` attribute to the `t` helper, which will escape arguments and render an ElementNode.  If you're using `{{format-html-message}}` with lookups you'll want to convert those to the `t` helper and pass `htmlSafe=true`.

In 3.0.0, `{{format-message}}` and `{{format-html-message}}` will just accept string literals (like the service APIs do today with `formatMessage` & `formatHtmlMessage`).  If you're using the literal helper today, i.e,:
`{{format-message (l '{name} took {createdOn, date, long}') name=model.name createdOn=model.createdOn}}` this will continue to be supported and will not be deprecated.  In 3.0.0, you'll be able to drop the `{{l}}` helper in favor of passing the string literal as the first argument.