### PR TITLE
Add primaryLocale to intl service

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -33,6 +33,7 @@ export default Service.extend(Evented, {
   /** @public **/
   formats: null,
 
+  /** @private **/
   _timer: null,
 
   /** @public **/
@@ -55,6 +56,17 @@ export default Service.extend(Evented, {
       return this._locale;
     }
   }),
+
+  /**
+   * Returns the first locale of the currently
+   * active locales
+   *
+   * @property primaryLocale
+   * @public
+   */
+  primaryLocale: computed('locale', function() {
+    return this.get('locale')[0];
+  }).readOnly(),
 
   /** @public **/
   formatRelative: formatter('relative'),

--- a/docs/ember-service-api.md
+++ b/docs/ember-service-api.md
@@ -14,13 +14,15 @@ Ember.Object.extend({
 });
 ```
 
-Access the service from within the instance via: `this.get('intl')` or `this.intl`
+Access the service from within the instance via: `this.get('intl')` or just `this.intl`, if you have [ES5 getters enabled](https://www.emberjs.com/blog/2018/04/13/ember-3-1-released.html#toc_es5-getters-for-computed-properties-2-of-4).
 
 ## Properties
 
 **locale**
 
-Set/get the current locale for your application.  The value is an Array of Strings.  When providing an array, the `t` helper and `t` method will attempt to try all the locales in order when resolving a translation key.  This is useful if you want to always fallback to another locale when a translation may be missing.
+Set/get the current locale for your application. The value you set it to can either be a string or an array of strings. When providing an array, the `t` helper and `t` method will attempt to try all the locales in order when resolving a translation key. This is useful if you want to always fallback to another locale when a translation may be missing.
+
+When you get this property, it will always return an array of strings, even if you have set it to be just one single locale. If you are only interested in retrieving the single (or first) locale, use **`primaryLocale`**.
 
 **primaryLocale** _readOnly_
 

--- a/docs/ember-service-api.md
+++ b/docs/ember-service-api.md
@@ -14,13 +14,21 @@ Ember.Object.extend({
 });
 ```
 
-Access the service from within the instance via: `this.get('intl')`
+Access the service from within the instance via: `this.get('intl')` or `this.intl`
 
 ## Properties
 
 **locale**
 
-Set/get the current locale for your application.  The value can either be a String or an Array of Strings.  When providing an array, the `t` helper and `t` method will attempt to try all the locales in order when resolving a translation key.  This is useful if you want to always fallback to another locale when a translation may be missing.
+Set/get the current locale for your application.  The value is an Array of Strings.  When providing an array, the `t` helper and `t` method will attempt to try all the locales in order when resolving a translation key.  This is useful if you want to always fallback to another locale when a translation may be missing.
+
+**primaryLocale** _readOnly_
+
+Returns the first locale of the currently active locales, i.e. the first object of the `locale` property.
+
+```js
+intl.get('primaryLocale') => 'en-us'
+```
 
 **locales** _readOnly_
 
@@ -143,7 +151,7 @@ Adds a translations to a given locale.  Useful for registering translations at r
 **lookup** _(translationKey:String, optionalLocale:String | Array<String>, optionalOptions:Object)_
 
 Given a translation key, will return the translation for either the active
-locale, or the locale specified as the second argument. 
+locale, or the locale specified as the second argument.
 
 ```js
 this.get('intl').lookup('shared.confirmMessage', 'en-us', {

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -268,9 +268,9 @@ module('service:intl', function(hooks) {
   test('primaryLocale returns the first locale of the currently active locales', async function(assert) {
     assert.expect(2);
 
-    assert.equal(this.intl.primaryLocale, LOCALE);
+    assert.equal(this.intl.get('primaryLocale'), LOCALE);
 
     this.intl.setLocale('de');
-    assert.equal(this.intl.primaryLocale, 'de');
+    assert.equal(this.intl.get('primaryLocale'), 'de');
   });
 });

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -264,4 +264,13 @@ module('service:intl', function(hooks) {
     await settled();
     assert.equal(document.documentElement.getAttribute('lang'), 'es');
   });
+
+  test('primaryLocale returns the first locale of the currently active locales', async function(assert) {
+    assert.expect(2);
+
+    assert.equal(this.intl.primaryLocale, LOCALE);
+
+    this.intl.setLocale('de');
+    assert.equal(this.intl.primaryLocale, 'de');
+  });
 });


### PR DESCRIPTION
This PR add an alias to `locale.firstObject` to the `intl` service called `primaryLocale`. This alias improves code readability when accessing the primary locale and eases the transition from `ember-i18n` to `ember-intl`: `i18n.locale` -> `intl.primaryLocale`

Closes https://github.com/ember-intl/ember-intl/issues/695 for good!

I've added documentation regarding this new property and updated the `locale` documentation, as it's always an array.