### PR TITLE
Mark `htmlSafe` param as optional

### DIFF
--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -78,7 +78,7 @@ export default class FormatMessage {
   format(
     locale: string | string[],
     maybeAst: string | TranslationAST,
-    options?: Partial<Record<string, unknown>> & { htmlSafe: boolean }
+    options?: Partial<Record<string, unknown>> & { htmlSafe?: boolean }
   ) {
     let ast = maybeAst as TranslationAST;
 


### PR DESCRIPTION
I ran into a couple of issues when calling `formatMessage` and not passing `htmlSafe` as part of the `data` object.

 1. The typings expect `htmlSafe` to be part of the `options` (which is also where you pass the data you are interpolating into the string)
 2. The return type is `SafeString | string` which requires casting to `string` in my case (where I don't pass `htmlSafe: true`)

This PR marks `htmlSafe` as optional and so fixes 1. I started playing around with function overloads to try and get the correct return type depending on the passed value of `htmlSafe` but didn't get that working yet.

Let me know your thoughts on the above and if you're interested I can try to look into a solution for 2.