### PR TITLE
feat: if failOnMissingTranslation option is set, throw missing errors

### DIFF
--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -62,7 +62,7 @@ class TranslationReducer extends CachingWriter {
     return locale;
   }
 
-  _logLocale(locale, message, options) {
+  _buildLogMessage(locale, message) {
     let fullMessage = `${locale}: ${message}`;
     if (this._supportsUnicode) {
       let emoji = localeEmoji(locale.replace(/-([a-z]{2})$/, (match, it) => `-${it.toUpperCase()}`));
@@ -71,7 +71,11 @@ class TranslationReducer extends CachingWriter {
       }
     }
 
-    this._log(fullMessage, options);
+    return fullMessage;
+  }
+
+  _logLocale(locale, message, options) {
+    this._log(this._buildLogMessage(locale, message), options);
   }
 
   _log(/*msg, options*/) {
@@ -82,12 +86,17 @@ class TranslationReducer extends CachingWriter {
 
   findMissingKeys(target, defaultTranslationKeys, locale) {
     let targetProps = propKeys(target);
+    let missingKeys = [];
 
     defaultTranslationKeys.forEach(property => {
       if (targetProps.indexOf(property) === -1) {
         this._logLocale(locale, `"${property}" message is missing`);
+
+        missingKeys.push([locale, property]);
       }
     });
+
+    return missingKeys;
   }
 
   readDirectory(inputPath, listFiles) {
@@ -145,6 +154,8 @@ class TranslationReducer extends CachingWriter {
     let baseLocale = this.options.baseLocale;
     let translations = this.readDirectory(this.inputPaths[0], this.listFiles());
     let defaultTranslationKeys, defaultTranslation, translation;
+    let missingKeys = [];
+
     mkdirp.sync(outputPath);
 
     if (baseLocale) {
@@ -160,7 +171,7 @@ class TranslationReducer extends CachingWriter {
         translation = translations[locale];
 
         if (this.options.verbose && baseLocale && defaultTranslationKeys) {
-          this.findMissingKeys(translation, defaultTranslationKeys, locale);
+          missingKeys.push(...this.findMissingKeys(translation, defaultTranslationKeys, locale));
         }
 
         if (this.options.verbose) {
@@ -173,6 +184,13 @@ class TranslationReducer extends CachingWriter {
 
         fs.writeFileSync(`${outputPath}/${this.filename(locale)}`, this.wrapEntry(translation), { encoding: 'utf8' });
       }
+    }
+
+    if (this.options.failOnMissingTranslation && missingKeys.length) {
+      throw new Error(
+        'Missing translation keys:\n' +
+          missingKeys.map(([locale, key]) => '\t' + this._buildLogMessage(locale, key)).join('\n')
+      );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,7 +2424,7 @@ debug@3.1.0, debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -4591,7 +4591,7 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -5360,10 +5360,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -5371,13 +5367,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -5386,12 +5378,6 @@ lodash._createassigner@^3.0.0:
     lodash._bindcallback "^3.0.0"
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
@@ -5415,7 +5401,7 @@ lodash._escapestringchar@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz#cce73ae60fc6da55d2bf8a0679c23ca2bab149fc"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -5604,7 +5590,7 @@ lodash.omit@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -7192,7 +7178,7 @@ readable-stream@~1.0.17, readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -7986,29 +7972,11 @@ spawn-sync@^1.0.11, spawn-sync@^1.0.15:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
 
-spdx-correct@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
   dependencies:
     spdx-license-ids "^1.0.2"
-
-spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
 
 spdx-expression-parse@~1.0.0:
   version "1.0.4"
@@ -8017,10 +7985,6 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -8785,13 +8749,6 @@ uuid@^3.0.0, uuid@^3.1.0:
 uuid@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-validate-npm-package-license@*:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This is an initial stab at fixing #553.

It introduces the `failOnMissingTranslation` `config/ember-intl.js` option which throws an error if any missing translation keys are detected.

If the general concept is ok, I'll add some documentation and additional tests.

There are a couple open questions:

- should we throw in the broccoli reducer and failing the whole build?
- would this be better by injecting failing tests, like ember-template-lint does it?

This currently ignores #547 but could be easily extended to solve it, if we add support for specifying `ignoreMissingMessage` (or similar) in the `config/ember-intl.js` config.