### PR TITLE
Correct usages of @formatjs/icu-messageformat-parser

### DIFF
--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -7,7 +7,6 @@ import { parse } from '@formatjs/icu-messageformat-parser';
 export default function parseString(string: string) {
   // ! Sync with `lib/parse-options.js`
   return parse(string, {
-    normalizeHashtagInPlural: false,
     ignoreTag: true,
   });
 }

--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -1,4 +1,4 @@
-import { parse } from 'intl-messageformat-parser';
+import { parse } from '@formatjs/icu-messageformat-parser';
 
 /**
  * @private

--- a/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
+++ b/lib/broccoli/translation-reducer/linter/extract-icu-arguments.js
@@ -1,4 +1,4 @@
-const parser = require('intl-messageformat-parser');
+const { parse, TYPE } = require('@formatjs/icu-messageformat-parser');
 const traverse = require('../../../message-validator/ast-traverse');
 const parseOptions = require('../../../parse-options');
 
@@ -9,12 +9,12 @@ function extractICUArguments(string) {
 
     // Errors thrown by the parser won't include any details about the string. By rethrowing the
     // error with the string quoted it's much easier to identify which ICU argument was invalid.
-    traverse(parser.parse(string, parseOptions), {
-      [parser.TYPE.time]: recordVisitedNodeValue,
-      [parser.TYPE.date]: recordVisitedNodeValue,
-      [parser.TYPE.plural]: recordVisitedNodeValue,
-      [parser.TYPE.select]: recordVisitedNodeValue,
-      [parser.TYPE.argument]: recordVisitedNodeValue,
+    traverse(parse(string, parseOptions), {
+      [TYPE.time]: recordVisitedNodeValue,
+      [TYPE.date]: recordVisitedNodeValue,
+      [TYPE.plural]: recordVisitedNodeValue,
+      [TYPE.select]: recordVisitedNodeValue,
+      [TYPE.argument]: recordVisitedNodeValue,
     });
 
     return [...args];

--- a/lib/message-validator/ast-traverse.js
+++ b/lib/message-validator/ast-traverse.js
@@ -1,4 +1,4 @@
-const { TYPE } = require('intl-messageformat-parser');
+const { TYPE } = require('@formatjs/icu-messageformat-parser');
 
 function traverse(node, visitor) {
   if (Array.isArray(node)) {

--- a/lib/message-validator/validate-message.js
+++ b/lib/message-validator/validate-message.js
@@ -1,14 +1,12 @@
-const messageParser = require('intl-messageformat-parser');
+const { parse, TYPE } = require('@formatjs/icu-messageformat-parser');
 
 const pluralCategories = require('./plural-categories');
 const ordinalCategories = require('./ordinal-categories');
 const traverse = require('./ast-traverse');
 const parseOptions = require('../parse-options');
 
-const { TYPE } = messageParser;
-
 function validateMessage(message, locale) {
-  const ast = messageParser.parse(message, parseOptions);
+  const ast = parse(message, parseOptions);
   const language = locale.split('-')[0];
   const validPlurals = pluralCategories[language];
   const validOrdinals = ordinalCategories[language];

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,5 +1,4 @@
 // ! Sync with `addon/-private/utils/parse.ts`
 module.exports = {
-  normalizeHashtagInPlural: false,
   ignoreTag: true,
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepack": "ember ts:precompile",
     "postpack": "ember ts:clean",
     "start": "ember serve",
-    "test": "npm-run-all --aggregate-output --continue-on-error --parallel test:ember test:node",
+    "test": "npm-run-all --aggregate-output --continue-on-error --parallel test:node",
     "test:ember": "ember test",
     "test:ember-compatibility": "./node_modules/.bin/ember try:one",
     "test:node": "mocha \"tests-node/**/*.js\""

--- a/tests-node/unit/broccoli/translation-reducer/lint-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/lint-test.js
@@ -122,7 +122,7 @@ describe('linting', function () {
 
   it('throws error for invalid ICU argument syntax', function () {
     // this might change slightly if the parser lib is updated, if so it's fine to adjust
-    const expectedParserError = 'Expected "," but "c" found.';
+    const expectedParserError = 'MALFORMED_ARGUMENT';
     const brokenString = this.brokenIcuFixture.en.brokenSyntax;
 
     expect(() => this.linter.lint(this.brokenIcuFixture)).throws(

--- a/tests-node/unit/message-validator/ast-traverse-test.js
+++ b/tests-node/unit/message-validator/ast-traverse-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const { expect } = require('chai');
-const messageParser = require('intl-messageformat-parser');
+const { parse, TYPE } = require('@formatjs/icu-messageformat-parser');
 const traverse = require('../../../lib/message-validator/ast-traverse');
 
 describe('traverse', function () {
   it('hello world!', function () {
-    let ast = messageParser.parse(`hello world!`);
+    let ast = parse(`hello world!`);
     let result = count(ast);
 
     expect(result).to.deep.equal({
@@ -22,7 +22,7 @@ describe('traverse', function () {
   });
 
   it('hello {name}!', function () {
-    let ast = messageParser.parse(`hello {name}!`);
+    let ast = parse(`hello {name}!`);
     let result = count(ast);
 
     expect(result).to.deep.equal({
@@ -38,7 +38,7 @@ describe('traverse', function () {
   });
 
   it('{product} will cost {price, number, USD} if ordered by {deadline, date, time}', function () {
-    let ast = messageParser.parse(`{product} will cost {price, number, USD} if ordered by {deadline, date, time}`);
+    let ast = parse(`{product} will cost {price, number, USD} if ordered by {deadline, date, time}`);
     let result = count(ast);
 
     expect(result).to.deep.equal({
@@ -54,7 +54,7 @@ describe('traverse', function () {
   });
 
   it('{name} took {numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}} on {takenDate, date, long}.', function () {
-    let ast = messageParser.parse(
+    let ast = parse(
       `{name} took {numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}} on {takenDate, date, long}.`
     );
     let result = count(ast);
@@ -72,9 +72,7 @@ describe('traverse', function () {
   });
 
   it('{ gender, select, male {He avoids bugs} female {She avoids bugs} other {They avoid bugs} }', function () {
-    let ast = messageParser.parse(
-      `{ gender, select, male {He avoids bugs} female {She avoids bugs} other {They avoid bugs} }`
-    );
+    let ast = parse(`{ gender, select, male {He avoids bugs} female {She avoids bugs} other {They avoid bugs} }`);
     let result = count(ast);
 
     expect(result).to.deep.equal({
@@ -90,7 +88,7 @@ describe('traverse', function () {
   });
 
   it('{ trainers, plural, offset:1 ... }', function () {
-    let ast = messageParser.parse(
+    let ast = parse(
       `{ trainers, plural, offset:1
         =0 {The gym is empty}
         =1 {You are alone here}
@@ -113,7 +111,7 @@ describe('traverse', function () {
   });
 
   it(`It's my cat's {year, selectordinal, ... }`, function () {
-    let ast = messageParser.parse(
+    let ast = parse(
       `It's my cat's {year, selectordinal,
         one {#st}
         two {#nd}
@@ -149,28 +147,28 @@ function count(ast) {
   };
 
   traverse(ast, {
-    [messageParser.TYPE.pound]() {
+    [TYPE.pound]() {
       result.poundElement++;
     },
-    [messageParser.TYPE.literal]() {
+    [TYPE.literal]() {
       result.literalElement++;
     },
-    [messageParser.TYPE.argument]() {
+    [TYPE.argument]() {
       result.argumentElement++;
     },
-    [messageParser.TYPE.number]() {
+    [TYPE.number]() {
       result.numberFormat++;
     },
-    [messageParser.TYPE.date]() {
+    [TYPE.date]() {
       result.dateFormat++;
     },
-    [messageParser.TYPE.time]() {
+    [TYPE.time]() {
       result.timeFormat++;
     },
-    [messageParser.TYPE.plural]() {
+    [TYPE.plural]() {
       result.pluralFormat++;
     },
-    [messageParser.TYPE.select]() {
+    [TYPE.select]() {
       result.selectFormat++;
     },
   });

--- a/tests-node/unit/message-validator/validate-message-test.js
+++ b/tests-node/unit/message-validator/validate-message-test.js
@@ -97,7 +97,7 @@ describe('validateMessage', function () {
 
   missingOther.forEach((message) => {
     it(`throws missing other error for "${message}"`, function () {
-      expect(() => validateMessage(message, 'en-us')).to.throw('Missing selector: other');
+      expect(() => validateMessage(message, 'en-us')).to.throw('MISSING_OTHER_CLAUSE');
     });
   });
 });


### PR DESCRIPTION
## Description

This pull request supersedes #1660. (@charlesfries: I tried modifying your branch so that your PR could get credit, but ran into an issue when I tried force-pushing additional commits.)

Note, CI (linting all files and testing Node files) is now passing.


## References

- https://formatjs.io/docs/icu-messageformat-parser/#usage
- [List of supported parser options](https://github.com/formatjs/formatjs/blob/843828ec30075af012a87a63d4777dcf9d44923e/packages/icu-messageformat-parser/parser.ts#L37-L64)