### PR TITLE
[WIP] Allow addons to extend ember-intl translation tree generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,15 +58,22 @@ module.exports = {
     this.processAddons(this.project.addons, addonNodes);
 
     let nodes = [...addonNodes];
-    let projectTranslationPath = path.join(this.app.project.root, this._options.inputPath);
+    let extensionAddon = this.project.addons.find(addon => addon['ember-intl-ext']);
 
-    if (existsSync(projectTranslationPath)) {
-      let projectTranslationTree = this.treeGenerator(projectTranslationPath);
+    if (extensionAddon && extensionAddon.generateTranslationTree) {
+      let projectTranslationTree = extensionAddon.generateTranslationTree(this.app, this._options.inputPath);
       nodes.push(projectTranslationTree);
+    } else {
+      let projectTranslationPath = path.join(this.app.project.root, this._options.inputPath);
+
+      if (existsSync(projectTranslationPath)) {
+        let projectTranslationTree = this.treeGenerator(projectTranslationPath);
+        nodes.push(projectTranslationTree);
+      }
     }
 
     let translationNodes = mergeTrees(nodes, { overwrite: true });
-    let plugins = [...registry.registeredForType('intl'), ...registry.registeredForType('i18n')];
+    let plugins = registry.registeredForType('intl');
 
     if (plugins.length > 0) {
       plugins.forEach(preprocessor => {
@@ -340,7 +347,7 @@ module.exports = {
     }
 
     return funnel(mergeTrees(trees), {
-      include: ['**/*.yaml', '**/*.yml', '**/*.json']
+      include: ['**/*.{yaml,yml,json}']
     });
   },
 


### PR DESCRIPTION
Now that I'm at a point where I have something to demo, I'd appreciate someone with deep knowledge of the build API to chime in.  The gist is... I've added a preprocessing ability for addons to mutate translations.  This works primarily off the `treeForTranslations` API (thank you ec-fastboot for the inspiration and enabled this) and the use of ember-cli's internal preprocess registry API.

The first addon I've built to leverage this new API is to support nested translations within any part of the add/addon tree.  It's still a work in progress, but the main point is it's very specific to certain consumers.  Much like pods or component css - it's something that the user should be buying into - which is why it is it's own optional ember-intl addon.

Is what I'm doing going to break anything planned for ember-cli in the future?  I don't believe the registry API is private since it powers many other addons (ember-cli-less/sass, htmlbars, etc.)

There may be quarks with the implementation that I'm hoping to nail down before cutting a new release.

https://github.com/ember-intl/component-nesting/blob/dev/index.js is a very basic idea of how the preprocessor API will be used.

* [ ] swap out preprocess registry with custom plugin API