### PR TITLE
feat: find missing translations without baseLocale being set

### DIFF
--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -80,12 +80,22 @@ class TranslationReducer extends CachingWriter {
     }
   }
 
-  findMissingKeys(target, defaultTranslationKeys, locale) {
-    let targetProps = propKeys(target);
+  findMissingTranslations(translations) {
+    const locales = Object.keys(translations);
 
-    defaultTranslationKeys.forEach(property => {
-      if (targetProps.indexOf(property) === -1) {
-        this._logLocale(locale, `"${property}" message is missing`);
+    // [['de',['foo.bar', 'bar.baz'], ['en',['foo.baz','bar.baz']]
+    const localeKeys = locales.map(locale => [locale, propKeys(translations[locale])]);
+
+    // create flattened list of all unique translation keys
+    const allTranslationKeys = new Set(Array.prototype.concat(...localeKeys.map(([, keys]) => keys)));
+
+    allTranslationKeys.forEach(key => {
+      const notInLocales = localeKeys
+        .filter(([, translationKeys]) => !translationKeys.includes(key))
+        .map(([locale]) => `"${locale}"`);
+
+      if (notInLocales.length) {
+        this._log(`"${key}" was not found in ${notInLocales.join(', ')}`);
       }
     });
   }
@@ -144,24 +154,20 @@ class TranslationReducer extends CachingWriter {
     let outputPath = `${this.outputPath}/${this.options.outputPath}`;
     let baseLocale = this.options.baseLocale;
     let translations = this.readDirectory(this.inputPaths[0], this.listFiles());
-    let defaultTranslationKeys, defaultTranslation, translation;
+    let defaultTranslation, translation;
     mkdirp.sync(outputPath);
 
     if (baseLocale) {
       defaultTranslation = translations[this.normalizeLocale(baseLocale)];
+    }
 
-      if (this.options.verbose) {
-        defaultTranslationKeys = propKeys(defaultTranslation);
-      }
+    if (this.options.verbose) {
+      this.findMissingTranslations(translations);
     }
 
     for (let locale in translations) {
       if (translations.hasOwnProperty(locale)) {
         translation = translations[locale];
-
-        if (this.options.verbose && baseLocale && defaultTranslationKeys) {
-          this.findMissingKeys(translation, defaultTranslationKeys, locale);
-        }
 
         if (this.options.verbose) {
           this.validateMessages(translation, locale);

--- a/tests-node/unit/broccoli/translation-reducer-test.js
+++ b/tests-node/unit/broccoli/translation-reducer-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+let mocha = require('mocha');
+let expect = require('chai').expect;
+
+let subject = require('../../../lib/broccoli/translation-reducer');
+
+describe('translation-reducer', function() {
+  it('logs missing translations', function() {
+    const logs = [];
+    const reducer = new subject('src');
+
+    reducer._log = msg => logs.push(msg);
+
+    reducer.findMissingTranslations({
+      de: {
+        foo: 'FOO',
+        bar: 'BAR',
+        nested: {
+          translation: {
+            key: 'key'
+          }
+        }
+      },
+      en: {
+        foo: 'foo',
+        io: 'io',
+        nested: {}
+      },
+      fr: {
+        foo: 'foo',
+        baz: 'baz',
+        io: 'io',
+        nested: {
+          translation: {
+            lock: 'lock'
+          }
+        }
+      },
+      it: {}
+    });
+
+    expect(logs).to.deep.equal([
+      '"foo" was not found in "it"',
+      '"bar" was not found in "en", "fr", "it"',
+      '"nested.translation.key" was not found in "en", "fr", "it"',
+      '"io" was not found in "de", "it"',
+      '"baz" was not found in "de", "en", "it"',
+      '"nested.translation.lock" was not found in "de", "en", "it"'
+    ]);
+  });
+});


### PR DESCRIPTION
This is an initial stab at fixing #562.

It reduces the usage of `baseLocale` to only being used when merging a translation with the default translation.