### PR TITLE
Eagerly instantiate intl service

### DIFF
--- a/app/instance-initializers/ember-intl.js
+++ b/app/instance-initializers/ember-intl.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 
 const { deprecate } = Ember;
 
-export function instanceInitializer(instance) {
+export function instanceInitializer() {
   deprecate('[ember-intl] instance initializer is deprecated, no longer necessary to call in testing.', false, {
     id: 'ember-intl-instance-initalizer',
     until: '3.0.0'
@@ -16,5 +16,14 @@ export function instanceInitializer(instance) {
 
 export default {
   name: 'ember-intl',
-  initialize() {}
+  initialize(instance) {
+    /*
+     * instantiate as early since hydration is async
+     * occurring too late could trigger a double-render if you did not instantiate
+     * up until rendering.  This is typically never the case, as you setup the locale
+     * when the app is initializing (route or initializer).  this is kept primary
+     * for ember-addons that do have an app-wide locale.
+     */
+    instance.lookup('service:intl');
+  }
 };


### PR DESCRIPTION
Since looking up a locale is async, it's possible to render before the hydration has finished.