### PR TITLE
feat(helpers): positional options that override named options

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ Jakub Olek <bukaj.kelo+github@gmail.com>
 Jan Bobisud <me@bobisjan.com>
 Jan Buschtöns <buschtoens@gmail.com>
 Jason Mitchell <jason.mitchell.w@gmail.com>
+Jesse David Peterson <jesdavpet@users.noreply.github.com>
 Jonas Cosandey <jonas.cosandey@adfinis-sygroup.ch>
 Jonathan Johnson <jon.johnson@ucsf.edu>
 Jordan Hawker <hawker.jordan@gmail.com>

--- a/addon/helpers/-format-base.d.ts
+++ b/addon/helpers/-format-base.d.ts
@@ -6,9 +6,9 @@ export default abstract class AbstractHelper<V, O extends {} | undefined> extend
   readonly intl: IntlService;
   allowEmpty: boolean;
 
-  abstract format(value: V, options?: O): string;
+  abstract format(value: V, namedOptions?: O): string;
 
-  compute(positional: [undefined], options: O & { allowEmpty: false }): never;
-  compute(positional: [undefined], options: O & { allowEmpty: true }): void;
-  compute(positional: [V], options: O & { allowEmpty?: boolean }): string | never;
+  compute(positional: [undefined], namedOptions: O & { allowEmpty: false }): never;
+  compute(positional: [undefined], namedOptions: O & { allowEmpty: true }): void;
+  compute(positional: [value: V, positionalOptions?: O], namedOptions: O & { allowEmpty?: boolean }): string | never;
 }

--- a/addon/helpers/-format-base.js
+++ b/addon/helpers/-format-base.js
@@ -29,9 +29,7 @@ export default class AbstractHelper extends Helper {
   }
 
   compute([value, positionalOptions], namedOptions) {
-    const options = positionalOptions
-      ? Object.assign({}, positionalOptions, namedOptions)
-      : namedOptions;
+    const options = positionalOptions ? Object.assign({}, positionalOptions, namedOptions) : namedOptions;
 
     if (isEmpty(value)) {
       if (options.allowEmpty ?? this.allowEmpty) {

--- a/addon/helpers/-format-base.js
+++ b/addon/helpers/-format-base.js
@@ -28,7 +28,11 @@ export default class AbstractHelper extends Helper {
     throw new Error('not implemented');
   }
 
-  compute([value], options) {
+  compute([value, positionalOptions], namedOptions) {
+    const options = positionalOptions
+      ? Object.assign({}, positionalOptions, namedOptions)
+      : namedOptions;
+
     if (isEmpty(value)) {
       if (options.allowEmpty ?? this.allowEmpty) {
         return;

--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -47,8 +47,6 @@ _Positional argument:_
 ```
 
 In the case where both named and positional arguments are used, they'll be merged together and named arguments will take precedence over the properties of a positional argument where there are duplicates.
-
-
 ## Format HTML Message
 
 To enable rendering HTML within translations, pass an `htmlSafe` attribute to the `t` helper.

--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -1,10 +1,10 @@
 {{locale-switcher}}
-# The `t` helper
+# The `t` Helper
 
 The `t` helper accepts a translation key and returns a translated string.
 To provide values to the dynamic segment of the translation, pass an object hash.
 
-## ICU message syntax
+## ICU Message Syntax
 
 Compiles a [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax) strings with its hash values passed.
 

--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -30,23 +30,22 @@ Compiles a [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-synta
 }
 ```
 
-## Named VS Positional Arguments
+## Named and Positional Arguments
 
-Options may be passed to the `t` helper as either named or positional arguments.
-
-The following examples are equivalent:
+Options may be passed to the `t` helper as either named or positional arguments. The following examples are equivalent:
 
 _Named arguments:_
 ```hbs
 {{t 'photos.banner' numPhotos=count}}
 ```
 
-_Positional argument:_
+_Positional arguments:_
 ```hbs
 {{t 'photos.banner' (hash numPhotos=count)}}
 ```
 
-In the case where both named and positional arguments are used, they'll be merged together and named arguments will take precedence over the properties of a positional argument where there are duplicates.
+When both named and positional arguments are used, they'll be merged together and named arguments will take precedence over the properties of duplicate positional arguments.
+
 ## Format HTML Message
 
 To enable rendering HTML within translations, pass an `htmlSafe` attribute to the `t` helper.

--- a/tests/dummy/app/pods/docs/helpers/t/template.md
+++ b/tests/dummy/app/pods/docs/helpers/t/template.md
@@ -30,6 +30,25 @@ Compiles a [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-synta
 }
 ```
 
+## Named VS Positional Arguments
+
+Options may be passed to the `t` helper as either named or positional arguments.
+
+The following examples are equivalent:
+
+_Named arguments:_
+```hbs
+{{t 'photos.banner' numPhotos=count}}
+```
+
+_Positional argument:_
+```hbs
+{{t 'photos.banner' (hash numPhotos=count)}}
+```
+
+In the case where both named and positional arguments are used, they'll be merged together and named arguments will take precedence over the properties of a positional argument where there are duplicates.
+
+
 ## Format HTML Message
 
 To enable rendering HTML within translations, pass an `htmlSafe` attribute to the `t` helper.

--- a/tests/unit/helpers/t-test.ts
+++ b/tests/unit/helpers/t-test.ts
@@ -72,6 +72,22 @@ module('t', function (hooks) {
     assert.equal(this.element.innerHTML, `<a href="/foo">&lt;em&gt;Jason&lt;/em&gt;</a>`);
   });
 
+  test('should support optional positional options object argument', async function (this: TestContext, assert) {
+    assert.expect(1);
+    await render(hbs`
+      {{t 'html.greeting' (hash name="Jason" count=42)}}
+    `);
+    assert.equal(this.element.textContent?.includes('<strong>Hello Jason 42</strong>'), true);
+  });
+
+  test('should overried optional positional options argument properties with named arguments', async function (this: TestContext, assert) {
+    assert.expect(1);
+    await render(hbs`
+      {{t 'html.greeting' (hash name="Jason" count=42) count=39.99}}
+    `);
+    assert.equal(this.element.textContent?.includes('<strong>Hello Jason 39.99</strong>'), true);
+  });
+
   test('should render a TextNode', async function (this: TestContext, assert) {
     assert.expect(2);
     await render(hbs`{{t 'html.greeting' name="<em>Jason</em>" count=42000}}`);


### PR DESCRIPTION
This change extends the base abstract helper's `compute` method to accept a positional `options` argument, as per @buschtoens [suggestion](https://github.com/ember-intl/ember-intl/issues/1566#issuecomment-854176540) in the discussion on [issue #1566](https://github.com/ember-intl/ember-intl/issues/1566).

After this change, options may be passed as a positional options argument object:
```handlebars
{{t "say.hello" (hash place="world")}} => "Hello world."  
```

Before this change, options could only be passed as named attributes:
```handlebars
{{t "say.hello" place="world"}} => "Hello world."
```

In the case of mixed use of both positional and named arguments, the named arguments will override properties of the positional argument object where there are duplicate entries:
```handlebars
{{t "say.hello" (hash place="people") place="world"}} => "Hello world."
```

_NOTE: Using `hash` is just to keep the examples brief, the real benefit of this change IMO is the flexibility of passing a dynamic options object down from the component class instead of hard coding named argument keys at the template layer._
