### PR TITLE
fix(translations-reducer): support legacy HTML escape format

### DIFF
--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -5,6 +5,7 @@ import { parse } from 'intl-messageformat-parser';
  * @hide
  */
 export default function parseString(string: string) {
+  // ! Sync with `lib/message-validator/validate-message.js`
   return parse(string, {
     normalizeHashtagInPlural: false,
     ignoreTag: true,

--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -5,7 +5,7 @@ import { parse } from 'intl-messageformat-parser';
  * @hide
  */
 export default function parseString(string: string) {
-  // ! Sync with `lib/message-validator/validate-message.js`
+  // ! Sync with `lib/parse-options.js`
   return parse(string, {
     normalizeHashtagInPlural: false,
     ignoreTag: true,

--- a/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
@@ -1,5 +1,6 @@
 const parser = require('intl-messageformat-parser');
 const traverse = require('../../../message-validator/ast-traverse');
+const parseOptions = require('../../../parse-options');
 
 function extractICUArguments(string) {
   try {
@@ -8,7 +9,7 @@ function extractICUArguments(string) {
 
     // Errors thrown by the parser won't include any details about the string. By rethrowing the
     // error with the string quoted it's much easier to identify which ICU argument was invalid.
-    traverse(parser.parse(string), {
+    traverse(parser.parse(string, parseOptions), {
       [parser.TYPE.time]: recordVisitedNodeValue,
       [parser.TYPE.date]: recordVisitedNodeValue,
       [parser.TYPE.plural]: recordVisitedNodeValue,

--- a/lib/message-validator/validate-message.js
+++ b/lib/message-validator/validate-message.js
@@ -7,7 +7,11 @@ const traverse = require('./ast-traverse');
 const { TYPE } = messageParser;
 
 function validateMessage(message, locale) {
-  const ast = messageParser.parse(message);
+  // ! Sync with `addon/-private/utils/parse.ts`
+  const ast = messageParser.parse(message, {
+    normalizeHashtagInPlural: false,
+    ignoreTag: true,
+  });
   const language = locale.split('-')[0];
   const validPlurals = pluralCategories[language];
   const validOrdinals = ordinalCategories[language];

--- a/lib/message-validator/validate-message.js
+++ b/lib/message-validator/validate-message.js
@@ -3,15 +3,12 @@ const messageParser = require('intl-messageformat-parser');
 const pluralCategories = require('./plural-categories');
 const ordinalCategories = require('./ordinal-categories');
 const traverse = require('./ast-traverse');
+const parseOptions = require('../parse-options');
 
 const { TYPE } = messageParser;
 
 function validateMessage(message, locale) {
-  // ! Sync with `addon/-private/utils/parse.ts`
-  const ast = messageParser.parse(message, {
-    normalizeHashtagInPlural: false,
-    ignoreTag: true,
-  });
+  const ast = messageParser.parse(message, parseOptions);
   const language = locale.split('-')[0];
   const validPlurals = pluralCategories[language];
   const validOrdinals = ordinalCategories[language];

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,0 +1,5 @@
+// ! Sync with `addon/-private/utils/parse.ts`
+module.exports = {
+  normalizeHashtagInPlural: false,
+  ignoreTag: true,
+};

--- a/tests-node/unit/message-validator/validate-message-test.js
+++ b/tests-node/unit/message-validator/validate-message-test.js
@@ -23,6 +23,9 @@ describe('validateMessage', function () {
         few {#rd}
         other {#th}
     } birthday!`,
+    '<a href="{href}">Click Here {text}</a>',
+    `'<'a href="{href}"'>'Click Here {text}'<'/a'>'`,
+    `'<a href="{href}">'Click Here {text}'</a>'`, // ! `{href}` will _not_ be treated as a variable
   ];
 
   valid.forEach((message) => {

--- a/tests/dummy/translations/en-us.json
+++ b/tests/dummy/translations/en-us.json
@@ -5,5 +5,6 @@
   },
   "photos": {
     "banner": "You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.}}"
-  }
+  },
+  "legacyHTML": "<a href=\"{href}\">Click Here</a>"
 }

--- a/tests/unit/helpers/format-message-(html)-test.ts
+++ b/tests/unit/helpers/format-message-(html)-test.ts
@@ -80,7 +80,7 @@ module('format-message (html)', function (hooks) {
 
     assert.equal(
       this.intl
-        .formatMessage(`<a href="{link}"'>text</a>`, {
+        .formatMessage(`<a href="{link}">text</a>`, {
           htmlSafe: true,
           link: 'http://formatjs.io',
         })

--- a/tests/unit/helpers/t-test.ts
+++ b/tests/unit/helpers/t-test.ts
@@ -16,6 +16,7 @@ module('t', function (hooks) {
     {
       html: {
         greeting: "'<strong>'Hello {name} {count, number}'</strong>'",
+        legacy: `<a href="{href}">{text}</a>`,
       },
       number: 2,
       foo: {
@@ -61,6 +62,14 @@ module('t', function (hooks) {
     assert.equal(this.element.querySelectorAll('strong').length, 1);
     assert.equal(this.element.querySelectorAll('em').length, 0);
     assert.equal(this.element.innerHTML, `<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>`);
+  });
+
+  test('should support legacy HTML escaping', async function (this: TestContext, assert) {
+    assert.expect(3);
+    await render(hbs`{{t 'html.legacy' htmlSafe=true text="<em>Jason</em>" href="/foo"}}`);
+    assert.equal(this.element.querySelectorAll('a').length, 1);
+    assert.equal(this.element.querySelectorAll('em').length, 0);
+    assert.equal(this.element.innerHTML, `<a href="/foo">&lt;em&gt;Jason&lt;/em&gt;</a>`);
   });
 
   test('should render a TextNode', async function (this: TestContext, assert) {


### PR DESCRIPTION
Attempts to fix #1443.
