### PR TITLE
feat: Skip the message formatter if the translation is not a string.

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -136,7 +136,12 @@ export default Service.extend(Evented, {
       msg = this.lookup(defaults.shift(), options.locale, assign({}, options, { resilient: defaults.length > 0 }));
     }
 
-    return this.formatMessage(msg, options);
+    /* Avoids passing msg to intl-messageformat if it is not a string */
+    if (typeof msg === 'string') {
+      return this.formatMessage(msg, options);
+    }
+
+    return msg;
   },
 
   /** @public **/

--- a/tests/unit/helpers/t-test.js
+++ b/tests/unit/helpers/t-test.js
@@ -16,6 +16,7 @@ module('t', function(hooks) {
       html: {
         greeting: '<strong>Hello {name} {count, number}</strong>'
       },
+      number: 2,
       foo: {
         bar: 'foo bar baz',
         baz: 'baz baz baz'
@@ -47,6 +48,11 @@ module('t', function(hooks) {
     await render(hbs`{{t 'does.not.exist' default='empty'}}`);
     assert.equal(this.element.textContent, '');
   });
+
+  test('should return a number string if translation is a number', async function(assert) {
+    await render(hbs`{{t 'number'}}`);
+    assert.equal(this.element.textContent, '2');
+  })
 
   test('should escape attributes but not the translation string', async function(assert) {
     assert.expect(3);

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -19,6 +19,14 @@ module('service:intl', function(hooks) {
     assert.ok(true, 'Exception was not raised');
   });
 
+  test('should return a number if the translation is a number', function(assert) {
+    this.intl.addTranslations(LOCALE, {
+      a_number: 2
+    });
+
+    assert.equal(this.intl.t('a_number'), 2);
+  });
+
   test('`t` should cascade translation lookup', function(assert) {
     this.intl.addTranslations(LOCALE, {
       should_exist: 'I do exist!',


### PR DESCRIPTION
fixes #620