### PR TITLE
Making it possible to specifcy custom handler for wrapEntry and filename

### DIFF
--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -69,6 +69,22 @@ module.exports = function(/* environment */) {
      * @type {Function?}
      * @default "function(){return true}"
      */
-    requiresTranslation: undefined
+    requiresTranslation: undefined,
+
+    /**
+     * translations output file name
+     * @property filename
+     * @type {Function?}
+     */
+    filename: undefined,
+
+    /**
+     * creates output file based on generated json with translations,
+     * can be used for final manipulation before writing to file
+     * @property wrapEntry
+     * @type {Function?}
+     * @default "function(){return `export default ${stringify(obj)};`}"
+     */
+    wrapEntry: undefined
   };
 };

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = {
       verbose: !this.isSilent,
       outputPath: this.opts.outputPath,
       filename: _bundlerOptions.filename,
-      wrapEntry: _bundlerOptions.wrapEntry,
+      wrapEntry: this.opts.wrapEntry,
       log() {
         return addon.log.apply(addon, arguments);
       },
@@ -97,11 +97,8 @@ module.exports = {
       trees.push(
         this.generateTranslationTree({
           outputPath: 'translations',
-          filename(key) {
+          filename: this.opts.filename || function filename(key) {
             return `${key}.js`;
-          },
-          wrapEntry(obj) {
-            return `export default ${stringify(obj)};`;
           }
         })
       );
@@ -137,7 +134,11 @@ module.exports = {
     }
 
     if (this.opts.publicOnly) {
-      trees.push(this.generateTranslationTree());
+      trees.push(this.generateTranslationTree({
+        filename: this.opts.filename || function filename(key) {
+          return `${key}.json`;
+        }
+      }));
     }
 
     return mergeTrees(trees, { overwrite: true });


### PR DESCRIPTION
In relation to a need described in issue (https://github.com/ember-intl/ember-intl/issues/607) I've created a possibility to specify custom handler for `wrapEntry` and `filename` methods used inside translation reducer.

Thanks to them one can achieve jsonp compatibile output from ember intl

```
filename: function filename(key) {
    return key + '.js';
},

wrapEntry: function wrapEntry(obj) {
    return 'loadTranslations(' + stringify(obj) + ');';
}
```