### PR TITLE
fix(types): only return `SafeString`, if `{ htmlSafe: true }`

### DIFF
--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -78,8 +78,18 @@ export default class FormatMessage {
   format(
     locale: string | string[],
     maybeAst: string | TranslationAST,
+    options?: Partial<Record<string, unknown>> & { htmlSafe?: false }
+  ): string;
+  format(
+    locale: string | string[],
+    maybeAst: string | TranslationAST,
+    options?: Partial<Record<string, unknown>> & { htmlSafe: true }
+  ): SafeString;
+  format(
+    locale: string | string[],
+    maybeAst: string | TranslationAST,
     options?: Partial<Record<string, unknown>> & { htmlSafe?: boolean }
-  ) {
+  ): string | SafeString {
     let ast = maybeAst as TranslationAST;
 
     if (typeof maybeAst === 'string') {

--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -83,7 +83,7 @@ export default class FormatMessage {
   format(
     locale: string | string[],
     maybeAst: string | TranslationAST,
-    options?: Partial<Record<string, unknown>> & { htmlSafe: true }
+    options: Partial<Record<string, unknown>> & { htmlSafe: true }
   ): SafeString;
   format(
     locale: string | string[],

--- a/addon/-private/formatters/format-relative.ts
+++ b/addon/-private/formatters/format-relative.ts
@@ -105,7 +105,7 @@ export default class FormatRelative extends Formatter<RelativeTimeFormatOptions>
     locale: string | string[],
     value: ConstructorParameters<typeof Date>[0],
     formatOptions: RelativeTimeFormatOptions & BaseOptions
-  ) {
+  ): string {
     const formatterOptions = this.readOptions(formatOptions);
 
     this.validateFormatterOptions(locale, formatterOptions);

--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -81,7 +81,7 @@ export default class IntlService extends Service.extend(Evented) {
   private validateKeys(keys: unknown[]): void | never;
 
   t(key: string, options?: TOptions & { htmlSafe?: false }): string | MissingMessage;
-  t(key: string, options?: TOptions & { htmlSafe: true }): SafeString | MissingMessage;
+  t(key: string, options: TOptions & { htmlSafe: true }): SafeString | MissingMessage;
   t(key: string, options?: TOptions): string | SafeString | MissingMessage;
 
   exists(key: string, localeName?: string | string[]): boolean;

--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -1,6 +1,7 @@
 import Evented from '@ember/object/evented';
 import Service from '@ember/service';
 import { EmberRunTimer } from '@ember/runloop/types';
+import type { SafeString } from '@ember/template/-private/handlebars';
 
 import { FormatDate, FormatMessage, FormatNumber, FormatRelative, FormatTime } from '../-private/formatters';
 import TranslationContainer from '../-private/store/container';
@@ -10,6 +11,7 @@ import { MessageFormatElement } from 'intl-messageformat-parser';
 export interface TOptions {
   default?: string | string[];
   locale?: string | string[];
+  htmlSafe?: boolean;
   [option: string]: unknown;
 }
 
@@ -78,7 +80,9 @@ export default class IntlService extends Service.extend(Evented) {
   private validateKeys(keys: string[]): void;
   private validateKeys(keys: unknown[]): void | never;
 
-  t(key: string, options?: TOptions): string | MissingMessage;
+  t(key: string, options?: TOptions & { htmlSafe?: false }): string | MissingMessage;
+  t(key: string, options?: TOptions & { htmlSafe: true }): SafeString | MissingMessage;
+  t(key: string, options?: TOptions): string | SafeString | MissingMessage;
 
   exists(key: string, localeName?: string | string[]): boolean;
 


### PR DESCRIPTION
Fixes the types of:

- `format-message`
- `IntlService#t()`
- `t()` test helper

... so that they only return `SafeString`, if `{ htmlSafe: true }` is provided.