### PR TITLE
feat: parse translations as they're pushed to translation store

### DIFF
--- a/addon/-private/store/translation.js
+++ b/addon/-private/store/translation.js
@@ -7,6 +7,7 @@ import EmberObject from '@ember/object';
 import { assign } from '@ember/polyfills';
 import EmptyObject from 'ember-intl/-private/utils/empty-object';
 import flatten from 'ember-intl/-private/utils/flatten';
+import { parse } from 'intl-messageformat-parser';
 
 /**
  * @private
@@ -23,8 +24,25 @@ const TranslationModel = EmberObject.extend({
     }
   },
 
+  compile(translation) {
+    return parse(translation);
+  },
+
   addTranslations(translations) {
-    assign(this.translations, flatten(translations));
+    const flatTranslations = flatten(translations);
+
+    for (let key in flatTranslations) {
+      let translation = flatTranslations[key];
+
+      // If it's not a string, coerce it to one.
+      if (typeof translation !== 'string') {
+        translation = `${translation}`;
+      }
+
+      flatTranslations[key] = this.compile(translation);
+    }
+
+    assign(this.translations, flatTranslations);
   },
 
   find(key) {

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -136,22 +136,17 @@ export default Service.extend(Evented, {
   /** @public **/
   t(key, options = {}) {
     let defaults = [key];
-    let msg;
+    let ast;
 
     if (options.default) {
       defaults = defaults.concat(options.default);
     }
 
-    while (!msg && defaults.length) {
-      msg = this.lookup(defaults.shift(), options.locale, assign({}, options, { resilient: defaults.length > 0 }));
+    while (!ast && defaults.length) {
+      ast = this.lookup(defaults.shift(), options.locale, assign({}, options, { resilient: defaults.length > 0 }));
     }
 
-    /* Avoids passing msg to intl-messageformat if it is not a string */
-    if (typeof msg === 'string') {
-      return this.formatMessage(msg, options);
-    }
-
-    return msg;
+    return this.formatMessage(ast, options);
   },
 
   /** @public **/

--- a/tests/unit/models/translation-test.js
+++ b/tests/unit/models/translation-test.js
@@ -12,12 +12,12 @@ module('Unit | Model | translation', function (hooks) {
   test('can handle deeply nested object passed into addTranslations', function (assert) {
     this.translationObject.addTranslations({ foo: { bar: { baz: 'BAZ WORKZ' } } });
 
-    assert.equal(this.translationObject.find('foo.bar.baz'), 'BAZ WORKZ');
+    assert.ok(this.translationObject.has('foo.bar.baz'));
   });
 
   test('can handle flat object shape passed into addTranslations', function (assert) {
     this.translationObject.addTranslations({ baz: 'BAZZZ' });
 
-    assert.equal(this.translationObject.find('baz'), 'BAZZZ');
+    assert.ok(this.translationObject.has('baz'));
   });
 });


### PR DESCRIPTION
This means that translations will only ever be parsed one time vs. every time they're seen.

Closes #1193