### PR TITLE
service intl.t support fallback option

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -177,9 +177,13 @@ const IntlService = Service.extend(Evented, {
 
   t(key, ...args) {
     const [options] = args;
-    const translation = this.lookup(key, options && options.locale);
+    const translation = this.lookup(key, options && options.locale, {
+      resilient: options && typeof options.fallback === 'string'
+    });
 
-    return this.formatMessage(translation, ...args);
+    const value = typeof translation === 'string' ? translation : options.fallback;
+
+    return this.formatMessage(value, ...args);
   },
 
   exists(key, localeName) {

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -17,6 +17,10 @@ test('can access formatMessage without a locale set', function(assert) {
   assert.ok(true, 'Exception was not raised');
 });
 
+test('`t` can be passed options fallback', function(assert) {
+  assert.equal(this.intl.t('does.not.exist', { fallback: 'It does not exists' }), 'It does not exists');
+});
+
 test('triggers notifyPropertyChange only when locale changes', function(assert) {
   let count = 0;
 


### PR DESCRIPTION
Tell me if we want to also support `defaultMessage` as well
closes #491