### PR TITLE
Safe string support

### DIFF
--- a/addon/-private/formatters/format-message.js
+++ b/addon/-private/formatters/format-message.js
@@ -10,36 +10,37 @@ import IntlMessageFormat from 'intl-messageformat';
 import parse from '../utils/parse';
 import Formatter from './-base';
 
-const { keys } = Object;
-
 const {
   Handlebars: {
     Utils: { escapeExpression },
   },
 } = Ember;
 
-function escape(object) {
+function escapeOptions(object) {
   if (typeof object !== 'object') {
     return;
   }
 
-  return keys(object).reduce(
-    (accum, key) => {
-      if (isHTMLSafe(object[key])) {
-        // If the option is an instance of Ember SafeString,
-        // we don't want to pass it into the formatter, since the
-        // formatter won't know what to do with it. Instead, we cast
-        // the SafeString to a regular string using `toHTML`.
-        // Since it was already marked as safe we should *not* escape it.
-        accum[key] = object[key].toHTML();
-      } else if (typeof object[key] === 'string') {
-        accum[key] = escapeExpression(object[key]);
-      }
+  let escapedOpts = {};
 
-      return accum;
-    },
-    { ...object }
-  );
+  Object.keys(object).forEach((key) => {
+    let val = object[key];
+
+    if (isHTMLSafe(val)) {
+      // If the option is an instance of Ember SafeString,
+      // we don't want to pass it into the formatter, since the
+      // formatter won't know what to do with it. Instead, we cast
+      // the SafeString to a regular string using `toHTML`.
+      // Since it was already marked as safe we should *not* escape it.
+      escapedOpts[key] = val.toHTML();
+    } else if (typeof val === 'string') {
+      escapedOpts[key] = escapeExpression(val);
+    } else {
+      escapedOpts[key] = val; // copy as-is
+    }
+  });
+
+  return escapedOpts;
 }
 
 /**
@@ -68,7 +69,7 @@ export default class FormatMessage extends Formatter {
 
     const isHTMLSafe = options && options.htmlSafe;
     const formatterInstance = this.createNativeFormatter(ast, locale, this.readFormatConfig());
-    const escapedOptions = isHTMLSafe ? escape(options) : options;
+    const escapedOptions = isHTMLSafe ? escapeOptions(options) : options;
     const result = formatterInstance.format(escapedOptions);
 
     return isHTMLSafe ? htmlSafe(result) : result;

--- a/addon/-private/formatters/format-message.js
+++ b/addon/-private/formatters/format-message.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import memoize from 'fast-memoize';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe, isHTMLSafe } from '@ember/string';
 import IntlMessageFormat from 'intl-messageformat';
 import parse from '../utils/parse';
 import Formatter from './-base';
@@ -25,9 +25,14 @@ function escape(object) {
 
   return keys(object).reduce(
     (accum, key) => {
-      // NOTE due to the typeof check this won't escape if
-      // the value is an Ember `SafeString`
-      if (typeof object[key] === 'string') {
+      if (isHTMLSafe(object[key])) {
+        // If the option is an instance of Ember SafeString,
+        // we don't want to pass it into the formatter, since the
+        // formatter won't know what to do with it. Instead, we cast
+        // the SafeString to a regular string using `toHTML`.
+        // Since it was already marked as safe we should *not* escape it.
+        accum[key] = object[key].toHTML();
+      } else if (typeof object[key] === 'string') {
         accum[key] = escapeExpression(object[key]);
       }
 

--- a/tests/unit/helpers/format-message-(html)-test.js
+++ b/tests/unit/helpers/format-message-(html)-test.js
@@ -1,4 +1,5 @@
 import { render } from '@ember/test-helpers';
+import { htmlSafe } from '@ember/string';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -20,6 +21,17 @@ module('format-message (html)', function (hooks) {
         count: 42000,
       }).string,
       '<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>'
+    );
+  });
+
+  test('arguments marked as safe-string is not escaped', function (assert) {
+    assert.expect(1);
+    assert.equal(
+      this.intl.formatMessage(`'<strong>'Welcome {name}!'</strong>'`, {
+        htmlSafe: true,
+        name: htmlSafe('<em>Alexander</em>'),
+      }).string,
+      '<strong>Welcome <em>Alexander</em>!</strong>'
     );
   });
 


### PR DESCRIPTION
This patch adds support for safe strings as arguments.

```js
import { htmlSafe } from '@ember/string';

this.intl.formatMessage(`'<strong>'Welcome {name}!'</strong>'`, {
  htmlSafe: true,
  name: htmlSafe('<em>Alexander</em>'),
});

// before patch output is (extra comma)
'<strong>Welcome ,<em>Alexander</em>,!</strong>'

// after patch output is
'<strong>Welcome <em>Alexander</em>!</strong>'
```

More details in commit messages and inline.

cc @jasonmit let me know what you think!