### PR TITLE
Move webpack configuration into dummy application

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,6 +10,14 @@ module.exports = function (defaults) {
     options.vendorFiles['jquery.js'] = null;
   }
 
+  options.autoImport = {
+    webpack: {
+      node: {
+        global: true,
+      },
+    },
+  };
+
   let app = new EmberAddon(defaults, options);
 
   app.options.snippetPaths = ['tests/dummy/snippets'];

--- a/index.js
+++ b/index.js
@@ -26,16 +26,6 @@ module.exports = {
   configOptions: null,
   isLocalizationFramework: true,
 
-  options: {
-    autoImport: {
-      webpack: {
-        node: {
-          global: true,
-        },
-      },
-    },
-  },
-
   included(parent) {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
This configuration is affecting our application in FastBoot with other dependencies, which require Node.js environment without mocking like this.

Based on https://github.com/ember-intl/ember-intl/commit/f0419f29e51cbbb0337203de9cd09dba3998b87e I'm not sure if it was affecting end-users? The issue I have found is with importing `testdouble` in tests, hence moving into dummy application configuration. I've tested removing this configuration in our application with `ember-intl#4.2.3` and it was working well both in FastBoot and browser.

@jasonmit, can you confirm, that the original issue was with `testdouble` only?