### PR TITLE
Fix link to ICU message syntax docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ If you have any questions or issues, please open in [ember-i18n-to-intl-migrator
 [travis]: https://travis-ci.com/ember-intl/ember-intl
 [travis-badge]: https://travis-ci.com/ember-intl/ember-intl.svg?branch=master
 [ember-version]: https://img.shields.io/badge/Ember-2.12%2B-brightgreen.svg
-[ICU]: https://formatjs.io/guides/message-syntax/
+[ICU]: https://formatjs.io/docs/icu-syntax

--- a/tests/dummy/app/pods/docs/getting-started/index/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/index/template.md
@@ -28,11 +28,9 @@ You have {itemCount, plural,
 ```
 
 * 🌐 Support for 150+ languages.
-* 📜 Built on standards such as the [ICU message syntax](https://formatjs.io/guides/message-syntax/) & [Native Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 📜 Built on standards such as the [ICU message syntax](https://formatjs.io/docs/icu-syntax) & [Native Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 * ⚡ Extensive Ember Service API and template helpers for formatting and translating.
 * 🎉 {{docs-link 'Advanced addon support' 'docs.advanced.addon-support'}} to provide translations to the host app
 
 ## Online Community Chat
 Join the `topic-i18n` channel [here](https://discordapp.com/invite/zT3asNS) to ask questions and chat with community members in real-time.
-
-

--- a/tests/dummy/app/pods/docs/guide/translating-text/template.md
+++ b/tests/dummy/app/pods/docs/guide/translating-text/template.md
@@ -1,7 +1,7 @@
 # Translating Text
 
 ## Translations
-Translations are defined in [ICU message syntax](https://formatjs.io/guides/message-syntax/) and stored in
+Translations are defined in [ICU message syntax](https://formatjs.io/docs/icu-syntax) and stored in
 `<root>/translations` in either JSON and/or YAML format. Nested objects are supported within your translation files.
 
 ### Nested translations

--- a/tests/dummy/app/pods/docs/helpers/format-message/template.md
+++ b/tests/dummy/app/pods/docs/helpers/format-message/template.md
@@ -1,7 +1,7 @@
 {{locale-switcher}}
 # Format Message
 
-Formats [ICU message syntax](https://formatjs.io/guides/message-syntax/) strings with the provided values passed as arguments to the helper/method.
+Formats [ICU message syntax](https://formatjs.io/docs/icu-syntax) strings with the provided values passed as arguments to the helper/method.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='docs-helpers-format-message-01-template.hbs'}}

--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -6,7 +6,7 @@ To provide values to the dynamic segment of the translation, pass an object hash
 
 ## ICU message syntax
 
-Compiles a [ICU message syntax](https://formatjs.io/guides/message-syntax/) strings with its hash values passed.
+Compiles a [ICU message syntax](https://formatjs.io/docs/icu-syntax) strings with its hash values passed.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name='docs-helpers-format-t-01-template.hbs'}}

--- a/tests/dummy/app/pods/index/template.hbs
+++ b/tests/dummy/app/pods/index/template.hbs
@@ -15,7 +15,7 @@
         🌐 Support for 150+ languages.
       </li>
       <li>
-        📜 Built largely on standards. <a href="https://formatjs.io/guides/message-syntax/">ICU message syntax</a> & <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl">Native Intl API</a>.
+        📜 Built largely on standards. <a href="https://formatjs.io/docs/icu-syntax">ICU message syntax</a> & <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl">Native Intl API</a>.
       </li>
       <li>
         ⚡ Extensive Ember Service API and template helpers for formatting and translating.
@@ -32,4 +32,3 @@
     {{/link-to}}
   </div>
 </div>
-


### PR DESCRIPTION
I noticed that the link was broken, this appears to be its new home.