### PR TITLE
fix(types): fix `Formats` declaration as type

### DIFF
--- a/addon/-private/formatters/-base.ts
+++ b/addon/-private/formatters/-base.ts
@@ -4,7 +4,7 @@
  */
 
 import type { SafeString } from '@ember/template/-private/handlebars';
-import { Formats } from '../../types';
+import type { Formats } from '../../types';
 import { IntlShape } from '@formatjs/intl';
 
 export type ValueOf<ObjectType, ValueType extends keyof ObjectType = keyof ObjectType> = ObjectType[ValueType];


### PR DESCRIPTION
This small change will fix the type error on #1560. `Formats` was previously not declared as `type` even though it is being used as a type declaration.