### PR TITLE
feat: Adds `notation` option to Intl.NumberFormat

### DIFF
--- a/addon/-private/formatters/format-number.js
+++ b/addon/-private/formatters/format-number.js
@@ -26,7 +26,8 @@ export default class FormatNumber extends Formatter {
       'minimumFractionDigits',
       'maximumFractionDigits',
       'minimumSignificantDigits',
-      'maximumSignificantDigits'
+      'maximumSignificantDigits',
+      'notation'
     ]);
   }
 

--- a/tests/unit/helpers/format-number-test.js
+++ b/tests/unit/helpers/format-number-test.js
@@ -176,4 +176,17 @@ module('format-number', function(hooks) {
 
     assert.equal(this.element.textContent.trim(), '$3.00€8.00¥10.00');
   });
+
+  test('should support notation option', async function(assert) {
+    if (!('notation' in new Intl.NumberFormat().resolvedOptions())) {
+      // test running in unsupported browser
+      assert.ok(true);
+
+      return;
+    }
+
+    assert.expect(1);
+    await render(hbs`{{format-number 50000 notation="compact"}}`);
+    assert.equal(this.element.textContent, '50K');
+  });
 });


### PR DESCRIPTION
`notation` is an experimental API but should be exposed as a possible option for those that want to start exploring it.

API currently works in Chrome and in Node 12 (partial) and 13 (full)

* [x] Add chrome test

Related to #934