### PR TITLE
fix: rm minimumFractionDigits & maximumFractionDigits from default format

### DIFF
--- a/blueprints/ember-intl/files/__app__/formats.js
+++ b/blueprints/ember-intl/files/__app__/formats.js
@@ -18,14 +18,10 @@ export default {
     EUR: {
       style: 'currency',
       currency: 'EUR',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
     },
     USD: {
       style: 'currency',
       currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
     },
   },
 };


### PR DESCRIPTION
Manually specifying `minimumFractionDigits` & `maximumFractionDigits` is actually worse since they have default values in LDML spec.

By default all currencies already have 2 decimal points: https://unicode.org/reports/tr35/tr35-numbers.html#Supplemental_Currency_Data.

> digits: the minimum and maximum number of decimal digits normally formatted. The default is 2. For example, in the en_US locale with the default value of 2 digits, the value 1 USD would format as "$1.00", and the value 1.123 USD would format as → "$1.12".

Any special ones have data in https://github.com/unicode-org/cldr-json/blob/872e62d6ca2343412311520909ee0c1f78e93d99/cldr-json/cldr-core/supplemental/currencyData.json (e.g `JPY` is 0 because there's no fractional yen)