### PR TITLE
fix: use htmlSafe from @ember/template for compatibility to ember >= 3.8

### DIFF
--- a/addon/-private/formatters/format-message.js
+++ b/addon/-private/formatters/format-message.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 import memoize from 'fast-memoize';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { assign } from '@ember/polyfills';
 import IntlMessageFormat from '@ember-intl/intl-messageformat';
 import Formatter from './-base';


### PR DESCRIPTION
This fixes the run-time `import` error in projects still using `4.x` with `ember-cli` versions `3.8` or above where `htmlSafe` was moved from `@ember/string` to `@ember/template`. 