### PR TITLE
BREAKING: removes baselocale

### DIFF
--- a/blueprints/ember-intl/files/config/ember-intl.js
+++ b/blueprints/ember-intl/files/config/ember-intl.js
@@ -18,17 +18,6 @@ module.exports = function(/* env */) {
     locales: null,
 
     /**
-     * baseLocale is used to determine if translation keys are missing from other locales.
-     * This property is optional, and if you rely on sideloading translations then
-     * this should be null
-     *
-     * @property baseLocale
-     * @type {String?}
-     * @default "null"
-     */
-    baseLocale: null,
-
-    /**
      * autoPolyfill, when true will automatically inject the IntlJS polyfill
      * into index.html
      *

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -18,17 +18,6 @@ module.exports = function(/* environment */) {
     locales: null,
 
     /**
-     * baseLocale is used to determine if translation keys are missing from other locales.
-     * This property is optional, and if you rely on sideloading translations then
-     * this should be null
-     *
-     * @property baseLocale
-     * @type {String?}
-     * @default "null"
-     */
-    baseLocale: null,
-
-    /**
      * autoPolyfill, when true will automatically inject the IntlJS polyfill
      * into index.html
      *

--- a/index.js
+++ b/index.js
@@ -172,16 +172,9 @@ module.exports = {
       this.log('Run `ember g ember-intl` to create a default config');
     }
 
-    if (addonConfig.defaultLocale) {
-      this.log('DEPRECATION: defaultLocale is deprecated in favor of baseLocale');
-      this.log('Please update config/ember-intl.js or config/environment.js');
-      addonConfig.baseLocale = addonConfig.defaultLocale;
-    }
-
     addonConfig = Object.assign(
       {
         locales: null,
-        baseLocale: null,
         publicOnly: false,
         disablePolyfill: false,
         autoPolyfill: false,

--- a/lib/broccoli/translation-reducer.js
+++ b/lib/broccoli/translation-reducer.js
@@ -152,14 +152,9 @@ class TranslationReducer extends CachingWriter {
 
   build() {
     let outputPath = `${this.outputPath}/${this.options.outputPath}`;
-    let baseLocale = this.options.baseLocale;
     let translations = this.readDirectory(this.inputPaths[0], this.listFiles());
-    let defaultTranslation, translation;
+    let translation;
     mkdirp.sync(outputPath);
-
-    if (baseLocale) {
-      defaultTranslation = translations[this.normalizeLocale(baseLocale)];
-    }
 
     if (this.options.verbose) {
       this.findMissingTranslations(translations);
@@ -171,10 +166,6 @@ class TranslationReducer extends CachingWriter {
 
         if (this.options.verbose) {
           this.validateMessages(translation, locale);
-        }
-
-        if (defaultTranslation) {
-          translation = extend(true, {}, defaultTranslation, translation);
         }
 
         fs.writeFileSync(`${outputPath}/${this.filename(locale)}`, this.wrapEntry(translation), { encoding: 'utf8' });

--- a/tests/dummy/config/ember-intl.js
+++ b/tests/dummy/config/ember-intl.js
@@ -16,16 +16,7 @@ module.exports = function(/*environment*/) {
      * @default "null"
      */
     locales: ['en-us', 'es-es', 'fr-fr', 'de-de'],
-    /**
-     * baseLocale is used to determine if translation keys are missing from other locales.
-     * This property is optional, and if you rely on sideloading translations then
-     * this should be null
-     *
-     * @property baseLocale
-     * @type {String?}
-     * @default "null"
-     */
-    baseLocale: 'en-us',
+
     /**
      * autoPolyfill, when true will automatically inject the IntlJS polyfill
      * into index.html
@@ -35,6 +26,7 @@ module.exports = function(/*environment*/) {
      * @default "false"
      */
     autoPolyfill: true,
+
     /**
      * disablePolyfill prevents the polyfill from being bundled in the asset folder of the build
      *
@@ -43,6 +35,7 @@ module.exports = function(/*environment*/) {
      * @default "false"
      */
     disablePolyfill: false,
+
     /**
      * prevents the translations from being bundled with the application code.
      * This enables asynchronously loading the translations for the active locale
@@ -55,6 +48,7 @@ module.exports = function(/*environment*/) {
      * @default "false"
      */
     publicOnly: false,
+
     /**
      * Path where translations are kept.  This is relative to the project root.
      * For example, if your translations are an npm dependency, set this to:


### PR DESCRIPTION
It's a source of confusion and no longer necessary since all the translations key are merged together into a manifest to determine which locales have translation keys missing. See #563

The behavior of merging the baseLocale into all locales is also unnecessary since you can specify multiple locales (fallback behavior) that are used when resolving a translation.