### PR TITLE
fix: Add test-support to typesVersions for TS v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,8 @@
   },
   "typesVersions": {
     "^3.0": {
+      "test-support": ["test-support/index.d.ts"],
+      "test-support/*": ["test-support/*"],  
       "*": [
         "types.ts3/*",
         "addon/*"


### PR DESCRIPTION
This was missing and caused TS to not recognize test-support functions:
![image](https://user-images.githubusercontent.com/452199/105057845-4c744700-5a7e-11eb-82c4-eac3ca010a81.png)
