### PR TITLE
feat: move formats prop to private

### DIFF
--- a/addon-test-support/setup-intl.ts
+++ b/addon-test-support/setup-intl.ts
@@ -4,6 +4,7 @@ import type { TestContext as BaseTestContext } from 'ember-test-helpers';
 import type IntlService from 'ember-intl/services/intl';
 import type { TOptions } from 'ember-intl/services/intl';
 import type { Translations } from 'ember-intl/-private/store/translation';
+import { Formats } from 'ember-intl/types';
 
 export interface IntlTestContext {
   intl: IntlService;
@@ -19,7 +20,7 @@ export interface SetupIntlOptions {
    */
   missingMessage?: boolean | ((key: string, locales: string[], options: TOptions) => string);
 
-  formats?: IntlService['formats'];
+  formats?: Formats;
 }
 
 /**
@@ -71,20 +72,20 @@ export default function setupIntl(
       this.owner.register('util:intl/missing-message', missingMessage);
     }
 
+    if (options?.formats) {
+      const factory = this.owner.factoryFor('service:intl');
+      this.owner.unregister('service:intl');
+      this.owner.register('formats:main', options.formats);
+      this.owner.register('service:intl', factory);
+    }
     this.intl = this.owner.lookup('service:intl');
 
-    if (options?.formats) {
-      this.intl.set('formats', options.formats);
+    if (locale) {
+      this.intl.setLocale(locale);
+    }
+
+    if (translations) {
+      addTranslations(translations);
     }
   });
-
-  if (locale) {
-    hooks.beforeEach(function (this: TestContext) {
-      this.intl.setLocale(locale!);
-    });
-  }
-
-  if (translations) {
-    hooks.beforeEach(() => addTranslations(translations!));
-  }
 }

--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -5,8 +5,6 @@ import type { SafeString } from '@ember/template/-private/handlebars';
 
 import { FormatDate, FormatMessage, FormatNumber, FormatRelative, FormatTime } from '../-private/formatters';
 import TranslationContainer from '../-private/store/container';
-import { Formats } from '../types';
-import { MessageFormatElement } from 'intl-messageformat-parser';
 import type Translation from '../-private/store/translation';
 import type { TranslationAST } from '../-private/store/translation';
 
@@ -30,11 +28,6 @@ type FormatterProxy<T extends keyof IntlService['_formatters']> = (
 type MissingMessage = string;
 
 export default class IntlService extends Service.extend(Evented) {
-  /**
-   * @public
-   */
-  readonly formats: Formats;
-
   /**
    * Returns an array of registered locale names
    *

--- a/tests/dummy/app/pods/docs/guide/testing/template.md
+++ b/tests/dummy/app/pods/docs/guide/testing/template.md
@@ -25,14 +25,14 @@ further down, that makes asserting against these translations a breeze.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
-module('setupIntl demo', function(hooks) {
+module('setupIntl demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it serializes missing translations and injects the `intl` service', async function(assert) {
+  test('it serializes missing translations and injects the `intl` service', async function (assert) {
     await render(hbs`{{t "some.translation" someVariable="Hello"}}`);
     assert.dom().hasText('t:some.translation:("someVariable":"Hello")');
 
@@ -50,14 +50,14 @@ Does what `setupIntl(hooks)` does and also sets the locale. You can also use
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
-module('setupIntl demo', function(hooks) {
+module('setupIntl demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
-  test('it sets the locale', async function(assert) {
+  test('it sets the locale', async function (assert) {
     assert.deepEqual(get(this.intl, 'locale'), ['en-us']);
   });
 });
@@ -73,20 +73,20 @@ for that.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
-module('setupIntl demo', function(hooks) {
+module('setupIntl demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, {
     some: {
       mocked: {
-        translations: 'Hello {thing}'
-      }
-    }
+        translations: 'Hello {thing}',
+      },
+    },
   });
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(hbs`{{t "some.mocked.translation" thing="world"}}`);
     assert.dom().hasText('Hello world');
 
@@ -110,20 +110,20 @@ for that.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 
-module('setupIntl demo', function(hooks) {
+module('setupIntl demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us', {
     some: {
       mocked: {
-        translations: 'Hello {thing}'
-      }
-    }
+        translations: 'Hello {thing}',
+      },
+    },
   });
 
-  test('it sets the locale and mocks the translations', async function(assert) {
+  test('it sets the locale and mocks the translations', async function (assert) {
     assert.deepEqual(get(this.intl, 'locale'), ['en-us']);
 
     await render(hbs`{{t "some.mocked.translation" thing="world"}}`);
@@ -146,14 +146,14 @@ Behaves as if you called `setLocale(locale)` on the `intl` service.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, setLocale } from 'ember-intl/test-support';
 
-module('setLocale demo', function(hooks) {
+module('setLocale demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it sets the locale', async function(assert) {
+  test('it sets the locale', async function (assert) {
     setLocale('en-us');
     assert.deepEqual(get(this.intl, 'locale'), ['en-us']);
 
@@ -175,30 +175,30 @@ locales were `['en-ca', 'en-gb', 'en-us']`, the translations would be added to
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, setLocale } from 'ember-intl/test-support';
 
-module('addTranslations demo', function(hooks) {
+module('addTranslations demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it adds the translations', async function(assert) {
+  test('it adds the translations', async function (assert) {
     setLocale(['en-ca', 'en-gb', 'en-us']);
 
     addTranslations({
       translation: {
         on: {
-          enUs: "'murica"
-        }
-      }
+          enUs: "'murica",
+        },
+      },
     });
 
     addTranslations('en-ca', {
       translation: {
         on: {
-          enCa: 'Sorry'
-        }
-      }
+          enCa: 'Sorry',
+        },
+      },
     });
 
     assert.ok(this.intl.exists('en-us', 'translation.on.enUs'));
@@ -222,14 +222,14 @@ translation messages are there and correctly interpolated by ember-intl.
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 
-module('t demo', function(hooks) {
+module('t demo', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it is a shortcut for accessing translations', async function(assert) {
+  test('it is a shortcut for accessing translations', async function (assert) {
     await render(hbs`{{t "some.translation" someVariable="Hello"}}`);
     assert.dom().hasText(t('some.translation', { someVariable: 'Hello' }));
   });
@@ -245,6 +245,6 @@ If you have a dynamic, variable driven usage of the `t` helper, you might see an
 import Helper from 'ember-intl/helpers/t';
 
 export default Helper.extend({
-  allowEmpty: true
+  allowEmpty: true,
 });
 ```

--- a/tests/unit/helpers/format-date-test.ts
+++ b/tests/unit/helpers/format-date-test.ts
@@ -1,14 +1,16 @@
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import formatDateHelper from 'ember-intl/helpers/format-date';
+import { setupIntl } from 'ember-intl/test-support';
 
 const date = 1390518044403;
 const locale = 'en-us';
 
 module('format-date', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test('exists', function (assert) {
     assert.expect(1);

--- a/tests/unit/helpers/format-message-(html)-test.ts
+++ b/tests/unit/helpers/format-message-(html)-test.ts
@@ -1,7 +1,7 @@
 import { render } from '@ember/test-helpers';
 import { htmlSafe } from '@ember/string';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupIntl, TestContext } from 'ember-intl/test-support';
 

--- a/tests/unit/helpers/format-message-test.ts
+++ b/tests/unit/helpers/format-message-test.ts
@@ -4,7 +4,7 @@ import { run, next } from '@ember/runloop';
 import { render } from '@ember/test-helpers';
 import formatMessageHelper from 'ember-intl/helpers/format-message';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, skip, test } from 'qunit';
 import { setupIntl, TestContext } from 'ember-intl/test-support';
 
@@ -154,7 +154,7 @@ module('format-message', function (hooks) {
     this.intl.addTranslations('es_MX', { foo: 'bar' });
     /* tests that the locale name becomes normalized to es-mx */
     this.intl.exists('test', 'fr-ca');
-    assert.equal(get(this.intl, 'locales').join('; '), 'en-us; es-es; fr-fr; es-mx');
+    assert.deepEqual(get(this.intl, 'locales'), ['en-us', 'es-es', 'fr-fr', 'es-mx']);
   });
 
   test('should respect format options for date ICU block', async function (this: TestContext & {

--- a/tests/unit/helpers/format-number-test.ts
+++ b/tests/unit/helpers/format-number-test.ts
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import { run } from '@ember/runloop';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
@@ -17,6 +17,7 @@ module('format-number', function (hooks) {
         number: {
           digits: { minimumFractionDigits: 2 },
           currency: { style: 'currency', minimumFractionDigits: 2 },
+          currency2: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 },
         },
       },
     }
@@ -141,11 +142,8 @@ module('format-number', function (hooks) {
   // https://github.com/ember-intl/ember-intl/pull/1401
   test('hash options take precedence over named format options', async function (this: TestContext, assert) {
     assert.expect(1);
-    this.intl.set('formats', {
-      number: { currency: { style: 'currency', currency: 'USD', minimumFractionDigits: 3 } },
-    });
     await render(
-      hbs`{{format-number 1 format="currency"}} / {{format-number 1 format="currency" minimumFractionDigits=0}}`
+      hbs`{{format-number 1 format="currency2"}} / {{format-number 1 format="currency2" minimumFractionDigits=0}}`
     );
     assert.equal(this.element.textContent, '$1.000 / $1', '`minimumFractionDigits` overrides named format');
   });

--- a/tests/unit/helpers/format-relative-test.ts
+++ b/tests/unit/helpers/format-relative-test.ts
@@ -1,4 +1,4 @@
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
@@ -7,11 +7,13 @@ import { setupIntl, TestContext } from 'ember-intl/test-support';
 
 module('format-relative', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
-
-  hooks.beforeEach(function (this: TestContext) {
-    this.intl.set('formats', { relative: { yearShort: { unit: 'year', style: 'short' } } });
-  });
+  setupIntl(
+    hooks,
+    {},
+    {
+      formats: { relative: { yearShort: { unit: 'year', style: 'short' } } },
+    }
+  );
 
   test('exists', function (this: TestContext, assert) {
     assert.expect(1);

--- a/tests/unit/helpers/format-time-test.ts
+++ b/tests/unit/helpers/format-time-test.ts
@@ -1,4 +1,4 @@
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
@@ -9,7 +9,19 @@ const date = 1390518044403;
 
 module('format-time-test', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(
+    hooks,
+    {},
+    {
+      formats: {
+        time: {
+          test: { timeZone: 'UTC' },
+          test2: { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' },
+          example: { timeZone: 'utc', timeZoneName: 'short' },
+        },
+      },
+    }
+  );
 
   test('exists', function (this: TestContext, assert) {
     assert.expect(1);
@@ -30,8 +42,6 @@ module('format-time-test', function (hooks) {
 
   test('invoke formatTime directly with format', function (this: TestContext, assert) {
     assert.expect(1);
-    this.intl.set('formats', { time: { test: { timeZone: 'UTC' } } });
-
     const output = this.intl.formatTime(date, { format: 'test', locale: 'fr-fr' });
 
     // Try both for browser Intl because of data inconsistencies between implementations
@@ -59,10 +69,6 @@ module('format-time-test', function (hooks) {
   test('it should return a formatted string formatted with formatConfig key', async function (this: TestContext, assert) {
     assert.expect(1);
 
-    this.intl.set('formats', {
-      time: { example: { timeZone: 'utc', timeZoneName: 'short' } },
-    });
-
     this.set('dateString', 'Thu Jan 23 2014 18:00:44 GMT-0500 (EST)');
 
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
@@ -72,10 +78,6 @@ module('format-time-test', function (hooks) {
 
   test('it should return a formatted string formatted using formatConfig key with inline locale', async function (this: TestContext, assert) {
     assert.expect(1);
-
-    this.intl.set('formats', {
-      time: { example: { timeZone: 'utc', timeZoneName: 'short' } },
-    });
 
     this.set('dateString', 'Thu Jan 23 2014 18:00:44 GMT-0500 (EST)');
 
@@ -114,15 +116,11 @@ module('format-time-test', function (hooks) {
 
     this.intl.setLocale(['en-ie']);
 
-    this.intl.set('formats', {
-      time: { test: { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' } },
-    });
-
-    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test"}}`);
+    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test2"}}`);
 
     assert.equal(this.element.textContent, '00:00', 'en-ie time format defaults to h23');
 
-    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test" hourCycle="h12"}}`);
+    await render(hbs`{{format-time "2020-04-30T00:00:00.000Z" format="test2" hourCycle="h12"}}`);
 
     assert.equal(this.element.textContent, '12:00 a.m.', 'en-ie hourCycle overridden');
   });

--- a/tests/unit/helpers/t-test.ts
+++ b/tests/unit/helpers/t-test.ts
@@ -1,7 +1,7 @@
 import { render, settled } from '@ember/test-helpers';
 import tHelper from 'ember-intl/helpers/t';
 import { setupRenderingTest } from 'ember-qunit';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { gte } from 'ember-compatibility-helpers';
 import { setupIntl, TestContext } from 'ember-intl/test-support';


### PR DESCRIPTION
Moving `formats` to private and only initialize during construction simplifies our caching strategy.

BREAKING CHANGES:
- `.set('formats')` no longer works. This was not a public API and only used in test.