### PR TITLE
fix(intl-computed-property): do not accidentally evaluate `intl` injection

### DIFF
--- a/addon/intl-computed-property.js
+++ b/addon/intl-computed-property.js
@@ -25,7 +25,7 @@ export default class IntlComputedProperty extends ComputedProperty {
       super.setup(...arguments);
     }
 
-    if (!proto.intl) {
+    if (!('intl' in proto)) {
       // Implicitly inject the `intl` service, if it is not already injected.
       // This allows the computed property to depend on `intl.locale`.
       defineProperty(proto, 'intl', service('intl'));

--- a/tests/unit/utils/intl-computed-property-test.js
+++ b/tests/unit/utils/intl-computed-property-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import EmberObject, { get, getProperties, set } from '@ember/object';
 import { run } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import { setupIntl } from 'ember-intl/test-support';
 import { IntlComputedProperty } from 'ember-intl';
 
@@ -35,11 +36,9 @@ module('Unit | IntlComputedProperty', function(hooks) {
   test('uses the pre-existing intl injection, if it already exists', function(assert) {
     assert.expect(1);
 
-    const IDENTITY = {};
-
     const object = this.ContainerObject.extend({
-      intl: IDENTITY,
-      property: new IntlComputedProperty(intl => assert.strictEqual(intl, IDENTITY))
+      intl: service('intl'),
+      property: new IntlComputedProperty(intl => assert.strictEqual(intl, this.intl))
     }).create();
 
     get(object, 'property');


### PR DESCRIPTION
If used with a real life service injection, accessing `proto.intl` eagerly evaluates the service injection *before* the instance owner is set, thus causing this error:

```
Assertion Failed: Attempting to lookup an injected property on an object without a container, ensure that the object was instantiated via a container.
     at new EmberError (http://localhost:4200/assets/vendor.js:50047:31)
     at assert (http://localhost:4200/assets/vendor.js:48947:23)
     at Class.injectedPropertyGet (http://localhost:4200/assets/vendor.js:35966:50)
     at InjectedProperty.get (http://localhost:4200/assets/vendor.js:34448:36)
     at Class.CPGETTER_FUNCTION [as intl] (http://localhost:4200/assets/vendor.js:32817:31)
     at TranslationMacro.setup (http://localhost:4200/assets/vendor.js:211563:18)
     at defineProperty (http://localhost:4200/assets/vendor.js:32891:18)
     at applyMixin (http://localhost:4200/assets/vendor.js:35521:13)
     at Mixin.apply (http://localhost:4200/assets/vendor.js:35699:20)
     at Function.proto (http://localhost:4200/assets/vendor.js:43996:31)
```