### PR TITLE
fix: typo

### DIFF
--- a/tests/dummy/app/pods/docs/guide/translating-text/template.md
+++ b/tests/dummy/app/pods/docs/guide/translating-text/template.md
@@ -139,7 +139,7 @@ export default Component.extend({
   dateFormat: 'hhmmss',
 
   nowFormatted: intl('now', 'dateFormat', function(intl /* , propertyKey, instance */) {
-    return intl.formatDate(this.now, { format: this.format });
+    return intl.formatDate(this.now, { format: this.dateFormat });
   })
 });
 ```


### PR DESCRIPTION
found a typo in the documentation: `dateFormat` seems to be a correct property name