### PR TITLE
Set the default branch to be main for ember-cli-addon-docs deployment

### DIFF
--- a/config/addon-docs.js
+++ b/config/addon-docs.js
@@ -6,4 +6,7 @@ const AddonDocsConfig = require('ember-cli-addon-docs/lib/config');
 module.exports = class extends AddonDocsConfig {
   // See https://ember-learn.github.io/ember-cli-addon-docs/docs/deploying
   // for details on configuration you can override here.
+  getPrimaryBranch() {
+    return 'main';
+  }
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://ember-intl.github.io/ember-intl/",
   "repository": {
     "type": "git",
-    "url": "http://github.com/ember-intl/ember-intl.git"
+    "url": "https://github.com/ember-intl/ember-intl.git"
   },
   "scripts": {
     "build": "ember build --environment=production",


### PR DESCRIPTION
## Description

After merging #1692, I saw that, even though the `gh-pages` branch had been updated (i.e. the `deploy-documentation` job succeeded), the deployed site would not show any new code.

This may be because `ember-cli-addon-docs` assumes the default branch name to be `master` instead of `main`. We need to [override `getPrimaryBranch()`](https://github.com/ember-learn/ember-cli-addon-docs/blob/v4.2.2/lib/config.js#L13-L15) by updating `config/deploy.js`.


## References

- https://ember-learn.github.io/ember-cli-addon-docs/docs/deploying#getprimarybranch-