### PR TITLE
feat: filters invalid key types, throws when encountering one.

### DIFF
--- a/addon/helpers/t.js
+++ b/addon/helpers/t.js
@@ -3,13 +3,10 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { assert } from '@ember/debug';
 import BaseHelper from '../-private/helpers/-format-base';
 
 export default BaseHelper.extend({
   format(key, options) {
-    assert('[ember-intl] translation lookup attempted but no translation key was provided.', key);
-
     return this.intl.t(key, options);
   },
 });

--- a/tests/unit/helpers/t-test.js
+++ b/tests/unit/helpers/t-test.js
@@ -116,4 +116,26 @@ module('t', function (hooks) {
     await render(hbs`{{t 'does.not.exist' default='happy_birthday' age=10}}`);
     assert.equal(this.element.textContent, 'You are 10 years old!');
   });
+
+  test('should throw when unknown key type is provided', async function (assert) {
+    const assertInvalidTranslationKey = (input) => {
+      let error;
+
+      try {
+        this.intl.t(input);
+      } catch (e) {
+        error = e;
+      }
+
+      assert.ok(error);
+      assert.ok(error.message.includes('expected translation key'));
+    };
+
+    assertInvalidTranslationKey(null);
+    assertInvalidTranslationKey(undefined);
+    assertInvalidTranslationKey(false);
+    assertInvalidTranslationKey([]);
+    assertInvalidTranslationKey({});
+    assertInvalidTranslationKey(1);
+  });
 });

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -29,11 +29,6 @@ module('service:intl', function (hooks) {
     this.intl.setLocale([LOCALE]);
   });
 
-  test('can access formatMessage without a locale set', function (assert) {
-    this.intl.t('does.not.exist');
-    assert.ok(true, 'Exception was not raised');
-  });
-
   test('should return a number if the translation is a number', function (assert) {
     this.intl.addTranslations(LOCALE, {
       a_number: 2,
@@ -44,15 +39,15 @@ module('service:intl', function (hooks) {
 
   test('`t` should cascade translation lookup', function (assert) {
     this.intl.addTranslations(LOCALE, {
-      should_exist: 'I do exist!',
-      should_also_exist: 'I do also exist!',
+      first: 'first translation should win',
+      second: 'second translation (error if used)',
     });
 
     assert.equal(
-      this.intl.t('does.not.exist', {
-        default: ['also.does.not.exist', 'should_exist', 'should_also_exist'],
+      this.intl.t('invalid', {
+        default: ['also_invalid', 'first', 'second'],
       }),
-      'I do exist!'
+      'first translation should win'
     );
   });
 
@@ -160,6 +155,7 @@ module('service:intl', function (hooks) {
 
   test('it does not mutate t options hash', function (assert) {
     this.intl.setLocale(LOCALE);
+    this.intl.addTranslations(LOCALE, { foo: '' });
     const obj = { bar: 'bar' };
     this.intl.t('foo', obj);
     assert.ok(typeof obj.locale === 'undefined');
@@ -167,6 +163,7 @@ module('service:intl', function (hooks) {
 
   test('`t` can be passed a null options hash', function (assert) {
     this.intl.setLocale(LOCALE);
+    this.intl.addTranslations(LOCALE, { foo: '' });
     this.intl.t('foo', undefined);
     assert.ok(true, 'Exception was not raised');
   });


### PR DESCRIPTION
This is some what related to #1299

Now we're validating the keys passed in and throw a more obvious exception when encountering one.  Prior, you would have seen a compiler error thrown: `"A message must be provided as a String or AST"`

For consistency, the service `intl.t()` API and the `{{t}}` helper now validate through the same path.  That's the only breaking change here and I don't expect many to be impacted by it.