### PR TITLE
ci: disabling ember lts 2.12 test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.12
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
+      env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-release


### PR DESCRIPTION
Historically, keeping 2.12 LTS tests working in Travis has been a massive pain and time sink.  Likely this will result in a permanent drop when I release 5.0.0-stable.

```sh
errorMessage: Cannot find module '@ember-data/canary-features/addon/default-features.js'
Require stack:
- /home/travis/build/ember-intl/ember-intl/node_modules/@ember-data/-build-infra/src/features.js
- /home/travis/build/ember-intl/ember-intl/node_modules/@ember-data/-build-infra/src/debug-macros.js
- /home/travis/build/ember-intl/ember-intl/node_modules/@ember-data/-build-infra/src/addon-build-config-for-data-package.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-data/index.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/models/package-info-cache/package-info.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/models/package-info-cache/index.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/models/project.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/utilities/get-config.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/utilities/instrumentation.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/lib/cli/index.js
- /home/travis/build/ember-intl/ember-intl/node_modules/ember-cli/bin/ember
  - errorType: [undefined]
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
  - message: Cannot find module '@ember-data/canary-features/addon/default-features.js'
```