### PR TITLE
isDevelopingAddon is ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
   },
 
   generateTranslationTree(bundlerOptions) {
-    const translationTree = buildTree(this.project, this.opts.inputPath, this.treeGenerator.bind(this));
+    const translationTree = buildTree(this.project, this.opts.inputPath, this.treeGenerator);
     const _bundlerOptions = bundlerOptions || {};
     const addon = this;
 

--- a/lib/broccoli/build-translation-tree.js
+++ b/lib/broccoli/build-translation-tree.js
@@ -37,7 +37,7 @@ function _processAddon(addon, translationTrees, treeGenerator) {
   let addonGeneratedTree;
 
   if (fs.existsSync(addonTranslationPath)) {
-    addonGeneratedTree = treeGenerator(addonTranslationPath);
+    addonGeneratedTree = treeGenerator.call(addon, addonTranslationPath);
   }
 
   if (addon.treeForTranslations) {


### PR DESCRIPTION
## Summary
Use the addon that has translations to decide whether to use WatchedDir or UnwatchedDir based on `isDevelopingAddon()` (via `addon.treeGenerator` instead of `emberCliAddon.treeGenerator`)

## Reproduction
Make an application that uses an addon that is set to `isDevelopingAddon() { return true; }` with translations directory inside. Or for example an in-repo-addon: `ember generate in-repo-addon addon-with-translations`.
If you do `ember s` now, modifications in the addon translations are not Watched. (maybe again windows only?)
