### PR TITLE
chore: rm unsupported ember LTS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,6 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - ember-lts-2.12
-          - ember-lts-2.16
-          - ember-lts-2.18
-          - ember-lts-3.4
-          - ember-lts-3.8
-          - ember-lts-3.12
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-release

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,59 +8,6 @@ module.exports = function () {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-cli-shims': '^1.2.0',
-              'ember-data': '~3.12.0',
-              'ember-source': '~2.12.0',
-              '@ember/jquery': '^0.5.2',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.16.0',
-              '@ember/jquery': '^0.5.2',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.18',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.18.0',
-              '@ember/jquery': '^0.5.2',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.4',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.8',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.8.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.12.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.16',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Based on https://emberjs.com/releases/lts/ only 3.16 & 3.20 are LTS now