### PR TITLE
bug: fixes treeFor hooks from fixing many times per build.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const walkSync = require('walk-sync');
 const mergeTrees = require('broccoli-merge-trees');
 const stringify = require('json-stable-stringify');
 const extract = require('@ember-intl/broccoli-cldr-data');
+const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 const buildTree = require('./lib/broccoli/build-translation-tree');
 const TranslationReducer = require('./lib/broccoli/translation-reducer');
@@ -37,6 +38,10 @@ module.exports = {
   name: 'ember-intl',
   opts: null,
   isLocalizationFramework: true,
+
+  cacheKeyForTree(treeType) {
+    return calculateCacheKeyForTree(treeType, this);
+  },
 
   included() {
     this._super.included.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "broccoli-merge-trees": "^3.0.2",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^2.0.1",
+    "calculate-cache-key-for-tree": "^1.1.0",
     "cldr-core": "^34.0.0",
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.2.0",


### PR DESCRIPTION
Before this, all treeFor hooks would fire as many times as it's present in a addon + once for the host app.  This yields better build performance results for those that are in that scenario.