### PR TITLE
fix: deprecated-run-loop-and-computed-dot-access, fix #1600

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   test-locked-deps:
     name: Locked Deps
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
@@ -46,7 +46,7 @@ jobs:
 
   test-old-dependencies:
     name: Oldest Supported Env
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
@@ -63,7 +63,7 @@ jobs:
 
   test-try:
     name: Ember Try
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [test-locked-deps]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -98,7 +98,7 @@ jobs:
 
   lint-ts3:
     name: TypeScript 3
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [test-locked-deps]
     steps:
       - name: Checkout Code

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -4,6 +4,7 @@
  */
 import { getOwner } from '@ember/application';
 import { computed, get, set } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import Evented from '@ember/object/evented';
 import { assert } from '@ember/debug';
 import { makeArray } from '@ember/array';
@@ -27,7 +28,7 @@ export default Service.extend(Evented, {
    * @property locales
    * @public
    */
-  locales: computed.readOnly('_translationContainer.locales'),
+  locales: readOnly('_translationContainer.locales'),
 
   /** @public **/
   locale: computed('_locale', {
@@ -56,7 +57,7 @@ export default Service.extend(Evented, {
    * @property primaryLocale
    * @public
    */
-  primaryLocale: computed.readOnly('locale.0'),
+  primaryLocale: readOnly('locale.0'),
 
   /** @public **/
   formatRelative: createFormatterProxy('relative'),


### PR DESCRIPTION
Fixes #1600:

> DEPRECATION: Using `computed.readOnly` has been deprecated. Instead, import the value directly from @ember/object/computed:
>
> import { readOnly } from '@ember/object/computed';