### PR TITLE
Fix "occurred" typo in error message

### DIFF
--- a/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
@@ -16,7 +16,7 @@ function extractICUArguments(string) {
       )
       .map((argumentElement) => argumentElement.value);
   } catch (err) {
-    throw new Error(`An error occured (${err.message}) when extracting ICU arguments for '${string}'`);
+    throw new Error(`An error occurred (${err.message}) when extracting ICU arguments for '${string}'`);
   }
 }
 

--- a/tests-node/unit/broccoli/translation-reducer/lint-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/lint-test.js
@@ -126,7 +126,7 @@ describe('linting', function () {
     const brokenString = this.brokenIcuFixture.en.brokenSyntax;
 
     expect(() => this.linter.lint(this.brokenIcuFixture)).throws(
-      `An error occured (${expectedParserError}) when extracting ICU arguments for '${brokenString}'`
+      `An error occurred (${expectedParserError}) when extracting ICU arguments for '${brokenString}'`
     );
   });
 


### PR DESCRIPTION
`occured` -> `occurred`