### PR TITLE
chore: migrate translation model to plain class

### DIFF
--- a/addon/-private/store/container.js
+++ b/addon/-private/store/container.js
@@ -6,28 +6,26 @@ import Translation from './translation';
  * @hide
  */
 export default EmberObject.extend({
-  locales: computed('_translations', function () {
-    return Array.from(this._translations.keys());
+  locales: computed('_translationModels', function () {
+    return Array.from(this._translationModels.keys());
   }).readOnly(),
 
   init() {
     this._super();
-    this._translations = new Map();
+    this._translationModels = new Map();
   },
 
   createTranslationModel(localeName) {
-    const translationModel = Translation.create({
-      localeName: localeName,
-    });
+    const translationModel = new Translation(localeName);
 
-    this._translations.set(localeName, translationModel);
+    this._translationModels.set(localeName, translationModel);
     this.notifyPropertyChange('locales');
 
     return translationModel;
   },
 
   findTranslationModel(localeName) {
-    return this._translations.get(localeName);
+    return this._translationModels.get(localeName);
   },
 
   push(localeName, payload) {

--- a/addon/-private/store/translation.js
+++ b/addon/-private/store/translation.js
@@ -3,29 +3,21 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import EmberObject from '@ember/object';
-import EmptyObject from 'ember-intl/-private/utils/empty-object';
 import flatten from 'ember-intl/-private/utils/flatten';
 import parse from 'ember-intl/-private/utils/parse';
 
-/**
- * @private
- * @hide
- */
-const TranslationModel = EmberObject.extend({
-  localeName: null,
+class Translation {
+  translations = new Map();
+  asts = new Map();
+  _localeName;
 
-  init() {
-    this._super();
+  get localeName() {
+    return this._localeName;
+  }
 
-    if (!this.translations) {
-      this.translations = new EmptyObject();
-    }
-
-    if (!this.asts) {
-      this.asts = new EmptyObject();
-    }
-  },
+  constructor(localeName) {
+    this._localeName = localeName;
+  }
 
   addTranslations(translations) {
     const flatTranslations = flatten(translations);
@@ -38,23 +30,23 @@ const TranslationModel = EmberObject.extend({
         translation = `${translation}`;
       }
 
-      this.translations[key] = translation;
-      this.asts[key] = parse(translation);
+      this.translations.set(key, translation);
+      this.asts.set(key, parse(translation));
     }
-  },
+  }
 
   find(key) {
     if (this.has(key)) {
       return {
-        ast: this.asts[key],
-        original: this.translations[key],
+        ast: this.asts.get(key),
+        original: this.translations.get(key),
       };
     }
-  },
+  }
 
   has(key) {
-    return hasOwnProperty.call(this.translations, key);
-  },
-});
+    return this.translations.has(key);
+  }
+}
 
-export default TranslationModel;
+export default Translation;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,14 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   let project = defaults.project;
-  let options = { vendorFiles: { 'app-shims.js': null } };
+  let options = {
+    'ember-fetch': {
+      preferNative: true,
+    },
+    vendorFiles: {
+      'app-shims.js': null,
+    },
+  };
 
   if (project.findAddonByName('ember-native-dom-event-dispatcher')) {
     options.vendorFiles['jquery.js'] = null;

--- a/tests/unit/models/translation-test.js
+++ b/tests/unit/models/translation-test.js
@@ -6,7 +6,7 @@ module('Unit | Model | translation', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.translationObject = Translation.create();
+    this.translationObject = new Translation('en-us');
   });
 
   test('can handle deeply nested object passed into addTranslations', function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,9 +1956,9 @@ abbrev@1:
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
 abortcontroller-polyfill@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz#0d5eb58e522a461774af8086414f68e1dda7a6c4"
-  integrity sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz#2c562f530869abbcf88d949a2b60d1d402e87a7c"
+  integrity sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==
 
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
@@ -14088,9 +14088,9 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
     iconv-lite "0.4.24"
 
 whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
+  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Internal API, good candidate to start migrating off EmberObjects where possible.