### PR TITLE
fix: `wrapTranslationsWithNamespace` not working on Windows

### DIFF
--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -16,12 +16,16 @@ const enums = require('../../enums');
  * @private
  */
 function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
-  let dirname = path.dirname(filepath).replace(inputPath, '');
+  const normalizedFilePath = path.normalize(filepath);
+  const normalizedInputPath = path.normalize(inputPath);
+  const normalizedAddonNames = addonNames.map(path.normalize);
+
+  let dirname = path.dirname(normalizedFilePath).replace(normalizedInputPath, '');
 
   if (dirname) {
     let prefix = path.sep;
 
-    for (let addon of addonNames) {
+    for (let addon of normalizedAddonNames) {
       let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
 
       if (dirname.startsWith(addonPrefix)) {


### PR DESCRIPTION
Fixes #1451

The problem arises from the format of the `filepath`, `inputPath` and the `addonNames`, which are in the format `/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json`. The problem with this is that in Windows the `path.sep` is `\\`, and not `/`, like in POSIX. Because of this the paths are then incorrectly parsed.

To fix this I use the `normalize` method of the `path` module, that normalizes the path according to the OS it is running on. With this the previous path is being converted, in Windows, to `\\tmp\\broccoli_debug-output_path-l4iBcmcT\\en-us.json`, which is then correctly parsed.

