### PR TITLE
Added missing translations to try to fix failing CI

### DIFF
--- a/tests/dummy/translations/smoke/de-de.yaml
+++ b/tests/dummy/translations/smoke/de-de.yaml
@@ -1,0 +1,2 @@
+parent:
+  child: Hallo Welt!

--- a/tests/dummy/translations/smoke/es-es.yaml
+++ b/tests/dummy/translations/smoke/es-es.yaml
@@ -1,0 +1,2 @@
+parent:
+  child: Hola mundo!

--- a/tests/dummy/translations/smoke/fr-fr.yaml
+++ b/tests/dummy/translations/smoke/fr-fr.yaml
@@ -1,0 +1,2 @@
+parent:
+  child: Bonjour monde!


### PR DESCRIPTION
## Description

After merging #1683, I saw that the `test-addon` job had failed.

```
$ ember test
Building
Environment: test
building... 
[ember-intl] "smoke.parent.child" was not found in "de-de", "es-es", "fr-fr"
ERROR: "test:ember" exited with 1.
WARNING:  ember-intl/services/intl:338: replacing incorrect tag: returns with return
WARNING:  ember-intl/-private/formatters/-base:1: Missing item type
```

The message `"smoke.parent.child" was not found in "de-de", "es-es", "fr-fr"` [shouldn't have failed the build](https://github.com/ember-intl/ember-intl/blob/6343998c50476ad92d0b980c925a7d9fb92a0f61/tests/dummy/config/ember-intl.js#L66-L75). Just in case, I'll complete the translations in this pull request.


## References

- [CI passed, when run during the pull request](https://github.com/ember-intl/ember-intl/actions/runs/2476741765)
- [CI failed, when run during the merge](https://github.com/ember-intl/ember-intl/actions/runs/2476935141)