### PR TITLE
fix addons without a root breaking the build

### DIFF
--- a/lib/broccoli/build-translation-tree.js
+++ b/lib/broccoli/build-translation-tree.js
@@ -38,6 +38,10 @@ function processAddons(addons, addonNames, translationTrees, treeGenerator) {
 }
 
 function _processAddon(addon, addonNames, translationTrees, treeGenerator) {
+  if (! addon.root) {
+    return;
+  }
+  
   const addonTranslationPath = path.join(addon.root, 'translations');
   let addonGeneratedTree;
 


### PR DESCRIPTION
Not all addons have a root, we have an addon that just does tasks during a build. It has no root in this case from what I can see.

When I look at this addon compared to others it is returning a `function` on the `index.js` vs all other addons returning an object.

eg. addon with this in `index.js` breaks:

```js
module.exports = function (defaults) {
  return {
    name: 'broken',
  };
};
```

eg. addon with this in `index.js` works as expected:

```js
module.exports = {
  name: 'working',
};
```