### PR TITLE
fix(formatter): options take precedence over named format

### DIFF
--- a/addon/-private/formatters/-base.js
+++ b/addon/-private/formatters/-base.js
@@ -55,8 +55,8 @@ export default class FormatterBase {
       const namedFormatsOptions = this.getNamedFormat(formatOptions.format);
 
       formatterOptions = {
-        ...formatterOptions,
         ...namedFormatsOptions,
+        ...formatterOptions,
       };
     }
 

--- a/tests/unit/helpers/format-number-test.js
+++ b/tests/unit/helpers/format-number-test.js
@@ -131,6 +131,19 @@ module('format-number', function (hooks) {
     assert.equal(this.element.textContent, '0,000,000,001.00', 'should return a string formatted to a percent');
   });
 
+  // v4 -> v5 regression
+  // https://github.com/ember-intl/ember-intl/pull/1401
+  test('hash options take precedence over named format options', async function (assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      number: { currency: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 } },
+    });
+    await render(
+      hbs`{{format-number 1 format="currency"}} / {{format-number 1 format="currency" minimumFractionDigits=0}}`
+    );
+    assert.equal(this.element.textContent, '$1.000 / $1', '`minimumFractionDigits` overrides named format');
+  });
+
   test('used to format percentages', async function (assert) {
     assert.expect(2);
     await render(hbs`{{format-number 400 style="percent"}}`);


### PR DESCRIPTION
This seems to be a behavioral change between v4 / v5. We noticed because in one place we invoke `formatNumber()` like so and our tests broke:

```ts
this.intl.formatNumber(12345, { format: 'EUR', minimumFractionDigits: 0 }); 
```

```ts
// formats.js
export default {
  // ...
  number: {
    EUR: {
      style: 'currency',
      currency: 'EUR',
      minimumFractionDigits: 2,
      maximumFractionDigits: 2
    },
    // ...
  }
};
```

In v4 this returned `12345 €`. In v5 it returns `12345,00 €`.

This is because the `namedFormatsOptions` take precedence over the explicitly specified `formatterOptions`. I would assume this change was accidental, as I would expect explicitly specified options to always override named format options.