### PR TITLE
chore: run CI on `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   test-locked-deps:
     name: Locked Deps
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
@@ -46,7 +46,7 @@ jobs:
 
   test-old-dependencies:
     name: Oldest Supported Env
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
@@ -63,7 +63,7 @@ jobs:
 
   test-try:
     name: Ember Try
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [test-locked-deps]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -92,7 +92,7 @@ jobs:
 
   lint-ts3:
     name: TypeScript 3
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [test-locked-deps]
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Looks like `ubuntu-16.04` is no longer avaliable as a virtual environment in GitHub Actions. This means actions get stuck with the following message..

```
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
```

Could update `ci.yml` to run on one of the following..
- `ubuntu-latest`
- `ubuntu-20.04`
- `ubuntu-18.04`

See https://github.com/actions/virtual-environments#available-environments