### PR TITLE
docs: add note on `\` escaping backward-compatibility

### DIFF
--- a/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
+++ b/tests/dummy/app/pods/docs/guide/migration-4-0-to-5-0/template.md
@@ -10,6 +10,8 @@ The `locales`, `disablePolyfill`, and `autoPolyfill` configuration options in `c
 
 Improved ICU-spec compliance, special characters are now escaped via a single quote `'` instead of a slash `\`
 
+**NOTE**: This change is advised for all future translations, however `\` escaping is backwards-compatible starting with the [V5.5.0 release](https://github.com/ember-intl/ember-intl/releases/tag/v5.5.0)
+
 ### **Node runtime**
 
 We now support down to Node 10, dropping support for Node 8.


### PR DESCRIPTION
Update the "4.x.x to 5.x.x" migration guide to include the backward-compatibility of escaping using `\`