### PR TITLE
corrected two small typos

### DIFF
--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -3,7 +3,7 @@
 module.exports = function(/* environment */) {
   return {
     /**
-     * The locales that are application supports.
+     * The locales that our application supports.
      *
      * This is optional and is automatically set if project stores translations
      * where ember-intl is able to look them up (<project root>/translations/).

--- a/tests/dummy/config/ember-intl.js
+++ b/tests/dummy/config/ember-intl.js
@@ -3,7 +3,7 @@
 module.exports = function(/*environment*/) {
   return {
     /**
-     * The locales that are application supports.
+     * The locales that our application supports.
      *
      * This is optional and is automatically set if project stores translations
      * where ember-intl is able to look them up (<project root>/translations/).


### PR DESCRIPTION
In

```
config/ember-intl.js
tests/dummy/config/ember-intl.js
```

There were two places where "are" was used instead of "our"