### PR TITLE
fix: use number skeleton instead of custom format

### DIFF
--- a/blueprints/ember-intl/files/translations/en-us.yaml
+++ b/blueprints/ember-intl/files/translations/en-us.yaml
@@ -1,1 +1,1 @@
-price_banner: The {product} costs {price, number, USD}
+price_banner: The {product} costs {price, number, ::currency/USD}


### PR DESCRIPTION
Custom format is not encouraged (not officially support by the MessageFormat spec) and the committee is nudging towards skeletons: https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md