### PR TITLE
Update "ember-getowner-polyfill" to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-assign-polyfill": "^2.0.1",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-import-polyfill": "^0.2.0",
-    "ember-getowner-polyfill": "^1.2.3",
+    "ember-getowner-polyfill": "^2.0.1",
     "ember-intl-format-cache": "^2.4.2",
     "ember-intl-messageformat": "^3.0.0",
     "ember-intl-relativeformat": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,7 +2221,7 @@ ember-assign-polyfill@^2.0.1:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-cli-babel@^5.1.0, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.0, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2563,11 +2563,10 @@ ember-factory-for-polyfill@^1.1.0:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-getowner-polyfill@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
+ember-getowner-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
   dependencies:
-    ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 


### PR DESCRIPTION
This drops the nested `ember-cli-babel@5` dependency :)