### PR TITLE
upgrade broccoli-funnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "broccoli-caching-writer": "^3.0.3",
-    "broccoli-funnel": "^3.0.2",
+    "broccoli-funnel": "^3.0.3",
     "broccoli-merge-files": "^0.8.0",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-source": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,7 +1126,7 @@
   dependencies:
     "@formatjs/intl-utils" "^3.0.1"
 
-"@formatjs/intl-utils@^3.0.0", "@formatjs/intl-utils@^3.0.1":
+"@formatjs/intl-utils@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-3.0.1.tgz#b9a7f79033b54bff1d03e7f05ba0e0627ba49451"
   integrity sha512-wA9jNZ/6sglIeOznDL19/EgX//xkj/IN0pffuKM2fFFm5F2LB/MItrMlLW0MJwdp/aRVa8UGNbSl1zg5mmYoiA==
@@ -3308,7 +3308,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.0, broccoli-funnel@^3.0.2:
+broccoli-funnel@^3.0.0, broccoli-funnel@^3.0.2, broccoli-funnel@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz#26fd42632471f67a91f4770d1987118087219937"
   integrity sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==


### PR DESCRIPTION
using `wrapTranslationsWithNamespace`,  I have a problem in https://github.com/ember-intl/ember-intl/issues/1061#issuecomment-635263823

after check, i found the reason is the version of broccoli-funnel .
the `relativePath` bug now is published in 3.0.3 fix version ( https://github.com/broccolijs/broccoli-funnel/pull/123 )

so , we can upgrade it now .