### PR TITLE
test: await settled in test `setupIntl()` to fix race condition with fake timers

### DIFF
--- a/addon-test-support/setup-intl.ts
+++ b/addon-test-support/setup-intl.ts
@@ -1,6 +1,7 @@
 import addTranslations from './add-translations';
 import { missingMessage } from './-private/serialize-translation';
 import type { TestContext as BaseTestContext } from 'ember-test-helpers';
+import { settled } from '@ember/test-helpers';
 import type IntlService from 'ember-intl/services/intl';
 import type { TOptions } from 'ember-intl/services/intl';
 import { Formats, Translations } from 'ember-intl/types';
@@ -64,7 +65,7 @@ export default function setupIntl(
     translations = translationsOrOptions as Translations | undefined;
   }
 
-  hooks.beforeEach(function (this: TestContext) {
+  hooks.beforeEach(async function (this: TestContext) {
     if (typeof options?.missingMessage === 'function') {
       this.owner.register('util:intl/missing-message', options.missingMessage);
     } else if ((options?.missingMessage ?? true) === true) {
@@ -86,5 +87,7 @@ export default function setupIntl(
     if (translations) {
       addTranslations(translations);
     }
+
+    await settled();
   });
 }


### PR DESCRIPTION
When initializing the service and/or setting locale, the service schedules a change event: https://github.com/ember-intl/ember-intl/blob/main/addon/services/intl.js#L48-L51. Afterwards, if the test sets up fake timers (e.g. https://sinonjs.org/releases/v1.17.7/fake-timers), it leaves this scheduled event stuck in the queue.

Explicitly waiting should resolve this edge case.