### PR TITLE
Adding htmlSafe to `t` service method to return safe string

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -202,6 +202,10 @@ const IntlService = Service.extend(Evented, {
     const [options] = args;
     const translation = this.lookup(key, options && options.locale);
 
+    if (options && options.htmlSafe) {
+      return this.formatHtmlMessage(translation, ...args);
+    }
+
     return this.formatMessage(translation, ...args);
   },
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.1.0",
+    "ember-string-ishtmlsafe-polyfill": "1.1.0",
     "eslint-plugin-prettier": "^2.0.1",
     "fs-extra": "^2.0.0",
     "loader.js": "^4.2.3",

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -3,6 +3,7 @@ import wait from 'ember-test-helpers/wait';
 import { moduleFor, test } from 'ember-qunit';
 
 const DEFAULT_LOCALE_NAME = 'en';
+const { String: emberString } = Ember;
 
 moduleFor('service:intl', 'Unit | Service | intl', {
   integration: true,
@@ -80,6 +81,46 @@ test('translations that are empty strings are valid', function(assert) {
   return this.intl.addTranslation(DEFAULT_LOCALE_NAME, 'empty_string', '').then(() => {
     assert.equal(this.intl.t('empty_string'), '');
   });
+});
+
+test('should return safestring when htmlSafe attribute passed to `t`', function(assert) {
+  assert.expect(1);
+
+  return this.intl
+    .addTranslation(
+      DEFAULT_LOCALE_NAME,
+      'html_safe_translation',
+      '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
+    )
+    .then(() => {
+      const out = this.intl.t('html_safe_translation', {
+        htmlSafe: true,
+        name: '<em>Jason</em>',
+        count: 42000
+      });
+
+      assert.ok(emberString.isHTMLSafe(out));
+    });
+});
+
+test('should return regular string when htmlSafe is falsey', function(assert) {
+  assert.expect(1);
+
+  return this.intl
+    .addTranslation(
+      DEFAULT_LOCALE_NAME,
+      'html_safe_translation',
+      '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
+    )
+    .then(() => {
+      const out = this.intl.t('html_safe_translation', {
+        htmlSafe: false,
+        name: '<em>Jason</em>',
+        count: 42000
+      });
+
+      assert.ok(!emberString.isHTMLSafe(out));
+    });
 });
 
 test('exists returns true when key found', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,6 +2582,13 @@ ember-router-generator@^1.0.0:
   dependencies:
     recast "^0.11.3"
 
+ember-string-ishtmlsafe-polyfill@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-1.1.0.tgz#ecde33419ff912b91dd8acf0640eb74b9758408e"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^1.2.0"
+
 ember-test-helpers@^0.6.0-beta.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"


### PR DESCRIPTION
Fixes #417

TODO: document

/cc @vvohra 