### PR TITLE
Append context to ICU parsing failure

### DIFF
--- a/lib/broccoli/translation-reducer/utils/extract-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/utils/extract-icu-arguments.js
@@ -4,10 +4,16 @@
 const parser = require('@ember-intl/intl-messageformat-parser');
 
 function extractICUArguments(string) {
-  return parser
-    .parse(string)
-    .elements.filter(element => element.type === 'argumentElement')
-    .map(argumentElement => argumentElement.id);
+  try {
+    // Errors thrown by the parser won't include any details about the string. By rethrowing the
+    // error with the string quoted it's much easier to identify which ICU argument was invalid.
+    return parser
+      .parse(string)
+      .elements.filter(element => element.type === 'argumentElement')
+      .map(argumentElement => argumentElement.id);
+  } catch (err) {
+    throw new Error(`An error occured (${err.message}) when extracting ICU arguments for '${string}'`);
+  }
 }
 
 module.exports = extractICUArguments;

--- a/tests-node/unit/broccoli/translation-reducer/index-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/index-test.js
@@ -149,6 +149,13 @@ describe('translation-reducer', function() {
         }
       };
 
+      this.brokenIcuFixture = {
+        en: {
+          brokenSyntax: 'You have {count, plural, =0 {one {cat} other {several cats}}.',
+          validSyntax: 'You have {count, plural, =0 {one cat} other {several cats}.}'
+        }
+      };
+
       this.fixture = {
         de: {
           foo: 'FOO',
@@ -190,6 +197,18 @@ describe('translation-reducer', function() {
         ['baz', ['de', 'en', 'it']],
         ['nested.translation.lock', ['de', 'en', 'it']]
       ]);
+    });
+
+    it('lintTranslations throws error for invalid ICU argument syntax', function() {
+      let subject = new TranslationReducer(this.input.path());
+
+      // this might change slightly if the parser lib is updated, if so it's fine to adjust
+      let expectedParserError = 'Expected "," or "}" but "c" found.';
+      let brokenString = this.brokenIcuFixture.en.brokenSyntax;
+
+      expect(() => subject.lintTranslations(this.brokenIcuFixture)).throws(
+        `An error occured (${expectedParserError}) when extracting ICU arguments for '${brokenString}'`
+      );
     });
 
     it('lintTranslations returns list of icu argument mismatch', function() {


### PR DESCRIPTION
Without the string context it's impossible to know which ICU argument had incorrect syntax.

Let me know what you think! @jasonmit