### PR TITLE
fix: polyfill docs with intl.relativetimeformat polyfill to support Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@formatjs/intl-relativetimeformat": "^4.5.14",
     "babel-eslint": "^10.1.0",
     "broccoli-test-helper": "^2.0.0",
     "chai": "^4.2.0",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,6 +3,11 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
+import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/en';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/fr';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/es';
+
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,6 +1052,13 @@
     resolve "^1.8.1"
     semver "^5.6.0"
 
+"@formatjs/intl-relativetimeformat@^4.5.14":
+  version "4.5.14"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.14.tgz#8ec90d536031b0b38446a261e627cca3f4978ae2"
+  integrity sha512-/lGg37Xqjh3h3yjOhfk67B/4d9MUFK2v56uxC8SlWptpFjsdp9iXX12T9sU9wsGTBCFA0k6gDKUJAqmr6P1YVQ==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.4"
+
 "@formatjs/intl-unified-numberformat@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.5.tgz#b150c25eb56c1b09a03bf24fb5d1e394b945a27c"


### PR DESCRIPTION
fixes #1268 