### PR TITLE
BREAKING: Replace fallback API with default array

### DIFF
--- a/addon/helpers/-format-base.js
+++ b/addon/helpers/-format-base.js
@@ -22,24 +22,13 @@ const AbstractHelper = Helper.extend({
     this.intl.on('localeChanged', this, this.recompute);
   },
 
-  getValue([value]) {
-    return value;
-  },
-
   format() {
     throw new Error('not implemented');
   },
 
-  compute(params, options) {
-    const value = this.getValue(params, options);
-    const allowEmpty = getWithDefault(options, 'allowEmpty', this.allowEmpty);
-
+  compute([value], options) {
     if (isEmpty(value)) {
-      if ('fallback' in options) {
-        return options.fallback;
-      }
-
-      if (allowEmpty) {
+      if (getWithDefault(options, 'allowEmpty', this.allowEmpty)) {
         return;
       }
 

--- a/addon/helpers/format-message.js
+++ b/addon/helpers/format-message.js
@@ -3,18 +3,9 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { assert } from '@ember/debug';
 import BaseHelper from './-format-base';
 
-export function getValue([translations]) {
-  assert('[ember-intl] no translation string provided to format-message.', translations);
-
-  return translations;
-}
-
 export default BaseHelper.extend({
-  getValue,
-
   format(value, options) {
     return this.intl.formatMessage(value, options);
   }

--- a/addon/helpers/t.js
+++ b/addon/helpers/t.js
@@ -6,23 +6,10 @@
 import { assert } from '@ember/debug';
 import BaseHelper from './-format-base';
 
-export function getValue([translationKey], options) {
-  assert('[ember-intl] translation lookup attempted but no translation key was provided.', translationKey);
-
-  const { fallback, allowEmpty, defaultMessage, locale: optionalLocale } = options;
-  const fallbackTranslation = defaultMessage || fallback;
-
-  const translation = this.intl.lookup(translationKey, optionalLocale, {
-    resilient: allowEmpty || typeof fallbackTranslation === 'string'
-  });
-
-  return typeof translation === 'string' ? translation : fallbackTranslation;
-}
-
 export default BaseHelper.extend({
-  getValue,
-
   format(value, options) {
-    return this.intl.formatMessage(value, options);
+    assert('[ember-intl] translation lookup attempted but no translation key was provided.', value);
+
+    return this.intl.t(value, options);
   }
 });

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -174,13 +174,20 @@ const IntlService = Service.extend(Evented, {
 
   /** @public **/
   t(key, options = {}) {
-    const translation = this.lookup(key, options.locale, {
-      resilient: typeof options.fallback === 'string'
-    });
+    let defaults = [key];
+    let msg;
 
-    const value = typeof translation === 'string' ? translation : options.fallback;
+    if (options.default) {
+      defaults = defaults.concat(options.default);
+    }
 
-    return this.formatMessage(value, options);
+    while (!msg && defaults.length) {
+      msg = this.lookup(defaults.shift(), options.locale, {
+        resilient: defaults.length
+      });
+    }
+
+    return this.formatMessage(msg, options);
   },
 
   /** @public **/

--- a/tests/unit/helpers/format-date-test.js
+++ b/tests/unit/helpers/format-date-test.js
@@ -45,6 +45,12 @@ module('format-date', function(hooks) {
     assert.equal(this.element.textContent, new Intl.DateTimeFormat(locale).format(0));
   });
 
+  test('should support allowEmpty', async function(assert) {
+    assert.expect(1);
+    await render(hbs`{{format-date allowEmpty=true}}`);
+    assert.equal(this.element.textContent, '');
+  });
+
   test('it should return a formatted string from a date string', async function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/jasonmit/ember-intl/issues/21

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -157,6 +157,12 @@ module('format-message', function(hooks) {
     assert.equal(this.element.textContent, 'Sale begins January 23, 2014');
   });
 
+  test('should support allowEmpty', async function(assert) {
+    assert.expect(1);
+    await render(hbs`{{format-message allowEmpty=true}}`);
+    assert.equal(this.element.textContent, '');
+  });
+
   test('should return 0 instead of nothing', async function(assert) {
     assert.expect(1);
     this.set('count', 0);

--- a/tests/unit/helpers/format-relative-test.js
+++ b/tests/unit/helpers/format-relative-test.js
@@ -28,6 +28,12 @@ module('format-relative', function(hooks) {
     // expectError(() => render(hbs`{{format-relative}}`), ex => assert.ok(ex));
   });
 
+  test('should support allowEmpty', async function(assert) {
+    assert.expect(1);
+    await render(hbs`{{format-relative allowEmpty=true}}`);
+    assert.equal(this.element.textContent, '');
+  });
+
   test('can specify a `value` and `now` on the options hash', async function(assert) {
     assert.expect(1);
     await render(hbs`{{format-relative 2000 now=0}}`);

--- a/tests/unit/helpers/format-time-test.js
+++ b/tests/unit/helpers/format-time-test.js
@@ -40,6 +40,12 @@ module('format-time-test', function(hooks) {
     assert.ok(output === '23/1/2014' || output === '23/01/2014');
   });
 
+  test('should support allowEmpty', async function(assert) {
+    assert.expect(1);
+    await render(hbs`{{format-time allowEmpty=true}}`);
+    assert.equal(this.element.textContent, '');
+  });
+
   test('it should return a formatted string from a date string', async function(assert) {
     assert.expect(1);
     this.set('dateString', 'Thu Jan 23 2014 18:00:44 GMT-0500 (EST)');


### PR DESCRIPTION
Instead of passing `fallback` or `defaultMessage` as a string literal, you now pass a default array (or string) to the `t` helper or method.  This is intended to better align ember-intl and ember-i18ns API.

```js
this.intl.t('does.not.exist', {
  default: ['also.does.not.exist', 'should_exist'] /* returns should_exist result */
});
```
```hbs
{{t 'does.not.exist' default='should_exist'}}
```