### PR TITLE
Add helper format-number-compact

### DIFF
--- a/addon/helpers/format-number-compact.js
+++ b/addon/helpers/format-number-compact.js
@@ -9,7 +9,7 @@ import { get } from '@ember/object';
 
 export default BaseHelper.extend({
   format(value, options) {
-    const style = get(options, "style");
+    const style = get(options, 'style');
     const opts = { value };
     const message = style ? `{value, shortNumber, ${style}}` : `{value, shortNumber}`;
 

--- a/addon/helpers/format-number-compact.js
+++ b/addon/helpers/format-number-compact.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+import BaseHelper from './-format-base';
+import { assign } from '@ember/polyfills';
+import { get } from '@ember/object';
+
+export default BaseHelper.extend({
+  format(value, options) {
+    const style = get(options, "style");
+    const opts = { value };
+    const message = style ? `{value, shortNumber, ${style}}` : `{value, shortNumber}`;
+
+    assign(opts, options);
+
+    return this.intl.formatMessage(message, opts);
+  }
+});

--- a/app/helpers/format-number-compact.js
+++ b/app/helpers/format-number-compact.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+export { default } from 'ember-intl/helpers/format-number-compact';

--- a/tests/dummy/app/pods/docs/helpers/format-number-compact/controller.js
+++ b/tests/dummy/app/pods/docs/helpers/format-number-compact/controller.js
@@ -1,0 +1,7 @@
+// BEGIN-SNIPPET docs-helpers-format-number-compact-controller.js
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  num: 19634
+});
+// END-SNIPPET

--- a/tests/dummy/app/pods/docs/helpers/format-number-compact/template.md
+++ b/tests/dummy/app/pods/docs/helpers/format-number-compact/template.md
@@ -1,0 +1,36 @@
+{{locale-switcher}}
+# Format Number Compact
+
+Formats numbers using [<code>cldr-compact-number</code>](https://github.com/snewcomer/cldr-compact-number), and returns the formatted string value.
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='docs-helpers-format-number-compact-01-template.hbs'}}
+    The Cisco DPC3000 has {{format-number-compact num}} customers
+  {{/demo.example}}
+
+  {{demo.snippet 'docs-helpers-format-number-compact-01-template.hbs'}}
+  {{demo.snippet 'docs-helpers-format-number-compact-controller.js'}}
+{{/docs-demo}}
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='docs-helpers-format-number-compact-02-template.hbs'}}
+    The Cisco DPC3000 has {{format-number-compact num style="oneSignificantDigit"}} customers
+  {{/demo.example}}
+
+  {{demo.snippet 'docs-helpers-format-number-compact-02-template.hbs'}}
+  {{demo.snippet 'docs-helpers-format-number-compact-controller.js'}}
+{{/docs-demo}}
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name='docs-helpers-format-number-compact-03-template.hbs'}}
+    The Cisco DPC3000 has {{format-number-compact num style="twoSignificantDigits"}} customers
+  {{/demo.example}}
+
+  {{demo.snippet 'docs-helpers-format-number-compact-03-template.hbs'}}
+  {{demo.snippet 'docs-helpers-format-number-compact-controller.js'}}
+{{/docs-demo}}
+
+## Format Number Compact Options
+`style`
+
+> The formatting style to use. Possible values are any style under the format "shortNumber" in your formats file.

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -23,6 +23,7 @@
     {{nav.item 'format-time' 'docs.helpers.format-time'}}
     {{nav.item 'format-message' 'docs.helpers.format-message'}}
     {{nav.item 'format-number' 'docs.helpers.format-number'}}
+    {{nav.item 'format-number-compact' 'docs.helpers.format-number-compact'}}
     {{nav.item 'format-relative' 'docs.helpers.format-relative'}}
 
     {{nav.section 'Cookbook'}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -28,6 +28,7 @@ Router.map(function() {
       this.route('format-date');
       this.route('format-message');
       this.route('format-number');
+      this.route('format-number-compact');
       this.route('format-relative');
       this.route('format-time');
     });

--- a/tests/unit/helpers/format-number-compact-test.js
+++ b/tests/unit/helpers/format-number-compact-test.js
@@ -1,0 +1,58 @@
+import hbs from 'htmlbars-inline-precompile';
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import formatNumberCompactHelper from 'ember-intl/helpers/format-number-compact';
+
+module('format-number-compact', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.set('formats', {
+      shortNumber: {
+        oneDigit: {
+          significantDigits: 1
+        },
+      }
+    });
+  });
+
+  test('exists', function(assert) {
+    assert.expect(1);
+    assert.ok(formatNumberCompactHelper);
+  });
+
+  test('invoke the formatMessage method', function(assert) {
+    assert.expect(1);
+    assert.equal(this.intl.formatMessage("{amount, shortNumber, oneDigit}", { amount: 19634 }), "19.6K");
+  });
+
+  test('number is formats unset locale (en-US)', async function(assert) {
+    assert.expect(1);
+    await render(hbs`{{format-number-compact 19634}}`);
+    assert.equal(this.element.textContent, '20K');
+  });
+
+  test('number is formatted correctly with active service locale', async function(assert) {
+    assert.expect(1);
+    this.intl.setLocale(['es-es']);
+    await render(hbs`{{format-number-compact 1000}}`);
+    assert.equal(this.element.textContent, '1\xa0mil');
+  });
+
+  test('locale can be passed as an argument', async function(assert) {
+    assert.expect(1);
+    this.intl.setLocale(['es-es']);
+    this.set('NUM', 1000);
+    await render(hbs`{{format-number-compact NUM locale="en-us"}}`);
+    assert.equal(this.element.textContent, '1K');
+  });
+
+  test('style can be passed as an argument', async function(assert) {
+    assert.expect(1);
+    this.set('NUM', 19634);
+    await render(hbs`{{format-number-compact NUM style="oneDigit"}}`);
+    assert.equal(this.element.textContent, '19.6K');
+  });
+});

--- a/tests/unit/helpers/format-number-compact-test.js
+++ b/tests/unit/helpers/format-number-compact-test.js
@@ -13,7 +13,7 @@ module('format-number-compact', function(hooks) {
       shortNumber: {
         oneDigit: {
           significantDigits: 1
-        },
+        }
       }
     });
   });
@@ -25,7 +25,7 @@ module('format-number-compact', function(hooks) {
 
   test('invoke the formatMessage method', function(assert) {
     assert.expect(1);
-    assert.equal(this.intl.formatMessage("{amount, shortNumber, oneDigit}", { amount: 19634 }), "19.6K");
+    assert.equal(this.intl.formatMessage('{amount, shortNumber, oneDigit}', { amount: 19634 }), '19.6K');
   });
 
   test('number is formats unset locale (en-US)', async function(assert) {

--- a/tests/unit/helpers/format-number-compact-test.js
+++ b/tests/unit/helpers/format-number-compact-test.js
@@ -1,5 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import formatNumberCompactHelper from 'ember-intl/helpers/format-number-compact';


### PR DESCRIPTION
#934

- [x] Add new helper format-number-compact.
`{{format-number-compact 19634}}` will display `20K`
- [x] Add `style` option to select the style from formats file.
`{{format-number-compact 19634 style="oneDigit"}}` will display `19.6K`
- [x] Add documentation for the new helper