### PR TITLE
Skip ICU arguments warning when requireTranslation returns false

### DIFF
--- a/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
@@ -1,8 +1,8 @@
 function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments, requiresTranslation) {
   const keyIcuArguments = Array.from(allIcuArguments[key]);
   return locales
-    .map(locale => {
-      let filteredArgs = keyIcuArguments.filter(arg => {
+    .map((locale) => {
+      let filteredArgs = keyIcuArguments.filter((arg) => {
         let missingProp = !Object.prototype.hasOwnProperty.call(icuArguments[locale], key);
         return missingProp || !icuArguments[locale][key].includes(arg);
       });

--- a/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
@@ -1,4 +1,4 @@
-function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments) {
+function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments, requiresTranslation) {
   const keyIcuArguments = Array.from(allIcuArguments[key]);
   return locales
     .map(locale => {
@@ -9,7 +9,7 @@ function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments) {
 
       return [locale, filteredArgs];
     })
-    .filter(([, missing]) => missing.length > 0);
+    .filter(([locale, missing]) => missing.length > 0 && requiresTranslation(key, locale));
 }
 
 module.exports = findMissingIcuArguments;

--- a/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
@@ -1,13 +1,14 @@
 function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments) {
   const keyIcuArguments = Array.from(allIcuArguments[key]);
   return locales
-    .map((locale) => [
-      locale,
-      keyIcuArguments.filter(
-        (arg) =>
-          !Object.prototype.hasOwnProperty.call(icuArguments[locale], key) || !icuArguments[locale][key].includes(arg)
-      ),
-    ])
+    .map(locale => {
+      let filteredArgs = keyIcuArguments.filter(arg => {
+        let missingProp = !Object.prototype.hasOwnProperty.call(icuArguments[locale], key);
+        return missingProp || !icuArguments[locale][key].includes(arg);
+      });
+
+      return [locale, filteredArgs];
+    })
     .filter(([, missing]) => missing.length > 0);
 }
 

--- a/lib/broccoli/translation-reducer/linter/index.js
+++ b/lib/broccoli/translation-reducer/linter/index.js
@@ -53,7 +53,7 @@ module.exports = class Linter {
         result.missingTranslations.push([key, notInLocales]);
       }
 
-      let missingICUArgs = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
+      let missingICUArgs = findMissingICUArguments(key, allIcuArguments, locales, icuArguments, requiresTranslation);
 
       if (fallbackLocale) {
         missingICUArgs = missingICUArgs.filter(([locale]) => fallbackLocale === locale);

--- a/tests-node/unit/broccoli/translation-reducer/find-missing-icu-arguments-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/find-missing-icu-arguments-test.js
@@ -2,6 +2,8 @@ const expect = require('chai').expect;
 
 const findMissingICUArguments = require('../../../../lib/broccoli/translation-reducer/linter/find-missing-icu-arguments');
 
+const isTrue = () => true;
+
 describe('findMissingICUArguments', function () {
   it('finds nothing if nothing is missing', function () {
     const key = 'foo';
@@ -12,7 +14,7 @@ describe('findMissingICUArguments', function () {
       en: { foo: ['aa'] },
     };
 
-    expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments)).to.deep.equal([]);
+    expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments, isTrue)).to.deep.equal([]);
   });
 
   it('finds missing icu arguments', function () {
@@ -24,9 +26,24 @@ describe('findMissingICUArguments', function () {
       en: { baz: ['arg1', 'arg2'] },
     };
 
-    expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments)).to.deep.equal([
+    expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments, isTrue)).to.deep.equal([
       ['de', ['arg1']],
       ['en', ['arg0']],
+    ]);
+  });
+
+  it('ignores missing icu arguments if not required', function() {
+    const key = 'baz';
+    const allIcuArguments = { baz: ['arg0', 'arg1', 'arg2'] };
+    const locales = ['de', 'en'];
+    const icuArguments = {
+      de: { baz: ['arg0', 'arg2'] },
+      en: { baz: ['arg1', 'arg2'] },
+    };
+    const isAllowed = (key, locale) => locale !== 'en';
+
+    expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments, isAllowed)).to.deep.equal([
+      ['de', ['arg1']]
     ]);
   });
 });

--- a/tests-node/unit/broccoli/translation-reducer/find-missing-icu-arguments-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/find-missing-icu-arguments-test.js
@@ -32,7 +32,7 @@ describe('findMissingICUArguments', function () {
     ]);
   });
 
-  it('ignores missing icu arguments if not required', function() {
+  it('ignores missing icu arguments if not required', function () {
     const key = 'baz';
     const allIcuArguments = { baz: ['arg0', 'arg1', 'arg2'] };
     const locales = ['de', 'en'];
@@ -43,7 +43,7 @@ describe('findMissingICUArguments', function () {
     const isAllowed = (key, locale) => locale !== 'en';
 
     expect(findMissingICUArguments(key, allIcuArguments, locales, icuArguments, isAllowed)).to.deep.equal([
-      ['de', ['arg1']]
+      ['de', ['arg1']],
     ]);
   });
 });


### PR DESCRIPTION
This will avoid warnings such as 

> [ember-intl] "my.translation.key" ICU argument missing: "de": "color"

When setting `config/ember-intl.js` to something like this:

```js
requiresTranslation(_key, locale) {
      return locale !== 'de'; // german translations aren't required
    },
```

Let me know what you think! @jasonmit