### PR TITLE
Update htmlSafe example to escape em tags

### DIFF
--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -41,7 +41,7 @@ To enable rendering HTML within translations, pass an `htmlSafe` attribute to th
 ```yaml
 # translations/en-en.yml
 a:
-  translations: '<em>Hello</em>'
+  translations: "'<em>'Hello'</em>'"
 ```
 It will escape all hash arguments and returns as an htmlSafe String which renders an ElementNode.  
 


### PR DESCRIPTION
Closes #1315 

I don't think the example in the documentation is true anymore. This PR updates the example.