### PR TITLE
feat(BREAKING): removes config.locales option.

### DIFF
--- a/blueprints/ember-intl/files/__config__/ember-intl.js
+++ b/blueprints/ember-intl/files/__config__/ember-intl.js
@@ -3,21 +3,6 @@
 module.exports = function (/* environment */) {
   return {
     /**
-     * The locales that the application needs to support.
-     *
-     * NOTE: this is optional and is automatically set *if* you store translations
-     * within the `inputPath` defined below.
-     *
-     * If you side load translations, you must then explicitly
-     * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
-     *
-     * @property locales
-     * @type {Array?}
-     * @default "null"
-     */
-    locales: null,
-
-    /**
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *

--- a/blueprints/translation/index.js
+++ b/blueprints/translation/index.js
@@ -27,7 +27,7 @@ module.exports = {
         'Full list of supported locales: https://ember-intl.github.io/ember-intl/docs/guide/supported-locales'
       );
 
-      throw new SilentError(`[ember-intl] Invalid locale format: "${locale}"`);
+      throw new SilentError(`[ember-intl] invalid locale format: "${locale}"`);
     }
   },
 

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -3,21 +3,6 @@
 module.exports = function (/* environment */) {
   return {
     /**
-     * The locales that the application needs to support.
-     *
-     * NOTE: this is optional and is automatically set *if* you store translations
-     * within the `inputPath` defined below.
-     *
-     * If you side load translations, you must then explicitly
-     * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
-     *
-     * @property locales
-     * @type {Array?}
-     * @default "null"
-     */
-    locales: null,
-
-    /**
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "lodash.last": "^3.0.0",
     "lodash.omit": "^4.5.0",
     "mkdirp": "^1.0.3",
-    "silent-error": "^1.1.1",
-    "walk-sync": "^2.0.2"
+    "silent-error": "^1.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/tests/dummy/app/pods/docs/guide/asynchronously-loading-translations/template.md
+++ b/tests/dummy/app/pods/docs/guide/asynchronously-loading-translations/template.md
@@ -15,19 +15,6 @@ module.exports = function() {
 };
 ```
 
-## Asynchronous loading of translations
-
-Manually configure ember-intl with the list of locales the application needs to support. This is an important step, since at build time we use this information to specific CLDR data for each locale. NOTE: If the translations are managed by ember-intl, i.e. stored in `/translations`, this step is not needed.
-
-```js
-// config/ember-intl.js
-module.exports = function() {
-  return {
-    locales: ['en-us', 'en-ca', 'es-es', 'fr-fr']
-  };
-};
-```
-
 ## Pushing translations into ember-intl
 
 ```js

--- a/tests/dummy/config/ember-intl.js
+++ b/tests/dummy/config/ember-intl.js
@@ -3,21 +3,6 @@
 module.exports = function (/* environment */) {
   return {
     /**
-     * The locales that the application needs to support.
-     *
-     * NOTE: this is optional and is automatically set *if* you store translations
-     * within the `inputPath` defined below.
-     *
-     * If you side load translations, you must then explicitly
-     * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
-     *
-     * @property locales
-     * @type {Array?}
-     * @default "null"
-     */
-    locales: ['en-us', 'es-es', 'fr-fr', 'de-de', 'pt-br'],
-
-    /**
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *


### PR DESCRIPTION
This option is obsolete now that ember-intl no longer handles polyfilling.

The reason we removed auto polyfilling is because there are many strategies and they often vary between projects.

If you're interested in understanding the runtime requirements, read:
https://github.com/ember-intl/ember-intl/blob/master/tests/dummy/app/pods/docs/getting-started/runtime-requirements/template.md