### PR TITLE
fix Symbol in ie

### DIFF
--- a/addon/-private/error-types.js
+++ b/addon/-private/error-types.js
@@ -16,4 +16,4 @@ export const MISSING_INTL_API = ErrorCode.MISSING_INTL_API;
  * @private
  * @hide
  */
-export const MISSING_TRANSLATION = Symbol();
+export const MISSING_TRANSLATION = 'MISSING_TRANSLATION';


### PR DESCRIPTION
ie not support native Symbol. and we are sensitive to package size, so can we make this const (`MISSING_TRANSLATION`) to String instead.
