### PR TITLE
Bugfix - Windows platform - wrapWithNamespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ jsconfig.json
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+package-lock.json

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -16,13 +16,15 @@ const enums = require('../../enums');
  * @private
  */
 function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
-  let dirname = path.dirname(filepath).replace(inputPath, '');
+  const pathPlatform = process.platform === 'win32' ? path.win32 : path.posix;
+  let dirname = pathPlatform.dirname(filepath).replace(inputPath, '');
 
   if (dirname) {
-    let prefix = path.sep;
+    const pathSep = pathPlatform.sep;
+    let prefix = pathSep;
 
     for (let addon of addonNames) {
-      let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
+      let addonPrefix = `${pathSep}${enums.addonNamespace}${pathSep}${addon}`;
 
       if (dirname.startsWith(addonPrefix)) {
         prefix = addonPrefix;
@@ -32,7 +34,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
 
     const dirnameParts = dirname
       .replace(prefix, '')
-      .split(path.sep)
+      .split(pathSep)
       .filter((part) => Boolean(part))
       .reverse();
 

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -94,4 +94,29 @@ describe('wrapWithNamespaceIfNeeded', function () {
       expect(wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames)).to.deep.equal(expected);
     });
   });
+
+  describe('with win32 platform', () => {
+    let originalPlatform;
+
+    before(() => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('path dirname uses win32 platform', () => {
+      const translationFileContent = { age: 'twenty' };
+      const filepath = 'C:\\Users\\*exampleDirectory/\\en-us.yaml';
+      const addons = [];
+
+      const translationFileWithDirpath = { 'C:Users': { '*exampleDirectory/': { age: 'twenty' } } };
+
+      const withNamespace = wrapWithNamespaceIfNeeded(translationFileContent, filepath, filepath, addons);
+
+      expect(withNamespace).to.deep.equal(translationFileWithDirpath);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Related to issue [#1451](https://github.com/ember-intl/ember-intl/issues/1451)

With this change, we are using `process.platform` in `path` dependency and fix translations errors on Windows platform