### PR TITLE
BREAKING: removes addTranslation in favor of just addTranslations

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -214,13 +214,6 @@ const IntlService = Service.extend(Evented, {
   },
 
   /** @public **/
-  addTranslation(localeName, key, value) {
-    const locale = this.localeFactory(localeName);
-
-    return locale.addTranslation(key, value);
-  },
-
-  /** @public **/
   addTranslations(localeName, payload) {
     const locale = this.localeFactory(localeName);
 

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -144,7 +144,7 @@ module('format-message', function(hooks) {
 
   test('able to discover all register translations', function(assert) {
     assert.expect(1);
-    this.intl.addTranslation('es_MX', 'foo', 'bar');
+    this.intl.addTranslations('es_MX', { foo: 'bar' });
     /* tests that the locale name becomes normalized to es-mx */
     this.intl.exists('test', 'fr-ca');
     assert.equal(get(this.intl, 'locales').join('; '), 'en-us; es-es; fr-fr; es-mx');

--- a/tests/unit/helpers/t-test.js
+++ b/tests/unit/helpers/t-test.js
@@ -1,8 +1,8 @@
-import hbs from 'htmlbars-inline-precompile';
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import tHelper from 'ember-intl/helpers/t';
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
 const LOCALE = 'en-us';
 
@@ -43,7 +43,7 @@ module('t', function(hooks) {
 
   test('should return nothing if key does not exist and allowEmpty is set to true', async function(assert) {
     assert.expect(1);
-    this.intl.addTranslation(LOCALE, 'empty', '');
+    this.intl.addTranslations(LOCALE, { empty: '' });
     await render(hbs`{{t 'does.not.exist' default='empty'}}`);
     assert.equal(this.element.textContent, '');
   });
@@ -72,7 +72,7 @@ module('t', function(hooks) {
   test('locale can add message to intl service and read it', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(LOCALE, 'oh', 'hai!');
+    this.intl.addTranslations(LOCALE, { oh: 'hai!' });
     await render(hbs`{{t 'oh'}}`);
     assert.equal(this.element.textContent, 'hai!');
   });
@@ -80,7 +80,7 @@ module('t', function(hooks) {
   test('translation value can be an empty string', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(LOCALE, 'empty_translation', '');
+    this.intl.addTranslations(LOCALE, { empty_translation: '' });
     await render(hbs`{{t 'empty_translation'}}`);
     assert.equal(this.element.textContent, '');
   });
@@ -88,8 +88,8 @@ module('t', function(hooks) {
   test('locale can add messages object and can read it', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslations(LOCALE, { 'bulk-add': 'bulk add works' });
-    await render(hbs`{{t 'bulk-add'}}`);
+    this.intl.addTranslations(LOCALE, { bulk_add: 'bulk add works' });
+    await render(hbs`{{t 'bulk_add'}}`);
     assert.equal(this.element.textContent, 'bulk add works');
   });
 
@@ -108,7 +108,7 @@ module('t', function(hooks) {
 
   test('should cascade translation keys', async function(assert) {
     assert.expect(1);
-    this.intl.addTranslation('en-us', 'happy_birthday', 'You are {age, number} years old!');
+    this.intl.addTranslations('en-us', { happy_birthday: 'You are {age, number} years old!' });
     await render(hbs`{{t 'does.not.exist' default='happy_birthday' age=10}}`);
     assert.equal(this.element.textContent, 'You are 10 years old!');
   });

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -1,8 +1,8 @@
-import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { registerWarnHandler } from '@ember/debug';
 import { isHTMLSafe } from '@ember/string';
 import { settled } from '@ember/test-helpers';
-import { registerWarnHandler } from '@ember/debug';
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
 const LOCALE = 'en';
 
@@ -20,8 +20,10 @@ module('service:intl', function(hooks) {
   });
 
   test('`t` should cascade translation lookup', function(assert) {
-    this.intl.addTranslation(LOCALE, 'should_exist', 'I do exist!');
-    this.intl.addTranslation(LOCALE, 'should_also_exist', 'I do also exist!');
+    this.intl.addTranslations(LOCALE, {
+      should_exist: 'I do exist!',
+      should_also_exist: 'I do also exist!'
+    });
 
     assert.equal(
       this.intl.t('does.not.exist', {
@@ -84,7 +86,7 @@ module('service:intl', function(hooks) {
       invokedWarn = true;
     });
 
-    this.intl.addTranslation(LOCALE, 'foo', 'FOO');
+    this.intl.addTranslations(LOCALE, { foo: 'FOO' });
     this.intl.t('foo');
     assert.ok(!invokedWarn, 'Warning was not raised');
   });
@@ -92,18 +94,17 @@ module('service:intl', function(hooks) {
   test('translations that are empty strings are valid', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(LOCALE, 'empty_string', '');
+    this.intl.addTranslations(LOCALE, { empty_string: '' });
     assert.equal(this.intl.t('empty_string'), '');
   });
 
   test('should return safestring when htmlSafe attribute passed to `t`', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(
-      LOCALE,
-      'html_safe_translation',
-      '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
-    );
+    this.intl.addTranslations(LOCALE, {
+      html_safe_translation: '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
+    });
+
     const out = this.intl.t('html_safe_translation', {
       htmlSafe: true,
       name: '<em>Jason</em>',
@@ -116,11 +117,9 @@ module('service:intl', function(hooks) {
   test('should return regular string when htmlSafe is falsey', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(
-      LOCALE,
-      'html_safe_translation',
-      '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
-    );
+    this.intl.addTranslations(LOCALE, {
+      html_safe_translation: '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
+    });
     const out = this.intl.t('html_safe_translation', {
       htmlSafe: false,
       name: '<em>Jason</em>',
@@ -133,7 +132,7 @@ module('service:intl', function(hooks) {
   test('exists returns true when key found', async function(assert) {
     assert.expect(1);
 
-    this.intl.addTranslation(LOCALE, 'hello', 'world');
+    this.intl.addTranslations(LOCALE, { hello: 'world' });
     assert.equal(this.intl.exists('hello'), true);
   });
 


### PR DESCRIPTION
No reason to have the two methods (`addTranslations` vs `addTranslation`) that do nearly the same thing.  Also, brings us closer to the ember-i18n service API.