### PR TITLE
Replace `intl-messageformat-parser` requires

### DIFF
--- a/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
@@ -1,4 +1,4 @@
-const parser = require('intl-messageformat-parser');
+const parser = require('@formatjs/icu-messageformat-parser');
 const traverse = require('../../../message-validator/ast-traverse');
 const parseOptions = require('../../../parse-options');
 

--- a/lib/message-validator/ast-traverse.js
+++ b/lib/message-validator/ast-traverse.js
@@ -1,4 +1,4 @@
-const { TYPE } = require('intl-messageformat-parser');
+const { TYPE } = require('@formatjs/icu-messageformat-parser');
 
 function traverse(node, visitor) {
   if (Array.isArray(node)) {

--- a/lib/message-validator/validate-message.js
+++ b/lib/message-validator/validate-message.js
@@ -1,4 +1,4 @@
-const messageParser = require('intl-messageformat-parser');
+const messageParser = require('@formatjs/icu-messageformat-parser');
 
 const pluralCategories = require('./plural-categories');
 const ordinalCategories = require('./ordinal-categories');

--- a/tests-node/unit/message-validator/ast-traverse-test.js
+++ b/tests-node/unit/message-validator/ast-traverse-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
-const messageParser = require('intl-messageformat-parser');
+const messageParser = require('@formatjs/icu-messageformat-parser');
 const traverse = require('../../../lib/message-validator/ast-traverse');
 
 describe('traverse', function () {


### PR DESCRIPTION
Fixes oversights from #1653

There is also an incorrect import in `addon/-private/utils/parse.ts` but TypeScript is complaining about the `normalizeHashtagInPlural` property not existing in the new package. Not entirely sure what that property does. `intl-messageformat-parser` documentation says this:

```js
/**
 * Whether to convert `#` in plural rule options
 * to `{var, number}`
 * Default is true
 */
normalizeHashtagInPlural?: boolean;
```

https://github.com/ember-intl/ember-intl/blob/main/addon/-private/utils/parse.ts#L10