### PR TITLE
feat(format): add `base` and `defaults`

### DIFF
--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -33,7 +33,7 @@ export default class IntlService extends Service.extend(Evented) {
   /**
    * @public
    */
-  readonly formats: Formats;
+  formats: Formats;
 
   /**
    * Returns an array of registered locale names

--- a/addon/types.d.ts
+++ b/addon/types.d.ts
@@ -1,6 +1,25 @@
 import type { Formats as BaseFormats } from 'intl-messageformat';
 import { RelativeTimeFormatOptions } from './-private/formatters/format-relative';
 
-export interface Formats extends Partial<BaseFormats> {
+interface EmberIntlFormats extends Partial<BaseFormats> {
   relative?: Record<string, RelativeTimeFormatOptions>;
+}
+
+export interface Formats extends EmberIntlFormats {
+  /**
+   * Format options that are always implied. Explicitly specified options when
+   * invoking a formatter override these base options.
+   */
+  base?: {
+    [F in keyof EmberIntlFormats]?: NonNullable<EmberIntlFormats[F]>[keyof NonNullable<EmberIntlFormats[F]>];
+  };
+
+  /**
+   * Format options that are implicitly used, if neither a named `format` nor
+   * any other know options were specified when invoking a formatter. These
+   * are combined with and override the `base` options.
+   */
+  defaults?: {
+    [F in keyof EmberIntlFormats]?: NonNullable<EmberIntlFormats[F]>[keyof NonNullable<EmberIntlFormats[F]>];
+  };
 }

--- a/blueprints/ember-intl/files/__app__/formats.js
+++ b/blueprints/ember-intl/files/__app__/formats.js
@@ -1,4 +1,31 @@
 export default {
+  /*
+  // Format options that are always implied. Explicitly specified options when
+  // invoking a formatter override these base options.
+  base: {
+    time: {
+      hour: 'numeric',
+      minute: 'numeric'
+    },
+    date: { },
+    number: { },
+    relative: { },
+  },
+
+  // Format options that are implicitly used, if neither a named `format` nor
+  // any other know options were specified when invoking a formatter. These
+  // are combined with and override the `base` options.
+  defaults: {
+    time: {
+      hour: 'numeric',
+      minute: 'numeric'
+    },
+    date: { },
+    number: { },
+    relative: { },
+  },
+  */
+
   time: {
     hhmmss: {
       hour: 'numeric',
@@ -12,6 +39,12 @@ export default {
       minute: 'numeric',
       second: 'numeric',
     },
+  },
+  relative: {
+    days: {
+      unit: 'days',
+      numeric: 'always'
+    }
   },
   number: {
     compact: { notation: 'compact' },

--- a/tests/dummy/app/formats.ts
+++ b/tests/dummy/app/formats.ts
@@ -3,8 +3,8 @@ import type { Formats } from 'ember-intl/types';
 const hhmmss = { hour: 'numeric', minute: 'numeric', second: 'numeric' };
 
 const formats: Formats = {
-  date: { hhmmss: hhmmss },
-  time: { hhmmss: hhmmss },
+  date: { hhmmss },
+  time: { hhmmss },
   number: {
     compact: { notation: 'compact' },
     EUR: { style: 'currency', currency: 'EUR' },

--- a/tests/unit/helpers/format-number-test.ts
+++ b/tests/unit/helpers/format-number-test.ts
@@ -137,19 +137,6 @@ module('format-number', function (hooks) {
     assert.equal(this.element.textContent, '0,000,000,001.00', 'should return a string formatted to a percent');
   });
 
-  // v4 -> v5 regression
-  // https://github.com/ember-intl/ember-intl/pull/1401
-  test('hash options take precedence over named format options', async function (this: TestContext, assert) {
-    assert.expect(1);
-    this.intl.set('formats', {
-      number: { currency: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 } },
-    });
-    await render(
-      hbs`{{format-number 1 format="currency"}} / {{format-number 1 format="currency" minimumFractionDigits=0}}`
-    );
-    assert.equal(this.element.textContent, '$1.000 / $1', '`minimumFractionDigits` overrides named format');
-  });
-
   test('used to format percentages', async function (this: TestContext, assert) {
     assert.expect(2);
     await render(hbs`{{format-number 400 style="percent"}}`);

--- a/tests/unit/helpers/format-options-merging-test.ts
+++ b/tests/unit/helpers/format-options-merging-test.ts
@@ -1,0 +1,102 @@
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { setupIntl, TestContext } from 'ember-intl/test-support';
+
+module('Format Options Merging', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('base + namedFormat + options', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      base: {
+        number: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+      },
+      defaults: {
+        number: { currency: 'EUR' },
+      },
+      number: {
+        test: { minimumFractionDigits: 3 },
+      },
+    });
+    await render(hbs`{{format-number 1 format="test" minimumFractionDigits=4}}`);
+    assert.equal(this.element.textContent, '$1.0000');
+  });
+
+  test('base + namedFormat', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      base: {
+        number: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+      },
+      defaults: {
+        number: { currency: 'EUR' },
+      },
+      number: {
+        test: { minimumFractionDigits: 3 },
+      },
+    });
+    await render(hbs`{{format-number 1 format="test"}}`);
+    assert.equal(this.element.textContent, '$1.000');
+  });
+
+  test('base + options', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      base: {
+        number: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+      },
+      defaults: {
+        number: { currency: 'EUR' },
+      },
+      number: {
+        test: { minimumFractionDigits: 3 },
+      },
+    });
+    await render(hbs`{{format-number 1 format="test" minimumFractionDigits=4}}`);
+    assert.equal(this.element.textContent, '$1.0000');
+  });
+
+  test('base + defaults', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      base: {
+        number: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+      },
+      defaults: {
+        number: { currency: 'EUR' },
+      },
+      number: {
+        test: { minimumFractionDigits: 3 },
+      },
+    });
+    await render(hbs`{{format-number 1}}`);
+    assert.equal(this.element.textContent, '€1.00');
+  });
+
+  // v4 -> v5 regression
+  // https://github.com/ember-intl/ember-intl/pull/1401
+  test('hash options take precedence over named format options', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      number: { currency: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 } },
+    });
+    await render(
+      hbs`{{format-number 1 format="currency"}} / {{format-number 1 format="currency" minimumFractionDigits=0}}`
+    );
+    assert.equal(this.element.textContent, '$1.000 / $1', '`minimumFractionDigits` overrides named format');
+  });
+
+  test('hash options take precedence over named format options', async function (this: TestContext, assert) {
+    assert.expect(1);
+    this.intl.set('formats', {
+      number: { currency: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 } },
+    });
+    await render(
+      hbs`{{format-number 1 format="currency"}} / {{format-number 1 format="currency" minimumFractionDigits=0}}`
+    );
+    assert.equal(this.element.textContent, '$1.000 / $1', '`minimumFractionDigits` overrides named format');
+  });
+});


### PR DESCRIPTION
Closes #1462.

Adds `base` and `defaults` format options.

```js
export default {
  // Format options that are always implied. Explicitly specified options when
  // invoking a formatter override these base options.
  base: {
    time: {
      hour: 'numeric',
      minute: 'numeric'
    },
    // date: { },
    // number: { },
    // relative: { },
  },

  // Format options that are implicitly used, if neither a named `format` nor
  // any other know options were specified when invoking a formatter. These
  // are combined with and override the `base` options.
  defaults: {
    time: {
      hour: 'numeric',
      minute: 'numeric'
    },
    // date: { },
    // number: { },
    // relative: { },
  },

  time: {
    hhmmss: {
      hour: 'numeric',
      minute: 'numeric',
      second: 'numeric',
    },
  },
  date: {
    // ...
  },
  relative: {
    // ...
  },
  number: {
    // ...
  },
};
```