### PR TITLE
fix: Only throw missing Intl.RelativeTimeFormat exception when API is used

### DIFF
--- a/addon/-private/formatters/format-relative.js
+++ b/addon/-private/formatters/format-relative.js
@@ -20,19 +20,21 @@ export default class FormatRelative extends Formatter {
   constructor(config) {
     super(config);
 
-    if (!Intl.RelativeTimeFormat) {
-      config.onError({
-        kind: MISSING_INTL_API,
-        error: new FormatError(
-          `Intl.RelativeTimeFormat is not available in this environment.
-  Try polyfilling it using "@formatjs/intl-relativetimeformat"
-  `,
-          ErrorCode.MISSING_INTL_API
-        ),
-      });
-    }
-
     this.createNativeFormatter = memoize((locales, options) => {
+      if (!Intl || !Intl.RelativeTimeFormat) {
+        config.onError({
+          kind: MISSING_INTL_API,
+          error: new FormatError(
+            `Intl.RelativeTimeFormat is not available in this environment.
+    Try polyfilling it using "@formatjs/intl-relativetimeformat"
+    `,
+            ErrorCode.MISSING_INTL_API
+          ),
+        });
+
+        return;
+      }
+
       return new Intl.RelativeTimeFormat(locales, options);
     });
   }

--- a/tests/unit/formatters/format-relative-test.js
+++ b/tests/unit/formatters/format-relative-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import FormatRelative from 'ember-intl/-private/formatters/format-relative';
+
+module('format-relative', function (hooks) {
+  let IntlRelativeTimeFormat;
+
+  hooks.beforeEach(function () {
+    IntlRelativeTimeFormat = Intl.RelativeTimeFormat;
+  });
+
+  hooks.afterEach(function () {
+    Intl.RelativeTimeFormat = IntlRelativeTimeFormat;
+  });
+
+  test('exists', function (assert) {
+    assert.ok(FormatRelative);
+  });
+
+  test('should instantiate without throwing when Intl.RelativeTimeFormat is missing', function (assert) {
+    Intl.RelativeTimeFormat = undefined;
+
+    assert.ok(
+      new FormatRelative({
+        config: {},
+        readFormatConfig() {
+          return {};
+        },
+      })
+    );
+  });
+
+  test('should throw when formatting when Intl.RelativeTimeFormat is missing', function (assert) {
+    Intl.RelativeTimeFormat = undefined;
+
+    const formatter = new FormatRelative({
+      onError({ error }) {
+        // NOTE: Default implementation in service is to throw.
+        throw error;
+      },
+      readFormatConfig() {
+        return {};
+      },
+    });
+
+    assert.throws(() => {
+      formatter.format(0, 'days');
+    }, /Intl.RelativeTimeFormat is not available in this environment/);
+  });
+});


### PR DESCRIPTION
Right now we throw eaglerly when the `Intl.RelativeTimeFormat` API is missing.  We should only throw if it's used - this will enable apps that do not rely on this API to not polyfill it.