### PR TITLE
chore(ci): migrate GitHub Actions env

### DIFF
--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -35,6 +35,6 @@ jobs:
         # 'master' or 'v1.2.3'
         # https://github.com/ember-learn/ember-cli-addon-docs/issues/454#issuecomment-584129324
         # https://github.com/ember-learn/ember-cli-addon-docs/issues/437
-        run: echo "::set-env name=ADDON_DOCS_VERSION_PATH::${GITHUB_REF##*/}"
+        run: echo "ADDON_DOCS_VERSION_PATH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Deploy docs with `ember-cli-deploy`
         run: yarn ember deploy production --verbose --activate

--- a/.github/workflows/docs-tag.yml
+++ b/.github/workflows/docs-tag.yml
@@ -35,7 +35,7 @@ jobs:
         # 'master' or 'v1.2.3'
         # https://github.com/ember-learn/ember-cli-addon-docs/issues/454#issuecomment-584129324
         # https://github.com/ember-learn/ember-cli-addon-docs/issues/437
-        run: echo "::set-env name=ADDON_DOCS_VERSION_PATH::${GITHUB_REF##*/}"
+        run: echo "ADDON_DOCS_VERSION_PATH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Deploy docs with `ember-cli-deploy`
         env:
           ADDON_DOCS_UPDATE_LATEST: 'true'


### PR DESCRIPTION
Fixes #1477.

I am 99.99 % sure that this is the correct fix. The GitHub Actions docs are a bit unclear.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/