### PR TITLE
Adding support for treeForTranslations

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -22,7 +22,7 @@ import hydrate from '../hydrate';
 
 export default Service.extend(Evented, {
   /** @private **/
-  _locale: 'en-us',
+  _locale: ['en-us'],
 
   /** @private **/
   _adapter: null,
@@ -41,6 +41,8 @@ export default Service.extend(Evented, {
 
         return this._locale;
       }
+
+      return this._locale;
     },
     get() {
       return this._locale;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
   },
 
   _buildTranslationTree() {
-    const projectTranslations = path.join(this.project.root, this.opts.inputPath || 'translations');
+    const projectTranslations = path.join(this.project.root, this.opts.inputPath);
     const translationTrees = [];
 
     this._processAddons(this.project.addons, translationTrees);
@@ -223,14 +223,16 @@ module.exports = {
     let locales = [];
     let joinedPath = path.join(this.app.project.root, this.opts.inputPath);
 
-    locales = locales.concat(
-      walkSync(joinedPath, { directories: false }).map(function(filename) {
-        return path
-          .basename(filename, path.extname(filename))
-          .toLowerCase()
-          .replace(/_/g, '-');
-      })
-    );
+    if (fs.existsSync(joinedPath)) {
+      locales = locales.concat(
+        walkSync(joinedPath, { directories: false }).map(function(filename) {
+          return path
+            .basename(filename, path.extname(filename))
+            .toLowerCase()
+            .replace(/_/g, '-');
+        })
+      );
+    }
 
     if (this.opts.locales) {
       locales = locales.concat(this.opts.locales);

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -4,6 +4,6 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   intl: service(),
   beforeModel() {
-    this.get('intl').set('locale', ['en-us']);
+    this.get('intl').setLocale(['en-us']);
   }
 });

--- a/tests/unit/helpers/format-message-test.js
+++ b/tests/unit/helpers/format-message-test.js
@@ -32,8 +32,6 @@ module('format-message', function(hooks) {
         }
       }
     });
-
-    this.intl.set('locale', DEFAULT_LOCALE_NAME);
   });
 
   test('exists', function(assert) {


### PR DESCRIPTION
Part of #401 

@cibernox let me know if this solves what we discussed.

Usage:

```js
// index.js

module.exports = {
  name: 'an-ember-addon',

  /**
   * NOTE: addon's translation tree provided as an arg.
   * No need to return it if you are reimplementing behavior.
   * If you want to programmatically modify the translation node,
   * then feel free to mutate the passed in tree and return it.
   */
  treeForTranslations(/*tree*/) {
     return new BroccoliTranslationPlugin();
  }
}
```