### PR TITLE
feat: Avoids complex escaping of HTML tags/attributes in translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,11 @@
 
 * Improved the internals for loading translations on boot
 * Polyfills have been remove and no longer bundle pluralization rules as they're available natively via the `Intl.PluralRules` API
-* `Intl.MessageFormat` [parser](https://formatjs.io/docs/intl-messageformat-parser) and [compiler](https://formatjs.io/docs/intl-messageformat) updated which changes how text and tags are escaped
 
 ### Breaking Changes
 
 * Node 8 support dropped
 * `Intl.RelativeTime` polyfill has been replaced with the native API which behaves entirely different than the previous older spec implementation (read about in the [Migration Document](https://ember-intl.github.io/ember-intl/docs/guide/migration-4-0-to-5-0))
-* Translations are now escaped differently (read about in the [Migration Document](https://ember-intl.github.io/ember-intl/docs/guide/migration-4-0-to-5-0))
 * `intl.lookup()` API will no longer return missing translation warnings
 * Removes `shortNumber` formatting in favor of now supported native implementation using the `"notation"` property i.e.,
 ```js

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 ### Breaking Changes
 
 * Node 8 support dropped
+* Improved ICU-spec compliance, special characters are now escaped via a single quote `'` instead of a slash `\`
 * `Intl.RelativeTime` polyfill has been replaced with the native API which behaves entirely different than the previous older spec implementation (read about in the [Migration Document](https://ember-intl.github.io/ember-intl/docs/guide/migration-4-0-to-5-0))
 * `intl.lookup()` API will no longer return missing translation warnings
 * Removes `shortNumber` formatting in favor of now supported native implementation using the `"notation"` property i.e.,

--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -58,7 +58,9 @@ export default class FormatMessage extends Formatter<Options> {
   // @ts-ignore This class does not match the abstract base class.
   createNativeFormatter = memoize(
     (ast: TranslationAST, locales: string | string[], formatConfig?: Partial<Formats>) => {
-      return new IntlMessageFormat(ast as any, locales, formatConfig);
+      return new IntlMessageFormat(ast as any, locales, formatConfig, {
+        ignoreTag: true,
+      });
     }
   );
 

--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -7,5 +7,6 @@ import { parse } from 'intl-messageformat-parser';
 export default function parseString(string: string) {
   return parse(string, {
     normalizeHashtagInPlural: false,
+    ignoreTag: true,
   });
 }

--- a/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
+++ b/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
@@ -6,6 +6,10 @@ The `locales`, `disablePolyfill`, and `autoPolyfill` configuration options in `c
 
 ## **Breaking Changes**
 
+### **Translations**	
+
+* Improved ICU-spec compliance, special characters are now escaped via a single quote `'` instead of a slash `\`
+
 ### **Node runtime**
 
 We now support down to Node 10, dropping support for Node 8.

--- a/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
+++ b/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
@@ -8,7 +8,7 @@ The `locales`, `disablePolyfill`, and `autoPolyfill` configuration options in `c
 
 ### **Translations**	
 
-* Improved ICU-spec compliance, special characters are now escaped via a single quote `'` instead of a slash `\`
+Improved ICU-spec compliance, special characters are now escaped via a single quote `'` instead of a slash `\`
 
 ### **Node runtime**
 

--- a/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
+++ b/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
@@ -34,24 +34,6 @@ Changes:
 * `interval` was removed from the format-relative helper
 * `now` was removed from the format-relative helper
 
-### **Translations**
-
-* Special character escaping in translations is now done via a single quote, `'` instead of the previous slash `\`.
-
-_This is not to be confused with string escaping in YAML or JSON where you'll need to use `\` to escape quotes to keep a string together.  This change is specifically about escaping special characters and HTML tags within your ICU message._
-* Additionally, all HTML tags now need to be escaped.
-
-`<strong>{name}</strong>`
-
-becomes
-
-`'<strong>'{name}'</strong>'`
-
-If you use placeholders _inside_ of an HTML tag for attributes, escape only the
-angle brackets, like so:
-
-`Please accept our '<'a href="{url}"'>'terms & conditions'</a>'.`
-
 ### **Compact Number Formatter**
 
 In 4.x, we introduced a shortNumber formatter.  This is no longer necessary as we can rely on the native Intl.NumberFormat to compact numbers into their abbreviated form.

--- a/tests/unit/helpers/format-message-(html)-test.js
+++ b/tests/unit/helpers/format-message-(html)-test.js
@@ -25,9 +25,18 @@ module('format-message (html)', function (hooks) {
   });
 
   test('arguments marked as safe-string is not escaped', function (assert) {
-    assert.expect(1);
+    assert.expect(2);
+
     assert.equal(
       this.intl.formatMessage(`'<strong>'Welcome {name}!'</strong>'`, {
+        htmlSafe: true,
+        name: htmlSafe('<em>Alexander</em>'),
+      }).string,
+      '<strong>Welcome <em>Alexander</em>!</strong>'
+    );
+
+    assert.equal(
+      this.intl.formatMessage(`<strong>Welcome {name}!</strong>`, {
         htmlSafe: true,
         name: htmlSafe('<em>Alexander</em>'),
       }).string,
@@ -52,24 +61,41 @@ module('format-message (html)', function (hooks) {
   });
 
   test('should handle dynamic attributes', function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
-    let output = this.intl.formatMessage(`'<'a href="{link}"'>'text'</a>'`, {
-      htmlSafe: true,
-      link: 'http://formatjs.io',
-    }).string;
+    assert.equal(
+      this.intl.formatMessage(`'<'a href="{link}"'>'text'</a>'`, {
+        htmlSafe: true,
+        link: 'http://formatjs.io',
+      }).string,
+      '<a href="http://formatjs.io">text</a>'
+    );
 
-    assert.equal(output, '<a href="http://formatjs.io">text</a>');
+    assert.equal(
+      this.intl.formatMessage(`<a href="{link}"'>text</a>`, {
+        htmlSafe: true,
+        link: 'http://formatjs.io',
+      }).string,
+      '<a href="http://formatjs.io">text</a>'
+    );
   });
 
   test('should handle static attributes', function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
-    let output = this.intl.formatMessage(`Fields marked '<'strong class="primary"'>'*'</strong>' are required`, {
-      htmlSafe: true,
-    }).string;
+    assert.equal(
+      this.intl.formatMessage(`Fields marked '<'strong class="primary"'>'*'</strong>' are required`, {
+        htmlSafe: true,
+      }).string,
+      'Fields marked <strong class="primary">*</strong> are required'
+    );
 
-    assert.equal(output, 'Fields marked <strong class="primary">*</strong> are required');
+    assert.equal(
+      this.intl.formatMessage(`Fields marked <strong class="primary">*</strong> are required`, {
+        htmlSafe: true,
+      }).string,
+      'Fields marked <strong class="primary">*</strong> are required'
+    );
   });
 
   test('should handle static attributes, approach #2', function (assert) {
@@ -101,8 +127,10 @@ module('format-message (html)', function (hooks) {
   });
 
   test('should allow for inlined html in the value but escape arguments', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
     await render(hbs`{{format-message "'<strong>'Hello {name}'</strong>'" name="<em>Jason</em>" htmlSafe=true}}`);
+    assert.equal(this.element.innerHTML, '<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>');
+    await render(hbs`{{format-message "<strong>Hello {name}</strong>" name="<em>Jason</em>" htmlSafe=true}}`);
     assert.equal(this.element.innerHTML, '<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>');
   });
 });

--- a/tests/unit/services/intl-test.js
+++ b/tests/unit/services/intl-test.js
@@ -109,6 +109,22 @@ module('service:intl', function (hooks) {
     assert.equal(this.intl.lookup('foo'), 'hello world');
   });
 
+  test('should escape attributes but render translation as HTML', async function (assert) {
+    this.intl.addTranslations(LOCALE, {
+      legacyStyle: `'<strong class="example">'Hello {name}'</strong>'`,
+      modernStyle: `<strong class="example">Hello {name}</strong>`,
+    });
+
+    assert.equal(
+      this.intl.t('modernStyle', { htmlSafe: true, name: '<em>Tom</em>' }).string,
+      '<strong class="example">Hello &lt;em&gt;Tom&lt;/em&gt;</strong>'
+    );
+    assert.equal(
+      this.intl.t('legacyStyle', { htmlSafe: true, name: '<em>Tom</em>' }).string,
+      '<strong class="example">Hello &lt;em&gt;Tom&lt;/em&gt;</strong>'
+    );
+  });
+
   test('lookup() should return undefined for missing translations ', function (assert) {
     assert.equal(this.intl.lookup('missing'), undefined);
   });


### PR DESCRIPTION
Migrating to v5 was painful for some because the translation syntax changed a bit around escaping tags in translations.  The compiler and parser have since been updated to support the translation syntax that we've been used to in every version up to 5.0.0.

This is backwards compatible, so anyone who put in the effort to migrate their translations to the new syntax does not need to migrate back.  Both styles will now be supported.

Resolves #1419

Related to #1350, #1396, #1336, #1321, #1289