### PR TITLE
fixes typo

### DIFF
--- a/tests/dummy/app/pods/docs/getting-started/quickstart/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/quickstart/template.md
@@ -8,7 +8,7 @@ ember install ember-intl
 
 This will create the following files:
 
-* `app/format.js`
+* `app/formats.js`
     <!-- default definitions of named formats -->
 * `config/ember-intl.js`
     <!-- default ember-intl settings -->


### PR DESCRIPTION
This PR is just fixing a typo for a file name in the documentation. installing the add-on will generate this file along with others:

app/format**s**.js