### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
 env:
   CI: true
 
+permissions:
+  contents: read
+
 jobs:
   test-locked-deps:
     name: Locked Deps

--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -9,6 +9,9 @@ env:
   CI: true
   NAME: deploy
 
+permissions:
+  contents: read
+
 jobs:
   deploy-docs:
     name: Deploy Docs

--- a/.github/workflows/docs-tag.yml
+++ b/.github/workflows/docs-tag.yml
@@ -9,6 +9,9 @@ env:
   CI: true
   NAME: deploy
 
+permissions:
+  contents: read
+
 jobs:
   deploy-docs:
     name: Deploy Docs


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
