### PR TITLE
Add namespaces to nested translations

### DIFF
--- a/blueprints/ember-intl/files/config/ember-intl.js
+++ b/blueprints/ember-intl/files/config/ember-intl.js
@@ -83,6 +83,15 @@ module.exports = function(/* environment */) {
     stripEmptyTranslations: false,
 
     /**
+     * Add the subdirectories of the translations as a namespace for all keys.
+     *
+     * @property wrapTranslationsWithNamespace
+     * @type {Boolean}
+     * @default false
+     */
+    wrapTranslationsWithNamespace: false,
+
+    /**
      * Filter missing translations to ignore expected missing translations.
      *
      * See https://ember-intl.github.io/ember-intl/docs/guide/missing-translations#requiring-translations

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   generateTranslationTree(bundlerOptions) {
-    const translationTree = buildTree(this.project, this.opts.inputPath, this.treeGenerator);
+    const [translationTree, addons] = buildTree(this.project, this.opts.inputPath, this.treeGenerator);
     const _bundlerOptions = bundlerOptions || {};
     const addon = this;
 
@@ -81,6 +81,8 @@ module.exports = {
       errorOnMissingTranslations: this.opts.throwMissingTranslations || this.opts.errorOnMissingTranslations,
       errorOnNamedArgumentMismatch: this.opts.errorOnNamedArgumentMismatch,
       stripEmptyTranslations: this.opts.stripEmptyTranslations,
+      wrapTranslationsWithNamespace: this.opts.wrapTranslationsWithNamespace,
+      addonsWithTranslations: addons,
       log() {
         return addon.log.apply(addon, arguments);
       }

--- a/lib/broccoli/build-translation-tree.js
+++ b/lib/broccoli/build-translation-tree.js
@@ -11,28 +11,33 @@ const WatchedDir = require('broccoli-source').WatchedDir;
 function buildTranslationTree(project, inputPath, treeGenerator) {
   const projectTranslations = path.join(project.root, inputPath);
   const trees = [];
+  const addonNames = [];
 
-  processAddons(project.addons, trees, treeGenerator);
+  processAddons(project.addons, addonNames, trees, treeGenerator);
 
   if (fs.existsSync(projectTranslations)) {
     trees.push(new WatchedDir(projectTranslations));
   }
 
-  return funnel(
-    mergeTrees(trees, {
-      overwrite: true
-    }),
-    {
-      include: ['**/*.yaml', '**/*.yml', '**/*.json']
-    }
-  );
+  return [
+    funnel(
+      mergeTrees(trees, {
+        overwrite: true
+      }),
+      {
+        include: ['**/*.yaml', '**/*.yml', '**/*.json']
+      }
+    ),
+
+    addonNames
+  ];
 }
 
-function processAddons(addons, translationTrees, treeGenerator) {
-  addons.forEach(addon => _processAddon(addon, translationTrees, treeGenerator));
+function processAddons(addons, addonNames, translationTrees, treeGenerator) {
+  addons.forEach(addon => _processAddon(addon, addonNames, translationTrees, treeGenerator));
 }
 
-function _processAddon(addon, translationTrees, treeGenerator) {
+function _processAddon(addon, addonNames, translationTrees, treeGenerator) {
   const addonTranslationPath = path.join(addon.root, 'translations');
   let addonGeneratedTree;
 
@@ -44,13 +49,15 @@ function _processAddon(addon, translationTrees, treeGenerator) {
     let additionalTranslationTree = addon.treeForTranslations(addonGeneratedTree);
 
     if (additionalTranslationTree) {
+      addonNames.push(addon.name)
       translationTrees.push(funnel(additionalTranslationTree, { destDir: addon.name }));
     }
   } else if (addonGeneratedTree !== undefined) {
+    addonNames.push(addon.name)
     translationTrees.push(funnel(addonGeneratedTree, { destDir: addon.name }));
   }
 
-  processAddons(addon.addons, translationTrees, treeGenerator);
+  processAddons(addon.addons, addonNames, translationTrees, treeGenerator);
 }
 
 module.exports = buildTranslationTree;

--- a/lib/broccoli/build-translation-tree.js
+++ b/lib/broccoli/build-translation-tree.js
@@ -49,11 +49,11 @@ function _processAddon(addon, addonNames, translationTrees, treeGenerator) {
     let additionalTranslationTree = addon.treeForTranslations(addonGeneratedTree);
 
     if (additionalTranslationTree) {
-      addonNames.push(addon.name)
+      addonNames.push(addon.name);
       translationTrees.push(funnel(additionalTranslationTree, { destDir: addon.name }));
     }
   } else if (addonGeneratedTree !== undefined) {
-    addonNames.push(addon.name)
+    addonNames.push(addon.name);
     translationTrees.push(funnel(addonGeneratedTree, { destDir: addon.name }));
   }
 

--- a/lib/broccoli/translation-reducer/index.js
+++ b/lib/broccoli/translation-reducer/index.js
@@ -172,7 +172,12 @@ class TranslationReducer extends CachingWriter {
       }
 
       if (this.options.wrapTranslationsWithNamespace === true) {
-        translation = wrapWithNamespaceIfNeeded(translation, filepath, this.inputPaths[0], this.options.addonsWithTranslations);
+        translation = wrapWithNamespaceIfNeeded(
+          translation,
+          filepath,
+          this.inputPaths[0],
+          this.options.addonsWithTranslations
+        );
       }
 
       let filename = path.basename(filepath).split('.')[0];

--- a/lib/broccoli/translation-reducer/index.js
+++ b/lib/broccoli/translation-reducer/index.js
@@ -23,6 +23,7 @@ const stripNestedNulls = require('./utils/strip-nested-nulls');
 const extractICUArguments = require('./utils/extract-icu-arguments');
 const findMissingTranslations = require('./utils/find-missing-translations');
 const findMissingICUArguments = require('./utils/find-missing-icu-arguments');
+const wrapWithNamespaceIfNeeded = require('./utils/wrap-with-namespace-if-needed');
 
 function readAsObject(filepath) {
   let data = fs.readFileSync(filepath);
@@ -168,6 +169,10 @@ class TranslationReducer extends CachingWriter {
         this._log(`cannot read path "${filepath}"`);
 
         return accum;
+      }
+
+      if (this.options.wrapTranslationsWithNamespace === true) {
+        translation = wrapWithNamespaceIfNeeded(translation, filepath, this.inputPaths[0], this.options.addonsWithTranslations);
       }
 
       let filename = path.basename(filepath).split('.')[0];

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -19,29 +19,28 @@ const path = require('path');
  * @private
  */
 function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
-  filepath = path.dirname(filepath);
-  filepath = filepath.replace(inputPath, '');
+  let dirname = path.dirname(filepath).replace(inputPath, '');
 
-  if (filepath) {
+  if (dirname) {
     let prefix = path.sep;
 
     for (let addon of addonNames) {
       addon = path.sep + addon;
 
-      if (filepath.startsWith(addon)) {
+      if (dirname.startsWith(addon)) {
         prefix = addon;
         break;
       }
     }
 
-    filepath = filepath.replace(prefix, '');
-    const filepathParts = filepath
+    dirname = dirname.replace(prefix, '');
+    const dirnameParts = dirname
       .split(path.sep)
       .filter(part => part)
       .reverse();
 
-    if (filepathParts.length > 0) {
-      for (const pathPart of filepathParts) {
+    if (dirnameParts.length > 0) {
+      for (const pathPart of dirnameParts) {
         object = {
           [pathPart]: object
         };

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -42,7 +42,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
     if (dirnameParts.length > 0) {
       for (const pathPart of dirnameParts) {
         object = {
-          [pathPart]: object
+          [pathPart.replace(/ /g, '_')]: object
         };
       }
     }

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -35,7 +35,10 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
     }
 
     filepath = filepath.replace(prefix, '');
-    const filepathParts = filepath.split(path.sep).filter(part => part).reverse();
+    const filepathParts = filepath
+      .split(path.sep)
+      .filter(part => part)
+      .reverse();
 
     if (filepathParts.length > 0) {
       for (const pathPart of filepathParts) {

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -20,13 +20,13 @@ const path = require('path');
  */
 function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
   filepath = path.dirname(filepath);
-  filepath = filepath.replace(inputPath, "");
+  filepath = filepath.replace(inputPath, '');
 
   if (filepath) {
-    let prefix = "/";
+    let prefix = '/';
 
     for (let addon of addonNames) {
-      addon = "/" + addon + "/";
+      addon = '/' + addon + '/';
 
       if (filepath.startsWith(addon)) {
         prefix = addon;
@@ -34,7 +34,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
       }
     }
 
-    filepath = filepath.replace(prefix, "");
+    filepath = filepath.replace(prefix, '');
     const filepathParts = filepath.split(path.sep).reverse();
 
     if (filepathParts.length > 0) {

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -23,10 +23,10 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
   filepath = filepath.replace(inputPath, '');
 
   if (filepath) {
-    let prefix = '/';
+    let prefix = path.sep;
 
     for (let addon of addonNames) {
-      addon = '/' + addon + '/';
+      addon = path.sep + addon;
 
       if (filepath.startsWith(addon)) {
         prefix = addon;
@@ -35,7 +35,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
     }
 
     filepath = filepath.replace(prefix, '');
-    const filepathParts = filepath.split(path.sep).reverse();
+    const filepathParts = filepath.split(path.sep).filter(part => part).reverse();
 
     if (filepathParts.length > 0) {
       for (const pathPart of filepathParts) {

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -1,0 +1,52 @@
+/* eslint-env node */
+
+'use strict';
+
+const path = require('path');
+
+/**
+ * Wraps the root object with a namespace if the file is under subdirectories
+ *
+ * If a file is under "translations/foo/bar/en-us.json" and we have the "baz" key in that file
+ * we will need to access to the translation using the "foo.bar.baz" key instead of "baz".
+ *
+ * @method wrapWithNamespaceIfNeeded
+ * @param {Object} object
+ * @param {String} filepath
+ * @param {String} inputPath
+ * @param {String[]} addonNames Names of the addons with translations
+ * @return {Object} Returns the input object
+ * @private
+ */
+function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
+  filepath = path.dirname(filepath);
+  filepath = filepath.replace(inputPath, "");
+
+  if (filepath) {
+    let prefix = "/";
+
+    for (let addon of addonNames) {
+      addon = "/" + addon + "/";
+
+      if (filepath.startsWith(addon)) {
+        prefix = addon;
+        break;
+      }
+    }
+
+    filepath = filepath.replace(prefix, "");
+    const filepathParts = filepath.split(path.sep).reverse();
+
+    if (filepathParts.length > 0) {
+      for (const pathPart of filepathParts) {
+        object = {
+          [pathPart]: object
+        };
+      }
+    }
+  }
+
+  return object;
+}
+
+module.exports = wrapWithNamespaceIfNeeded;

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -10,6 +10,7 @@ describe('wrapWithNamespaceIfNeeded', function() {
     [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
     [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],
     [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "an-addon", "other-addon"]],
+    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/////en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "an-addon", "other-addon"]],
     [{ a: true, b: false }, { foo: { a: true, b: false } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
     [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
     [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+'use strict';
+
+let expect = require('chai').expect;
+
+let wrapWithNamespaceIfNeeded = require('../../../../lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed');
+
+describe('wrapWithNamespaceIfNeeded', function() {
+  [
+    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
+    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],
+    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "an-addon", "other-addon"]],
+    [{ a: true, b: false }, { foo: { a: true, b: false } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
+    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
+    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],
+    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["other-addon", "an-addon"]],
+    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "other-addon", "an-addon"]],
+  ].forEach(([object, expected, filepath, inputPath, addonNames]) => {
+    it(`${JSON.stringify(object)} -> ${JSON.stringify(expected)}`, function() {
+      expect(wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames)).to.deep.equal(expected);
+    });
+  });
+});

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -69,6 +69,27 @@ describe('wrapWithNamespaceIfNeeded', function() {
       '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo/bar/en-us.json',
       '/tmp/broccoli_debug-output_path-l4iBcmcT',
       ['@a-scoped/addon', 'other-addon', 'an-addon']
+    ],
+    [
+      { a: true, b: false },
+      { foo_bar: { a: true, b: false } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo_bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'other-addon', 'an-addon']
+    ],
+    [
+      { a: true, b: false },
+      { 'foo-bar': { a: true, b: false } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo-bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'other-addon', 'an-addon']
+    ],
+    [
+      { a: true, b: false },
+      { foo_bar: { a: true, b: false } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'other-addon', 'an-addon']
     ]
   ].forEach(([object, expected, filepath, inputPath, addonNames]) => {
     it(`${JSON.stringify(object)} -> ${JSON.stringify(expected)}`, function() {

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -7,15 +7,69 @@ let wrapWithNamespaceIfNeeded = require('../../../../lib/broccoli/translation-re
 
 describe('wrapWithNamespaceIfNeeded', function() {
   [
-    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
-    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],
-    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "an-addon", "other-addon"]],
-    [{ a: true, b: false }, { a: true, b: false }, "/tmp/broccoli_debug-output_path-l4iBcmcT/////en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "an-addon", "other-addon"]],
-    [{ a: true, b: false }, { foo: { a: true, b: false } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
-    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", []],
-    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["an-addon", "other-addon"]],
-    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["other-addon", "an-addon"]],
-    [{ a: true, b: false }, { foo: { bar: { a: true, b: false } } }, "/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo/bar/en-us.json", "/tmp/broccoli_debug-output_path-l4iBcmcT", ["@a-scoped/addon", "other-addon", "an-addon"]],
+    [
+      { a: true, b: false },
+      { a: true, b: false },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      []
+    ],
+    [
+      { a: true, b: false },
+      { a: true, b: false },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['an-addon', 'other-addon']
+    ],
+    [
+      { a: true, b: false },
+      { a: true, b: false },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'an-addon', 'other-addon']
+    ],
+    [
+      { a: true, b: false },
+      { a: true, b: false },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/////en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'an-addon', 'other-addon']
+    ],
+    [
+      { a: true, b: false },
+      { foo: { a: true, b: false } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/foo/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      []
+    ],
+    [
+      { a: true, b: false },
+      { foo: { bar: { a: true, b: false } } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/foo/bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      []
+    ],
+    [
+      { a: true, b: false },
+      { foo: { bar: { a: true, b: false } } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['an-addon', 'other-addon']
+    ],
+    [
+      { a: true, b: false },
+      { foo: { bar: { a: true, b: false } } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/an-addon/foo/bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['other-addon', 'an-addon']
+    ],
+    [
+      { a: true, b: false },
+      { foo: { bar: { a: true, b: false } } },
+      '/tmp/broccoli_debug-output_path-l4iBcmcT/@a-scoped/addon/foo/bar/en-us.json',
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['@a-scoped/addon', 'other-addon', 'an-addon']
+    ]
   ].forEach(([object, expected, filepath, inputPath, addonNames]) => {
     it(`${JSON.stringify(object)} -> ${JSON.stringify(expected)}`, function() {
       expect(wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames)).to.deep.equal(expected);

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -28,7 +28,10 @@ module('Acceptance: Smoke', function(hooks) {
 
   test('translation-subdirectory', async function(assert) {
     await visit('/smoke');
-    assert.ok(t('smoke.subdirectory'));
-    assert.dom('.translation-subdirectory').includesText(t('smoke.subdirectory'));
+
+    const translation = t('subdirectory.smoke.subdirectory') || t('smoke.subdirectory');
+
+    assert.ok(translation);
+    assert.dom('.translation-subdirectory').includesText(translation);
   });
 });

--- a/tests/dummy/app/pods/smoke/controller.js
+++ b/tests/dummy/app/pods/smoke/controller.js
@@ -14,5 +14,9 @@ export default Controller.extend({
     changeLocale(locale) {
       this.get('intl').setLocale(locale);
     }
+  },
+
+  get namespacesAreActive() {
+    return this.intl.exists("subdirectory.smoke.subdirectory");
   }
 });

--- a/tests/dummy/app/pods/smoke/controller.js
+++ b/tests/dummy/app/pods/smoke/controller.js
@@ -17,6 +17,6 @@ export default Controller.extend({
   },
 
   get namespacesAreActive() {
-    return this.intl.exists("subdirectory.smoke.subdirectory");
+    return this.intl.exists('subdirectory.smoke.subdirectory');
   }
 });

--- a/tests/dummy/app/pods/smoke/controller.js
+++ b/tests/dummy/app/pods/smoke/controller.js
@@ -1,6 +1,7 @@
 import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 const now = new Date();
 const yesterday = new Date(now).setDate(now.getDate() - 1);
@@ -16,7 +17,7 @@ export default Controller.extend({
     }
   },
 
-  get namespacesAreActive() {
-    return this.intl.exists('subdirectory.smoke.subdirectory');
-  }
+  namespacesAreActive: computed(function() {
+    return this.get('intl').exists('subdirectory.smoke.subdirectory');
+  })
 });

--- a/tests/dummy/app/pods/smoke/template.hbs
+++ b/tests/dummy/app/pods/smoke/template.hbs
@@ -25,7 +25,15 @@
   {{format-relative yesterday}}
 </div>
 
-<h3>Translation Subdirectory</h3>
-<div class="translation-subdirectory">
-  {{t 'smoke.subdirectory'}}
-</div>
+{{#if namespacesAreActive}}
+  <h3>Translation Subdirectory (with namespaces)</h3>
+  <div class="translation-subdirectory">
+    {{t 'subdirectory.smoke.subdirectory'}}
+  </div>
+{{else}}
+  <h3>Translation Subdirectory</h3>
+  <div class="translation-subdirectory">
+    {{t 'smoke.subdirectory'}}
+  </div>
+{{/if}}
+

--- a/tests/dummy/config/ember-intl.js
+++ b/tests/dummy/config/ember-intl.js
@@ -83,6 +83,15 @@ module.exports = function(/* environment */) {
     stripEmptyTranslations: false,
 
     /**
+     * Add the subdirectories of the translations as a namespace for all keys.
+     *
+     * @property wrapTranslationsWithNamespace
+     * @type {Boolean}
+     * @default false
+     */
+    wrapTranslationsWithNamespace: true,
+
+    /**
      * Filter missing translations to ignore expected missing translations.
      *
      * See https://ember-intl.github.io/ember-intl/docs/guide/missing-translations#requiring-translations


### PR DESCRIPTION
> If a file is under "translations/foo/bar/en-us.json" and we have the "baz" key in that file we will need to access to the translation using the "foo.bar.baz" key instead of "baz". This feature needs be activated setting the config "wrapTranslationsWithNamespace" to true.

The issue #228 is related with this pull request.

Hello, in our current project we have several translations organize in subdirectories. For example, we have a `validation` directory with the next translations:

```
validation:
  accepted: The :attribute must be accepted.
  birthday: The :attribute field is an invalid birthday date.
  digits: The :attribute must be :digits digits.
  digits_between: The :attribute must be between :min and :max digits.
  email: The :attribute must be a valid email address.
  integer: The :attribute must be an integer.

  max:
    array: The :attribute may not have more than :max items.
    number: The :attribute may not be greater than :max.
    string: The :attribute may not be greater than :max characters.

  min:
    array: The :attribute must have at least :min items.
    number: The :attribute must be at least :min.
    string: The :attribute must be at least :min characters.

  not_regex: The :attribute format is invalid.
  number: The :attribute must be a number.
  regex: The :attribute format is invalid.
  required: The :attribute field is required.
```

The idea of this pull request is to have an option in the config file (`wrapTranslationsWithNamespace`) to tell to intl that we want add a namespace/prefix to the nested translations. Converting the previous translation file to:

```
accepted: The :attribute must be accepted.
birthday: The :attribute field is an invalid birthday date.
digits: The :attribute must be :digits digits.
digits_between: The :attribute must be between :min and :max digits.
email: The :attribute must be a valid email address.
integer: The :attribute must be an integer.

max:
  array: The :attribute may not have more than :max items.
  number: The :attribute may not be greater than :max.
  string: The :attribute may not be greater than :max characters.

min:
  array: The :attribute must have at least :min items.
  number: The :attribute must be at least :min.
  string: The :attribute must be at least :min characters.

not_regex: The :attribute format is invalid.
number: The :attribute must be a number.
regex: The :attribute format is invalid.
required: The :attribute field is required.
```
And  using the same key to access to the translations: `validation.max.array`, for example.
