### PR TITLE
chore(ci): re-enable testing against `ember-canary`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,9 @@ jobs:
           - ember-release
           - ember-beta
         experimental: [false]
-        # https://github.com/emberjs/ember.js/issues/19313
-        # include:
-        #   - scenario: ember-canary
-        #     experimental: true
+        include:
+          - scenario: ember-canary
+            experimental: true
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1


### PR DESCRIPTION
This reverts commit 6623c0d1008bc7cc26e083f1eecefb662b9666b0. The upstream issue has been fixed (by https://github.com/emberjs/ember.js/pull/19320).
