### PR TITLE
Add support for hourCycle date/time formatting option

### DIFF
--- a/addon/-private/formatters/format-date.js
+++ b/addon/-private/formatters/format-date.js
@@ -27,6 +27,7 @@ export default class FormatDate extends Formatter {
       'localeMatcher',
       'timeZone',
       'hour12',
+      'hourCycle',
       'formatMatcher',
       'weekday',
       'era',

--- a/tests/dummy/app/pods/docs/helpers/format-date/template.md
+++ b/tests/dummy/app/pods/docs/helpers/format-date/template.md
@@ -43,6 +43,12 @@ _Note:_ The Intl.js polyfill does not have full support for `timeZone`
 > Whether to use 12-hour time (as opposed to 24-hour time). Possible values
 > are `true` and `false`; the default is locale dependent.
 
+`hourCycle`
+
+> The hour cycle to use. Possible values are "h11", "h12", "h23", or "h24".
+> This option overrides the hc language tag, if both are present, and the
+> hour12 option takes precedence in case both options have been specified.
+
 `formatMatcher`
 
 > The format matching algorithm to use. Possible values are "basic" and

--- a/tests/dummy/app/pods/docs/helpers/format-time/template.md
+++ b/tests/dummy/app/pods/docs/helpers/format-time/template.md
@@ -44,6 +44,12 @@ _Note:_ The Intl.js polyfill does not have full support for `timeZone`
 > Whether to use 12-hour time (as opposed to 24-hour time). Possible values
 > are `true` and `false`; the default is locale dependent.
 
+`hourCycle`
+
+> The hour cycle to use. Possible values are "h11", "h12", "h23", or "h24".
+> This option overrides the hc language tag, if both are present, and the
+> hour12 option takes precedence in case both options have been specified.
+
 `formatMatcher`
 
 > The format matching algorithm to use. Possible values are "basic" and

--- a/tests/unit/helpers/format-time-test.js
+++ b/tests/unit/helpers/format-time-test.js
@@ -39,6 +39,22 @@ module('format-time-test', function(hooks) {
     assert.ok(output === '23/1/2014' || output === '23/01/2014');
   });
 
+  test('should support hourCycle', async function(assert) {
+    assert.expect(2);
+
+    this.intl.set('formats', {
+      time: { test: { timeZone: 'UTC', locale: 'en-ie', hour: 'numeric', minute: 'numeric' } }
+    });
+
+    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test"}}`);
+
+    assert.equal(this.element.textContent, '00:00', 'en-ie time format defaults to h23');
+
+    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test" hourCycle="h12"}}`);
+
+    assert.equal(this.element.textContent, '12:00 a.m.', 'en-ie hourCycle overridden');
+  });
+
   test('should support allowEmpty', async function(assert) {
     assert.expect(1);
     await render(hbs`{{format-time allowEmpty=true}}`);


### PR DESCRIPTION
This PR whitelists the `hourCycle` date/time formatting option so that it can be set when formatting times.

[LINK to docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat)

I have added the option, added a test for it and updated the docs.

Once question I have, I have created this agains the `4.x` branch simply because that's what we're currently using. If you're happy to move forward with this change, shall I create a new PR for the same change for the `master` branch?

Closes #1260 