### PR TITLE
BREAKING(on-hold): passthrough options to missing message and move fallback logic

### DIFF
--- a/addon/utils/missing-message.js
+++ b/addon/utils/missing-message.js
@@ -2,13 +2,21 @@ import { isEmpty } from '@ember/utils';
 import { warn } from '@ember/debug';
 import links from './links';
 
-export default function missingMessage(key, locales) {
+export default function missingMessage(key, locales, options) {
   if (isEmpty(locales)) {
     warn(`[ember-intl] no locale has been set. Documentation: ${links.unsetLocale}`, false, {
       id: 'ember-intl-no-locale-set'
     });
 
     return `No locale defined.  Unable to resolve translation: "${key}"`;
+  }
+
+  if (options.default.length > 0) {
+    return undefined; // make `lookup` continue trying the other fallback defaults
+  }
+
+  if (options.resilient) {
+    return ''; // return empty string in order to not crash consumers
   }
 
   const localeNames = locales.join(', ');

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -92,6 +92,16 @@ module('service:intl', function(hooks) {
     );
   });
 
+  test('`t` should return empty string, if `resilient: true`', function(assert) {
+    assert.strictEqual(
+      this.intl.t('does.not.exist', {
+        default: ['also.does.not.exist', 'should_also_exist'],
+        resilient: true
+      }),
+      ''
+    );
+  });
+
   test('triggers notifyPropertyChange only when locale changes', function(assert) {
     let count = 0;
 


### PR DESCRIPTION
Closes #579.

This achieves two things:

- pass the complete `options` hash to the `missing-message` util
- offload the `default` fallback logic to the `missing-message` util, in that `missing-message` could theoretically log all steps of the resolution or even return a missing message before all `default` locales have been tried

This ultimately gives the user more control over how to handle message resolution and is really useful for mocking in tests.

Two things I am not happy about:

#### `defaults` / `default` inconsistency

IMHO the `default` should have been called `defaults` in the first place, because `default` is a reserved keyword and makes for weird code. But yeah. This'll never change. 😅 

#### Possible breakage for users of custom `missing-message` & `default`

Users that have their own `missing-message` util and also use the `default` option, will run into issues, because they are potentially not returning `undefined`, if there are still defaults to try.

The only thing I wanted to do with #579 in the first place (after I cleared some misunderstanding on my side), was to just have access to the `options` hash, when we've actually tried all `default` locales and could not find a translation.

If this potential breakage is too dangerous for your taste, I can move the fallback logic back into the `lookup` method and just pass the options through. If not, also fine – I'd like using this to log fallthroughs to the backend. :)