### PR TITLE
Reduce dependabot noise

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+# Create Pull-Requests for NPM updates automatically
+# https://dependabot.com/docs/config-file/
+
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date:
+  # - security updates will be created immediately
+  # - other updates monthly (to cut down on repo noise)
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"


### PR DESCRIPTION
Running it too often creates noise in the commit log. How about running it less often?

![image](https://user-images.githubusercontent.com/122287/82663902-e0acb680-9c30-11ea-947a-fd5aad581778.png)
