### PR TITLE
Don't report ICU linting errors if not needed

### DIFF
--- a/lib/broccoli/translation-reducer/index.js
+++ b/lib/broccoli/translation-reducer/index.js
@@ -129,21 +129,23 @@ class TranslationReducer extends CachingWriter {
     // create flattened list of all unique translation keys
     const allTranslationKeys = new Set(Array.prototype.concat(...localeKeys.map(([, keys]) => keys)));
 
+    const { requiresTranslation, fallbackLocale } = this.options;
+
     allTranslationKeys.forEach(key => {
-      const requiresTranslation = this.options.requiresTranslation;
       const notInLocales = findMissingTranslations(key, localeKeys, requiresTranslation);
 
       if (notInLocales.length) {
         result.missingTranslations.push([key, notInLocales]);
       }
 
-      const missingICUArgsAll = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
-      const missingICUArgsRequired = missingICUArgsAll.filter(([locale, translationKeys]) => {
-        return !translationKeys.includes(key) && requiresTranslation(key, locale);
-      });
+      let missingICUArgs = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
 
-      if (missingICUArgsRequired.length) {
-        result.icuMismatch.push([key, missingICUArgsRequired]);
+      if (fallbackLocale) {
+        missingICUArgs = missingICUArgs.filter(([locale]) => fallbackLocale === locale);
+      }
+
+      if (missingICUArgs.length) {
+        result.icuMismatch.push([key, missingICUArgs]);
       }
     });
 

--- a/lib/broccoli/translation-reducer/index.js
+++ b/lib/broccoli/translation-reducer/index.js
@@ -130,16 +130,20 @@ class TranslationReducer extends CachingWriter {
     const allTranslationKeys = new Set(Array.prototype.concat(...localeKeys.map(([, keys]) => keys)));
 
     allTranslationKeys.forEach(key => {
-      const notInLocales = findMissingTranslations(key, localeKeys, this.options.requiresTranslation);
+      const requiresTranslation = this.options.requiresTranslation;
+      const notInLocales = findMissingTranslations(key, localeKeys, requiresTranslation);
 
       if (notInLocales.length) {
         result.missingTranslations.push([key, notInLocales]);
       }
 
-      const missingICUArgs = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
+      const missingICUArgsAll = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
+      const missingICUArgsRequired = missingICUArgsAll.filter(([locale, translationKeys]) => {
+        return !translationKeys.includes(key) && requiresTranslation(key, locale);
+      });
 
-      if (missingICUArgs.length) {
-        result.icuMismatch.push([key, missingICUArgs]);
+      if (missingICUArgsRequired.length) {
+        result.icuMismatch.push([key, missingICUArgsRequired]);
       }
     });
 

--- a/tests-node/unit/broccoli/translation-reducer/index-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/index-test.js
@@ -203,16 +203,12 @@ describe('translation-reducer', function() {
       ]);
     });
 
-    it('lintTranslations returns list of icu argument mismatch without those that are required', function () {
-      let subject = new TranslationReducer(this.input.path(), { fallbackLocale: 'en'});
+    it('lintTranslations returns list of icu argument mismatch without those that are required', function() {
+      let subject = new TranslationReducer(this.input.path(), { fallbackLocale: 'en' });
 
-      subject.options.requiresTranslation = (_, locale) => locale === 'en';
+      delete this.icuFixture['de'].foo;
 
-      let icuFixtureWithFallback = this.icuFixture;
-      
-      delete icuFixtureWithFallback['de'].foo;
-
-      let { icuMismatch } = subject.lintTranslations(icuFixtureWithFallback);
+      let { icuMismatch } = subject.lintTranslations(this.icuFixture);
 
       expect(icuMismatch).to.deep.equal([
         ['missingArg', [['en', ['numPhotos']]]],

--- a/tests-node/unit/broccoli/translation-reducer/index-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/index-test.js
@@ -203,6 +203,23 @@ describe('translation-reducer', function() {
       ]);
     });
 
+    it('lintTranslations returns list of icu argument mismatch without those that are required', function () {
+      let subject = new TranslationReducer(this.input.path(), { fallbackLocale: 'en'});
+
+      subject.options.requiresTranslation = (_, locale) => locale === 'en';
+
+      let icuFixtureWithFallback = this.icuFixture;
+      
+      delete icuFixtureWithFallback['de'].foo;
+
+      let { icuMismatch } = subject.lintTranslations(icuFixtureWithFallback);
+
+      expect(icuMismatch).to.deep.equal([
+        ['missingArg', [['en', ['numPhotos']]]],
+        ['deep.nested.ok', [['en', ['reason']]]]
+      ]);
+    });
+
     it('_handleMissingTranslations logs translation if verbose', function() {
       let logs = [];
       let subject = new TranslationReducer(this.input.path());


### PR DESCRIPTION
# Use case
Don't report ICU arguments lint errors if a translation is missing and is not obligatory.

It resolves the following issue: https://github.com/ember-intl/ember-intl/issues/730 