### PR TITLE
Initial ember-engines support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 const buildTree = require('./lib/broccoli/build-translation-tree');
 const TranslationReducer = require('./lib/broccoli/translation-reducer');
 const isValidLocaleFormat = require('./lib/utils/is-valid-locale-format');
+const findEngine = require('./lib/utils/find-engine');
 
 const DEFAULT_CONFIG = {
   locales: null,
@@ -40,20 +41,25 @@ module.exports = {
   isLocalizationFramework: true,
 
   cacheKeyForTree(treeType) {
-    return calculateCacheKeyForTree(treeType, this);
+    return calculateCacheKeyForTree(treeType, this, this.package.root);
   },
 
-  included() {
+  included(parent) {
     this._super.included.apply(this, arguments);
 
-    this.app = this._findHost();
-    this.opts = this.createOptions(this.app.env, this.app.project);
-    this.isSilent = this.app.options.intl && this.app.options.intl.silent;
+    const host = this._findHost();
+    const engine = findEngine(parent);
+
+    this.package = engine || this.project;
+
+    this.appOptions = (engine || host).options || {};
+    this.opts = this.createOptions(host.env);
+    this.isSilent = host.options.intl && host.options.intl.silent;
     this.locales = this.findAvailableLocales();
   },
 
   generateTranslationTree(bundlerOptions) {
-    const translationTree = buildTree(this.project, this.opts.inputPath, this.treeGenerator);
+    const translationTree = buildTree(this.package, this.opts.inputPath, this.treeGenerator);
     const _bundlerOptions = bundlerOptions || {};
     const addon = this;
 
@@ -89,7 +95,7 @@ module.exports = {
 
   contentFor(name, config) {
     if (name === 'head' && !this.opts.disablePolyfill && this.opts.autoPolyfill) {
-      let assetPath = this.findAssetPath(this.app.options);
+      let assetPath = this.findAssetPath(this.appOptions);
       let locales = this.locales;
       let prefix = '';
 
@@ -145,12 +151,10 @@ module.exports = {
     let trees = [];
 
     if (!this.opts.disablePolyfill) {
-      let appOptions = this.app.options || {};
-
       trees.push(
         require('./lib/broccoli/intl-polyfill')({
           locales: this.locales,
-          destDir: (appOptions.app && appOptions.app.intl) || 'assets/intl'
+          destDir: this.findAssetPath(this.appOptions)
         })
       );
     }
@@ -175,11 +179,11 @@ module.exports = {
   },
 
   readConfig(environment, project) {
-    // NOTE: For ember-cli >= 2.6.0-beta.3, project.configPath() returns absolute path
-    // while older ember-cli versions return path relative to project root
-    let configPath = path.dirname(project.configPath());
+    let configPath = project.configPath ? path.dirname(project.configPath()) : path.join(project.root, 'config');
     let config = path.join(configPath, 'ember-intl.js');
 
+    // NOTE: For ember-cli >= 2.6.0-beta.3, project.configPath() returns absolute path
+    // while older ember-cli versions return path relative to project root
     if (!path.isAbsolute(config)) {
       config = path.join(project.root, config);
     }
@@ -191,8 +195,8 @@ module.exports = {
     return {};
   },
 
-  createOptions(environment, project) {
-    let config = Object.assign({}, DEFAULT_CONFIG, this.readConfig(environment, project));
+  createOptions(environment) {
+    let config = Object.assign({}, DEFAULT_CONFIG, this.readConfig(environment, this.package));
 
     if (typeof config.requiresTranslation !== 'function') {
       this.log('Configured `requiresTranslation` is not a function. Using default implementation.');
@@ -208,11 +212,11 @@ module.exports = {
 
   findAvailableLocales() {
     let locales = [];
-    let projectInputPath = path.join(this.app.project.root, this.opts.inputPath);
+    let inputPath = path.join(this.package.root, this.opts.inputPath);
 
-    if (fs.existsSync(projectInputPath)) {
+    if (fs.existsSync(inputPath)) {
       locales.push(
-        ...walkSync(projectInputPath, {
+        ...walkSync(inputPath, {
           globs: ['**/*.{yml,yaml,json}'],
           directories: false
         }).map(function(filename) {

--- a/lib/broccoli/build-translation-tree.js
+++ b/lib/broccoli/build-translation-tree.js
@@ -7,6 +7,7 @@ const path = require('path');
 const funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const WatchedDir = require('broccoli-source').WatchedDir;
+const isEngine = require('../utils/is-engine');
 
 function buildTranslationTree(project, inputPath, treeGenerator) {
   const projectTranslations = path.join(project.root, inputPath);
@@ -28,8 +29,14 @@ function buildTranslationTree(project, inputPath, treeGenerator) {
   );
 }
 
+function isEngineWithIntl(addon) {
+  return isEngine(addon) && addon.pkg.dependencies['ember-intl'];
+}
+
 function processAddons(addons, translationTrees, treeGenerator) {
-  addons.forEach(addon => _processAddon(addon, translationTrees, treeGenerator));
+  addons
+    .filter(addon => !isEngineWithIntl(addon))
+    .forEach(addon => _processAddon(addon, translationTrees, treeGenerator));
 }
 
 function _processAddon(addon, translationTrees, treeGenerator) {

--- a/lib/utils/find-engine.js
+++ b/lib/utils/find-engine.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+
+'use strict';
+
+const isEngine = require('./is-engine');
+
+function findEngine(current) {
+  do {
+    if (isEngine(current)) {
+      return current;
+    }
+  } while ((current = current.parent));
+  return null;
+}
+
+module.exports = findEngine;

--- a/lib/utils/is-engine.js
+++ b/lib/utils/is-engine.js
@@ -1,0 +1,9 @@
+/* eslint-env node */
+
+'use strict';
+
+function isEngine(addon) {
+  return addon.pkg && addon.pkg.keywords && addon.pkg.keywords.includes('ember-engine');
+}
+
+module.exports = isEngine;


### PR DESCRIPTION
In looking into #797 in more detail, we found the current behavior of ember-intl in engines to be a bit unexpected (see https://github.com/ember-intl/ember-intl/issues/797#issuecomment-479195256 for more details). Looking for feedback on the proposed behavior changes to better support ember-engines.

This change makes a few modifications to the behavior in the build process. With these changes, there are now two sets of behavior, depending on how an engine depends on `ember-intl`: 

* If an ember-engine depends directly on `ember-intl`, it will perform its own `ember-intl` build and produce its own set of translation files. This build will respect the configuration provided in the `config/ember-intl.js` file in the engine. It still uses the treeForApp hook because ember-engines already transforms this output so that they’re namespaced for the engine. Additionally, if a host application of the engine depends itself on `ember-intl`, it will ignore the engine addon and not bundle the engine’s translations in the host app. This provides engine-level translation isolation, and the expectation is that each engine will use its own independent intl service.
* If an ember-engine does not depend directly on `ember-intl`, then it will be treated as a normal addon, and its host application will bundle its translations in its own translation build. This enables folks to use the host application’s intl service and pass it down to the child engine and use the host application’s intl service.

In order to introduce this behavior, we did have to introduce knowledge into the addon during the build process on whether it’s being invoked in an engine or not (since they have slightly different methods of fetching configuration data), and so that we can treat addons as either plain addons, or engines with their own, scoped ember-intl config/build. We also had to fix the `cacheKeyForTree` cache key so that the same assets wouldn’t be re-used for every engine that’s built.

Not entirely sure how best to write tests for this behavior (it looks like the existing build tests are relatively light, e.g. https://github.com/ember-intl/ember-intl/blob/master/tests-node/unit/index-test.js?), any suggestions welcome.