### PR TITLE
fix: Do not report missing ICU arguments for locales that have not implemented translation.

### DIFF
--- a/blueprints/ember-intl/files/__config__/ember-intl.js
+++ b/blueprints/ember-intl/files/__config__/ember-intl.js
@@ -6,7 +6,9 @@ module.exports = function (/* environment */) {
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *
-     * NOTE: a side effect of this option could result in missing translation warnings to be masked.
+     * This will **not** prevent missing translation warnings or errors from occurring.
+     * It's meant as safety net when warning are enabled.
+     * When enabled along with `errorOnMissingTranslations` any fallback attempts will result in an error.
      *
      * @property fallbackLocale
      * @type {String?}
@@ -39,6 +41,15 @@ module.exports = function (/* environment */) {
     publicOnly: false,
 
     /**
+     * Add the subdirectories of the translations as a namespace for all keys.
+     *
+     * @property wrapTranslationsWithNamespace
+     * @type {Boolean}
+     * @default "false"
+     */
+    wrapTranslationsWithNamespace: false,
+
+    /**
      * Cause a build error if ICU argument mismatches are detected.
      *
      * @property errorOnNamedArgumentMismatch
@@ -63,18 +74,9 @@ module.exports = function (/* environment */) {
      *
      * @property stripEmptyTranslations
      * @type {Boolean}
-     * @default false
+     * @default "false"
      */
     stripEmptyTranslations: false,
-
-    /**
-     * Add the subdirectories of the translations as a namespace for all keys.
-     *
-     * @property wrapTranslationsWithNamespace
-     * @type {Boolean}
-     * @default false
-     */
-    wrapTranslationsWithNamespace: false,
 
     /**
      * Filter missing translations to ignore expected missing translations.
@@ -83,7 +85,7 @@ module.exports = function (/* environment */) {
      *
      * @property requiresTranslation
      * @type {Function}
-     * @default "function(key,locale){return true}"
+     * @default "function(key,locale) { return true }"
      */
     requiresTranslation(/* key, locale */) {
       return true;

--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -6,8 +6,6 @@ module.exports = function (/* environment */) {
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *
-     * NOTE: a side effect of this option could result in missing translation warnings to be masked.
-     *
      * @property fallbackLocale
      * @type {String?}
      * @default "null"
@@ -39,6 +37,15 @@ module.exports = function (/* environment */) {
     publicOnly: false,
 
     /**
+     * Removes empty translations from the build output.
+     *
+     * @property stripEmptyTranslations
+     * @type {Boolean}
+     * @default "false"
+     */
+    stripEmptyTranslations: false,
+
+    /**
      * Cause a build error if ICU argument mismatches are detected.
      *
      * @property errorOnNamedArgumentMismatch
@@ -57,15 +64,6 @@ module.exports = function (/* environment */) {
      * @default "false"
      */
     errorOnMissingTranslations: false,
-
-    /**
-     * removes empty translations from the build output.
-     *
-     * @property stripEmptyTranslations
-     * @type {Boolean}
-     * @default false
-     */
-    stripEmptyTranslations: false,
 
     /**
      * Filter missing translations to ignore expected missing translations.

--- a/lib/broccoli/translation-reducer/index.js
+++ b/lib/broccoli/translation-reducer/index.js
@@ -61,12 +61,12 @@ class TranslationReducer extends CachingWriter {
       ...options,
     };
 
+    this.options.fallbackLocale = normalizeLocale(this.options.fallbackLocale);
+
     this.linter = new Linter({
-      fallbackLocale: this.options.fallbackLocale,
       requiresTranslation: this.options.requiresTranslation,
     });
 
-    this.options.fallbackLocale = normalizeLocale(this.options.fallbackLocale);
     this.supportsUnicode = hasUnicode();
   }
 
@@ -113,6 +113,7 @@ class TranslationReducer extends CachingWriter {
 
       let translation = readAsObject(filepath);
 
+      // TODO: make the default in 6.0.0
       if (this.options.stripEmptyTranslations === true) {
         translation = stripNestedNulls(translation);
       }
@@ -159,7 +160,7 @@ class TranslationReducer extends CachingWriter {
           .map(([locale, missingICUArgs]) => `"${locale}": ${missingICUArgs.map((arg) => `"${arg}"`).join(', ')}`)
           .join(', ');
 
-        return `"${key}" ICU argument missing: ${missingString}`;
+        return `"${key}" ICU argument mismatch: ${missingString}`;
       });
 
       if (
@@ -202,11 +203,12 @@ class TranslationReducer extends CachingWriter {
 
   build() {
     const translations = this.mergeTranslations(this.listFiles());
-    const fallbacks = translations[this.options.fallbackLocale];
-    const filepath = path.join(this.outputPath, this.options.outputPath);
     const lintResults = this.linter.lint(translations);
-
     this.handleLintResult(lintResults);
+
+    const filepath = path.join(this.outputPath, this.options.outputPath);
+    const fallbacks = translations[this.options.fallbackLocale];
+
     mkdirp.sync(filepath);
 
     for (const locale in translations) {

--- a/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/find-missing-icu-arguments.js
@@ -1,5 +1,6 @@
 function findMissingIcuArguments(key, allIcuArguments, locales, icuArguments) {
   const keyIcuArguments = Array.from(allIcuArguments[key]);
+
   return locales
     .map((locale) => [
       locale,

--- a/lib/broccoli/translation-reducer/linter/find-missing-translations.js
+++ b/lib/broccoli/translation-reducer/linter/find-missing-translations.js
@@ -1,7 +1,11 @@
-function findMissingTranslations(key, localeKeys, requiresTranslation) {
+function findLocalesMissingTranslation(key, localeKeys) {
   return localeKeys
-    .filter(([locale, translationKeys]) => !translationKeys.includes(key) && requiresTranslation(key, locale))
-    .map(([locale]) => locale);
+    .filter(([, translationKeys]) => {
+      return !translationKeys.includes(key);
+    })
+    .map(([locale]) => {
+      return locale;
+    });
 }
 
-module.exports = findMissingTranslations;
+module.exports = findLocalesMissingTranslation;

--- a/lib/broccoli/translation-reducer/linter/index.js
+++ b/lib/broccoli/translation-reducer/linter/index.js
@@ -1,5 +1,5 @@
 const extractICUArguments = require('./extract-icu-arguments');
-const findMissingTranslations = require('./find-missing-translations');
+const findLocalesMissingTranslation = require('./find-missing-translations');
 const findMissingICUArguments = require('./find-missing-icu-arguments');
 const forEachMessage = require('../utils/for-each-message');
 
@@ -44,25 +44,31 @@ module.exports = class Linter {
 
     // create flattened list of all unique translation keys
     const allTranslationKeys = new Set(Array.prototype.concat(...localeKeys.map(([, keys]) => keys)));
-    const { requiresTranslation, fallbackLocale } = this.options;
+    const { requiresTranslation } = this.options;
 
     allTranslationKeys.forEach((key) => {
-      const notInLocales = findMissingTranslations(key, localeKeys, requiresTranslation);
+      const translationMissingFromLocales = findLocalesMissingTranslation(key, localeKeys);
 
-      if (notInLocales.length) {
-        result.missingTranslations.push([key, notInLocales]);
+      if (translationMissingFromLocales.length) {
+        const alertableMissingTranslations = translationMissingFromLocales.filter((locale) =>
+          requiresTranslation(key, locale)
+        );
+
+        if (alertableMissingTranslations.length) {
+          result.missingTranslations.push([key, alertableMissingTranslations]);
+        }
       }
 
-      let missingICUArgs = findMissingICUArguments(key, allIcuArguments, locales, icuArguments);
+      const localesToScanMissingICUArguments = locales.filter((locale) => {
+        return !translationMissingFromLocales.includes(locale);
+      });
 
-      if (fallbackLocale) {
-        missingICUArgs = missingICUArgs.filter(([locale]) => fallbackLocale === locale);
-      }
-
-      if (notInLocales.length) {
-        // keep only the ICU mismatches where the key isn't missing (key itself will still be reported as missing)
-        missingICUArgs = missingICUArgs.filter(([locale]) => !notInLocales.includes(locale));
-      }
+      let missingICUArgs = findMissingICUArguments(
+        key,
+        allIcuArguments,
+        localesToScanMissingICUArguments,
+        icuArguments
+      );
 
       if (missingICUArgs.length) {
         result.icuMismatch.push([key, missingICUArgs]);

--- a/tests-node/unit/broccoli/translation-reducer/find-missing-translations-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/find-missing-translations-test.js
@@ -1,10 +1,8 @@
 const expect = require('chai').expect;
 
-const findMissingTranslations = require('../../../../lib/broccoli/translation-reducer/linter/find-missing-translations');
+const findLocalesMissingTranslation = require('../../../../lib/broccoli/translation-reducer/linter/find-missing-translations');
 
-const isTrue = () => true;
-
-describe('findMissingTranslations', function () {
+describe('findLocalesMissingTranslation', function () {
   it('finds nothing if nothing is missing', function () {
     const key = 'foo';
     const localeKeys = [
@@ -12,7 +10,7 @@ describe('findMissingTranslations', function () {
       ['en', ['foo']],
     ];
 
-    expect(findMissingTranslations(key, localeKeys, isTrue)).to.deep.equal([]);
+    expect(findLocalesMissingTranslation(key, localeKeys)).to.deep.equal([]);
   });
 
   it('finds missing translations', function () {
@@ -22,17 +20,6 @@ describe('findMissingTranslations', function () {
       ['en', ['bar']],
     ];
 
-    expect(findMissingTranslations(key, localeKeys, isTrue)).to.deep.equal(['en']);
-  });
-
-  it('ignores missing translations if not required', function () {
-    const key = 'foo';
-    const localeKeys = [
-      ['de', ['foo']],
-      ['en', ['bar']],
-    ];
-    const isAllowed = (key, locale) => locale !== 'en';
-
-    expect(findMissingTranslations(key, localeKeys, isAllowed)).to.deep.equal([]);
+    expect(findLocalesMissingTranslation(key, localeKeys)).to.deep.equal(['en']);
   });
 });

--- a/tests-node/unit/broccoli/translation-reducer/index-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/index-test.js
@@ -73,7 +73,11 @@ describe('translation-reducer', function () {
         'en-us.json': `{ "greet": "hello" }`,
       });
 
-      return expect(build(createBuilder(subject))).to.eventually.rejectedWith(/"greet" was not found in "de-de"/);
+      return expect(
+        build(createBuilder(subject), () => {
+          throw new Error('Should have have been reached.');
+        })
+      ).to.eventually.rejectedWith(/"greet" was not found in "de-de"/);
     });
 
     it('should not not overwrite translations', function () {
@@ -230,9 +234,9 @@ describe('translation-reducer', function () {
       subject._log = (msg) => logs.push(msg);
 
       expect(() => subject.handleLintResult(subject.linter.lint(this.icuFixture))).throws(`ICU arguments mismatch:
-- "foo" ICU argument missing: "de": "whos", "en": "who"
-- "missingArg" ICU argument missing: "en": "numPhotos"
-- "deep.nested.ok" ICU argument missing: "de": "code"`);
+- "foo" ICU argument mismatch: "de": "whos", "en": "who"
+- "missingArg" ICU argument mismatch: "en": "numPhotos"
+- "deep.nested.ok" ICU argument mismatch: "de": "code"`);
     });
 
     describe('mergeTranslations', function () {

--- a/tests-node/unit/broccoli/translation-reducer/lint-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/lint-test.js
@@ -130,21 +130,22 @@ describe('linting', function () {
     );
   });
 
-  it('returns list of icu argument mismatch without those that are required', function () {
-    this.linter = new Linter({
-      fallbackLocale: 'en',
-      requiresTranslation() {
+  it('ignores icu mismatch reporting for translations that do not exist', function () {
+    const linter = new Linter({
+      requiresTranslation(/* key, locale */) {
         return true;
       },
     });
 
-    delete this.icuFixture['de'].greeting;
+    const results = linter.lint({
+      en: { one: '{one}' }, // not reported, no match
+      es: { missing: '{foo}' }, // not reported, no match
+    });
 
-    const { icuMismatch } = this.linter.lint(this.icuFixture);
-
-    expect(icuMismatch).to.deep.equal([
-      ['missingArg', [['en', ['numPhotos']]]],
-      ['deep.nested.missing', [['en', ['code']]]],
+    expect(results.icuMismatch).to.deep.equal([]);
+    expect(results.missingTranslations).to.deep.equal([
+      ['one', ['es']],
+      ['missing', ['en']],
     ]);
   });
 });

--- a/tests/dummy/config/ember-intl.js
+++ b/tests/dummy/config/ember-intl.js
@@ -6,13 +6,11 @@ module.exports = function (/* environment */) {
      * Merges the fallback locale's translations into all other locales as a
      * build-time fallback strategy.
      *
-     * NOTE: a side effect of this option could result in missing translation warnings to be masked.
-     *
      * @property fallbackLocale
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: 'en-us',
+    fallbackLocale: null,
 
     /**
      * Path where translations are kept.  This is relative to the project root.
@@ -24,6 +22,24 @@ module.exports = function (/* environment */) {
      * @default "'translations'"
      */
     inputPath: './tests/dummy/translations',
+
+    /**
+     * Removes empty translations from the build output.
+     *
+     * @property stripEmptyTranslations
+     * @type {Boolean}
+     * @default false
+     */
+    stripEmptyTranslations: false,
+
+    /**
+     * Add the subdirectories of the translations as a namespace for all keys.
+     *
+     * @property wrapTranslationsWithNamespace
+     * @type {Boolean}
+     * @default false
+     */
+    wrapTranslationsWithNamespace: true,
 
     /**
      * Prevents the translations from being bundled with the application code.
@@ -57,24 +73,6 @@ module.exports = function (/* environment */) {
      * @default "false"
      */
     errorOnMissingTranslations: false,
-
-    /**
-     * removes empty translations from the build output.
-     *
-     * @property stripEmptyTranslations
-     * @type {Boolean}
-     * @default false
-     */
-    stripEmptyTranslations: false,
-
-    /**
-     * Add the subdirectories of the translations as a namespace for all keys.
-     *
-     * @property wrapTranslationsWithNamespace
-     * @type {Boolean}
-     * @default false
-     */
-    wrapTranslationsWithNamespace: true,
 
     /**
      * Filter missing translations to ignore expected missing translations.


### PR DESCRIPTION
fixes #1218, #1283

Also reverts a behavior that shouldn't have been added where if you used `fallbackLocale` it opted you out of ICU argument mismatch checking.