### PR TITLE
refactor: create IntlComputedProperty base class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,13 +12,7 @@ module.exports = {
     browser: true
   },
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        printWidth: 120
-      }
-    ],
+    'prettier/prettier': 'error',
     'ember/no-restricted-resolver-tests': 'off',
     'ember/avoid-leaking-state-in-ember-objects': 0
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
-
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 120
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,3 @@
 export { default as Service } from './services/intl';
 export { default as translationMacro, raw } from './macro';
+export { default as IntlComputedProperty } from './intl-computed-property';

--- a/addon/intl-computed-property.js
+++ b/addon/intl-computed-property.js
@@ -8,10 +8,7 @@ export default class IntlComputedProperty extends ComputedProperty {
     super(function(propertyKey) {
       let intl = get(this, 'intl');
 
-      assert(
-        `ember-intl: Could not look up 'intl' service for the property '${propertyKey}' on '${this}'.`,
-        intl
-      );
+      assert(`ember-intl: Could not look up 'intl' service for the property '${propertyKey}' on '${this}'.`, intl);
 
       return fn.call(this, intl, propertyKey, this);
     });

--- a/addon/intl-computed-property.js
+++ b/addon/intl-computed-property.js
@@ -4,13 +4,16 @@ import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
 
 export default class IntlComputedProperty extends ComputedProperty {
-  constructor(fn, ...dependentKeys) {
+  constructor(...dependentKeysAndGetterFn) {
+    const getterFn = dependentKeysAndGetterFn.pop();
+    const dependentKeys = dependentKeysAndGetterFn;
+
     super(function(propertyKey) {
       let intl = get(this, 'intl');
 
       assert(`ember-intl: Could not look up 'intl' service for the property '${propertyKey}' on '${this}'.`, intl);
 
-      return fn.call(this, intl, propertyKey, this);
+      return getterFn.call(this, intl, propertyKey, this);
     });
 
     this.property('intl.locale', ...dependentKeys);

--- a/addon/intl-computed-property.js
+++ b/addon/intl-computed-property.js
@@ -1,0 +1,34 @@
+import { get, defineProperty } from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import { assert } from '@ember/debug';
+
+export default class IntlComputedProperty extends ComputedProperty {
+  constructor(fn, ...dependentKeys) {
+    super(function(propertyKey) {
+      let intl = get(this, 'intl');
+
+      assert(
+        `ember-intl: Could not look up 'intl' service for the property '${propertyKey}' on '${this}'.`,
+        intl
+      );
+
+      return fn.call(this, intl, propertyKey, this);
+    });
+
+    this.property('intl.locale', ...dependentKeys);
+    this.readOnly();
+  }
+
+  setup(proto) {
+    if (super.setup) {
+      super.setup(...arguments);
+    }
+
+    if (!proto.intl) {
+      // Implicitly inject the `intl` service, if it is not already injected.
+      // This allows the computed property to depend on `intl.locale`.
+      defineProperty(proto, 'intl', service('intl'));
+    }
+  }
+}

--- a/addon/macro.js
+++ b/addon/macro.js
@@ -71,10 +71,8 @@ class TranslationMacro extends IntlComputedProperty {
     const [dynamicValues, staticValues] = partitionDynamicValuesAndStaticValues(hash);
     const dependentKeys = Object.values(dynamicValues);
 
-    super(
-      (intl, propertyKey, ctx) =>
-        intl.t(translationKey, assign({}, staticValues, mapPropertiesByHash(ctx, dynamicValues))),
-      ...dependentKeys
+    super(...dependentKeys, (intl, propertyKey, ctx) =>
+      intl.t(translationKey, assign({}, staticValues, mapPropertiesByHash(ctx, dynamicValues)))
     );
   }
 }

--- a/addon/macro.js
+++ b/addon/macro.js
@@ -8,6 +8,7 @@ import ComputedProperty from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { assign } from '@ember/polyfills';
 import EmptyObject from 'ember-intl/-private/empty-object';
+import IntlComputedProperty from 'ember-intl/intl-computed-property';
 
 function partitionDynamicValuesAndStaticValues(options) {
   const dynamicValues = new EmptyObject();
@@ -67,37 +68,22 @@ export function raw(value) {
   return new Raw(value);
 }
 
-class TranslationMacro extends ComputedProperty {
+class TranslationMacro extends IntlComputedProperty {
   constructor(translationKey, options) {
     const hash = options || new EmptyObject();
-    const [dynamicValues, staticValues] = partitionDynamicValuesAndStaticValues(hash);
-    const dependentKeys = ['intl.locale'].concat(Object.values(dynamicValues));
+    const [dynamicValues, staticValues] = partitionDynamicValuesAndStaticValues(
+      hash
+    );
+    const dependentKeys = Object.values(dynamicValues);
 
-    super(function(propertyKey) {
-      let intl = get(this, 'intl');
-
-      assert(
-        `Cannot translate "${translationKey}" as "${propertyKey}".\n${this} does not have an 'intl' property set and there is no 'intl' service registered with the owner.`,
-        intl
-      );
-
-      return intl.t(translationKey, assign({}, staticValues, mapPropertiesByHash(this, dynamicValues)));
-    });
-
-    this.property(...dependentKeys);
-    this.readOnly();
-  }
-
-  setup(proto) {
-    if (super.setup) {
-      super.setup(...arguments);
-    }
-
-    if (!proto.intl) {
-      // Implicitly inject the `intl` service, if it is not already injected.
-      // This allows the computed property to depend on `intl.locale`.
-      defineProperty(proto, 'intl', service('intl'));
-    }
+    super(
+      (intl, propertyKey, ctx) =>
+        intl.t(
+          translationKey,
+          assign({}, staticValues, mapPropertiesByHash(ctx, dynamicValues))
+        ),
+      ...dependentKeys
+    );
   }
 }
 

--- a/addon/macro.js
+++ b/addon/macro.js
@@ -2,10 +2,7 @@
  * <3 ember-i18n <3
  * https://github.com/jamesarosen/ember-i18n/blob/master/addon/utils/macro.js
  */
-import { assert } from '@ember/debug';
-import { get, defineProperty } from '@ember/object';
-import ComputedProperty from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import EmptyObject from 'ember-intl/-private/empty-object';
 import IntlComputedProperty from 'ember-intl/intl-computed-property';
@@ -71,17 +68,12 @@ export function raw(value) {
 class TranslationMacro extends IntlComputedProperty {
   constructor(translationKey, options) {
     const hash = options || new EmptyObject();
-    const [dynamicValues, staticValues] = partitionDynamicValuesAndStaticValues(
-      hash
-    );
+    const [dynamicValues, staticValues] = partitionDynamicValuesAndStaticValues(hash);
     const dependentKeys = Object.values(dynamicValues);
 
     super(
       (intl, propertyKey, ctx) =>
-        intl.t(
-          translationKey,
-          assign({}, staticValues, mapPropertiesByHash(ctx, dynamicValues))
-        ),
+        intl.t(translationKey, assign({}, staticValues, mapPropertiesByHash(ctx, dynamicValues))),
       ...dependentKeys
     );
   }

--- a/tests/unit/utils/intl-computed-property-test.js
+++ b/tests/unit/utils/intl-computed-property-test.js
@@ -1,0 +1,114 @@
+import { setOwner } from '@ember/application';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import EmberObject, { get, getProperties, set } from '@ember/object';
+import { run } from '@ember/runloop';
+import { setupIntl } from 'ember-intl/test-support';
+import { IntlComputedProperty } from 'ember-intl';
+
+module('Unit | IntlComputedProperty', function(hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function() {
+    this.intl = this.owner.lookup('service:intl');
+
+    const { owner } = this;
+    this.ContainerObject = EmberObject.extend({
+      init() {
+        this._super();
+        setOwner(this, owner);
+      }
+    });
+  });
+
+  test('looks up the intl service through the owner, if it is not injected', function(assert) {
+    assert.expect(1);
+
+    const object = this.ContainerObject.extend({
+      property: new IntlComputedProperty(intl => assert.strictEqual(intl, this.intl))
+    }).create();
+
+    get(object, 'property');
+  });
+
+  test('uses the pre-existing intl injection, if it already exists', function(assert) {
+    assert.expect(1);
+
+    const IDENTITY = {};
+
+    const object = this.ContainerObject.extend({
+      intl: IDENTITY,
+      property: new IntlComputedProperty(intl => assert.strictEqual(intl, IDENTITY))
+    }).create();
+
+    get(object, 'property');
+  });
+
+  test('passes the propertyKey, context, and binds to it', function(assert) {
+    assert.expect(3);
+
+    const object = this.ContainerObject.extend({
+      property: new IntlComputedProperty(function(intl, propertyKey, ctx) {
+        assert.strictEqual(propertyKey, 'property', 'passes propertyKey');
+        assert.strictEqual(ctx, object, 'passes context');
+        assert.strictEqual(this, object, 'binds to the instance');
+      })
+    }).create();
+
+    get(object, 'property');
+  });
+
+  test('uses the return value of the passed function as the computed property value', function(assert) {
+    assert.expect(1);
+
+    const IDENTITY = {};
+
+    const object = this.ContainerObject.extend({
+      property: new IntlComputedProperty(() => IDENTITY)
+    }).create();
+
+    assert.strictEqual(get(object, 'property'), IDENTITY);
+  });
+
+  test('listens for locale changes', function(assert) {
+    assert.expect(2);
+
+    this.intl.setLocale('en-us');
+
+    const object = this.ContainerObject.extend({
+      property: new IntlComputedProperty(intl => get(intl, 'locale'))
+    }).create();
+
+    assert.deepEqual(get(object, 'property'), ['en-us']);
+
+    run(() => this.intl.setLocale('de-de'));
+    assert.deepEqual(get(object, 'property'), ['de-de']);
+  });
+
+  test('accpets further dependent keys', function(assert) {
+    const dependencies = { dependencyA: 1, dependencyB: 2, dependencyC: 3 };
+    const dependencyKeys = Object.keys(dependencies);
+
+    const object = this.ContainerObject.extend({
+      dependencyA: 1,
+      dependencyB: 2,
+      dependencyC: 3,
+      property: new IntlComputedProperty(
+        (intl, propertyKey, ctx) => getProperties(ctx, ...dependencyKeys),
+        ...dependencyKeys
+      )
+    }).create();
+
+    assert.deepEqual(get(object, 'property'), dependencies);
+
+    run(() => set(object, 'dependencyA', 4));
+    assert.deepEqual(get(object, 'property'), getProperties(object, ...dependencyKeys));
+
+    run(() => set(object, 'dependencyB', 5));
+    assert.deepEqual(get(object, 'property'), getProperties(object, ...dependencyKeys));
+
+    run(() => set(object, 'dependencyC', 6));
+    assert.deepEqual(get(object, 'property'), getProperties(object, ...dependencyKeys));
+  });
+});

--- a/tests/unit/utils/intl-computed-property-test.js
+++ b/tests/unit/utils/intl-computed-property-test.js
@@ -94,9 +94,8 @@ module('Unit | IntlComputedProperty', function(hooks) {
       dependencyA: 1,
       dependencyB: 2,
       dependencyC: 3,
-      property: new IntlComputedProperty(
-        (intl, propertyKey, ctx) => getProperties(ctx, ...dependencyKeys),
-        ...dependencyKeys
+      property: new IntlComputedProperty(...dependencyKeys, (intl, propertyKey, ctx) =>
+        getProperties(ctx, ...dependencyKeys)
       )
     }).create();
 


### PR DESCRIPTION
As written in https://github.com/ember-intl/ember-intl/pull/707#issuecomment-442390143:

> I'll likely refactor this slightly and extract a `IntlComputedProperty` base class that implicitly injects the `intl` service, so that we can create a range of macros that extend from it. I am eyeing towards [#392 (comment)](https://github.com/ember-intl/ember-intl/issues/392#issuecomment-431570182) here.

