### PR TITLE
fix: filter translation files without supported extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,12 +198,14 @@ module.exports = {
 
     if (fs.existsSync(joinedPath)) {
       locales = locales.concat(
-        walkSync(joinedPath, { directories: false }).map(function(filename) {
-          return path
-            .basename(filename, path.extname(filename))
-            .toLowerCase()
-            .replace(/_/g, '-');
-        })
+        walkSync(joinedPath, { directories: false })
+          .filter(utils.validLocaleFile)
+          .map(function(filename) {
+            return path
+              .basename(filename, path.extname(filename))
+              .toLowerCase()
+              .replace(/_/g, '-');
+          })
       );
     }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -10,5 +10,6 @@
 module.exports = {
   unique: require('./unique'),
   castArray: require('./cast-array'),
-  isSupportedLocale: require('./is-supported-locale')
+  isSupportedLocale: require('./is-supported-locale'),
+  validLocaleFile: require('./valid-locale-file')
 };

--- a/lib/utils/valid-locale-file.js
+++ b/lib/utils/valid-locale-file.js
@@ -1,0 +1,12 @@
+/* eslint-env node */
+const path = require('path');
+
+const allowedExtensions = ['.json', '.yaml', '.yml'];
+
+function validLocaleFile(filename) {
+  if (typeof filename !== 'string') return false;
+
+  return allowedExtensions.includes(path.extname(filename));
+}
+
+module.exports = validLocaleFile;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "ember serve",
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
-    "tests-node": "mocha tests-node/**/*.*",
+    "tests-node": "mocha \"tests-node/**/*.*\"",
     "test": "npm run tests-node && ember test",
     "testall": "npm run tests-node && ember try:each",
     "prettier": "prettier --single-quote --print-width 120 --write \"{blueprints,config,lib,app,addon,addon-test-support,tests,tests-node}/**/*.js\""

--- a/tests-node/unit/utils/valid-locale-file-test.js
+++ b/tests-node/unit/utils/valid-locale-file-test.js
@@ -1,0 +1,25 @@
+/* eslint-env node */
+/* globals describe, it */
+
+'use strict';
+
+let expect = require('chai').expect;
+
+let validLocaleFile = require('../../../lib/utils/valid-locale-file');
+
+describe('validLocaleFile', function() {
+  [
+    ['en-us.yaml', true],
+    ['en.json', true],
+    ['sub/en-us.yml', true],
+
+    ['index.html', false],
+    ['.bashrc', false],
+    ['.DS_Store', false],
+    [undefined, false]
+  ].forEach(([filename, isValid]) => {
+    it(`${filename}`, function() {
+      expect(validLocaleFile(filename)).to.equal(isValid);
+    });
+  });
+});


### PR DESCRIPTION
fixes #594

This also fixes the mocha tests which weren't completely run previously

```
$ mocha tests-node/**/*.*
  index
    ✓ createOptions ensures that requiresTranslation is a function.
  1 passing (9ms)
```