### PR TITLE
docs: Fix bad link in post install

### DIFF
--- a/blueprints/ember-intl/index.js
+++ b/blueprints/ember-intl/index.js
@@ -32,8 +32,8 @@ module.exports = {
 
   afterInstall() {
     this.ui.writeLine(
-      "[ember-intl] Don't forget to setup your application-wide locale.  " +
-        'Documentation: https://github.com/ember-intl/ember-intl#setting-locale'
+      "[ember-intl] Don't forget to configure your application.  " +
+        'Documentation: https://ember-intl.github.io/ember-intl/versions/master/docs/quickstart#4-configure-ember-intl'
     );
   },
 };


### PR DESCRIPTION
This information doesn't seem to be on the README anymore so I linked it
to what looks like the right place in the docs.