### PR TITLE
Uninstalled ember-cli-deploy-git-ci

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,10 +176,10 @@ jobs:
 
       - name: Deploy the latest documentation
         if: github.ref == 'refs/heads/main'
-        run: yarn deploy
+        run: yarn deploy --activate --verbose
 
       - name: Deploy the tagged documentation
         if: github.ref.type == 'tag'
-        run: yarn deploy
+        run: yarn deploy --activate --verbose
         env:
           ADDON_DOCS_UPDATE_LATEST: 'true'

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -6,6 +6,7 @@ module.exports = function (deployTarget) {
     build: {},
 
     git: {
+      enabled: true,
       repo: 'https://github.com/ember-intl/ember-intl.git',
     },
   };

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "ember-cli-deploy": "^1.0.2",
     "ember-cli-deploy-build": "^2.0.0",
     "ember-cli-deploy-git": "^1.3.4",
-    "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-typescript-blueprints": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/ember-intl/ember-intl.git"
   },
   "scripts": {
-    "build": "ember build",
+    "build": "ember build --environment=production",
     "deploy": "ember deploy production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:js": "eslint . --cache --ext=.js,.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6185,15 +6185,6 @@ ember-cli-deploy-build@^2.0.0:
     glob "^7.1.1"
     rsvp "^3.5.0"
 
-ember-cli-deploy-git-ci@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-deploy-git-ci/-/ember-cli-deploy-git-ci-1.0.1.tgz#846b046f82196538cc6eea2aa5d410c9111f76f4"
-  integrity sha512-F5lbie3T6vBCHYSCi7yT6KC+4dlM/BkeOv+6oPra0a2Px4q2J3Rv4Yuh8aailOVVRE+2iRyVFM57ijB8QBb9WA==
-  dependencies:
-    ember-cli-deploy-plugin "^0.2.9"
-    execa "^0.7.0"
-    fs-extra "^4.0.0"
-
 ember-cli-deploy-git@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ember-cli-deploy-git/-/ember-cli-deploy-git-1.3.4.tgz#918905df863eb867d23a323ff0b80d1336cfa05d"
@@ -7439,19 +7430,6 @@ execa@5.1.1, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  integrity sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -8064,7 +8042,7 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^4.0.0, fs-extra@^4.0.2, fs-extra@^4.0.3:
+fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
@@ -8262,11 +8240,6 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
-  integrity sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Description

The deployment of the documentation site has been failing with the error message,

```sh
Run yarn deploy
yarn run v1.22.19
$ ember deploy production
Error: No `deployKey` or `deployKeyPath` configured; unable to deploy
Error: No `deployKey` or `deployKeyPath` configured; unable to deploy
    at GitCIDeployPlugin.validateDeployKey (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy-git-ci/index.js:107:25)
    at GitCIDeployPlugin.determineDeployKeyPath (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy-git-ci/index.js:93:19)
    at GitCIDeployPlugin.setup (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy-git-ci/index.js:3[8](https://github.com/ember-intl/ember-intl/runs/6903804480?check_suite_focus=true#step:7:9):17)
    at Object.fn (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/lib/tasks/pipeline.js:[9](https://github.com/ember-intl/ember-intl/runs/6903804480?check_suite_focus=true#step:7:10)3:21)
    at Pipeline._notifyPipelinePluginHookExecution (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/lib/models/pipeline.js:173:19)
    at tryCatch (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/node_modules/rsvp/dist/rsvp.js:525:12)
    at invokeCallback (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/node_modules/rsvp/dist/rsvp.js:538:13)
    at publish (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/node_modules/rsvp/dist/rsvp.js:508:7)
    at flush (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy/node_modules/rsvp/dist/rsvp.js:2415:5)
    at processTicksAndRejections (internal/process/task_queues.js:77:[11](https://github.com/ember-intl/ember-intl/runs/6903804480?check_suite_focus=true#step:7:12))Pipeline aborted
```

The problem occurred because, in #1683, I had thought that we need to install the missing `ember-cli-deploy-git-ci` (see https://github.com/ember-intl/ember-intl/pull/1683#discussion_r894813561). It turned out, the addon hadn't been installed intentionally because we pass credentials in CI/CD in a different manner (by setting a Git user).


## Notes

I tried testing the code changes proposed in this pull request, but am unsure what will happen when I merge the pull request.

In December 2021, [GitHub introduced a feature](https://github.blog/changelog/2021-12-16-github-pages-using-github-actions-for-builds-and-deployments-for-public-repositories/) that seems to conflict with how `ember-cli-deploy-git` pushes code changes to the `gh-pages` branch (at least when I tried testing with a new addon). The deployed site for the new addon would show the `README` content instead of the demo app.