### PR TITLE
TravisCI: Remove deprecated `sudo: false` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: node_js
 node_js:
   - "6"
 
-sudo: false
-dist: trusty
-
 addons:
   chrome: stable
 


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration