### PR TITLE
Fixed continuous deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,7 +146,7 @@ jobs:
     needs: [lint, test-addon, test-floating-dependencies, try-scenarios]
     timeout-minutes: 10
     # Only run on pushes to the main branch or a tag (i.e. ignore pull requests and cron)
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref.type == 'tag')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v3
@@ -182,5 +182,5 @@ jobs:
           ADDON_DOCS_UPDATE_LATEST: 'true'
 
       - name: Deploy the tagged documentation
-        if: github.ref.type == 'tag'
+        if: startsWith(github.ref, 'refs/tags/')
         run: yarn deploy --activate --verbose

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -177,9 +177,10 @@ jobs:
       - name: Deploy the latest documentation
         if: github.ref == 'refs/heads/main'
         run: yarn deploy --activate --verbose
+        env:
+          # Rebuild the demo application
+          ADDON_DOCS_UPDATE_LATEST: 'true'
 
       - name: Deploy the tagged documentation
         if: github.ref.type == 'tag'
         run: yarn deploy --activate --verbose
-        env:
-          ADDON_DOCS_UPDATE_LATEST: 'true'

--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
       "optional": true
     }
   },
+  "resolutions": {
+    "ember-get-config": "0.5.0"
+  },
   "engines": {
     "node": "14.* || >= 16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,7 +1252,7 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
-"@embroider/macros@1.7.1", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.6.0":
+"@embroider/macros@1.7.1", "@embroider/macros@^1.0.0", "@embroider/macros@^1.6.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.7.1.tgz#125b73f30f983866528b7b6ccd6d2ca565628c70"
   integrity sha512-JmWSCaRVSubV2FIFlOORZzLa8YfSndGqI8B013LtzOkYDkiLTFmE6L9kQmu/c8gdSUoqYiK+pVQn/AIh8ChtHQ==
@@ -3919,6 +3919,14 @@ broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     heimdalljs-logger "^0.1.7"
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
+
+broccoli-file-creator@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
+  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
 
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
@@ -6710,13 +6718,14 @@ ember-fetch@^8.1.1:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.6.2"
 
-ember-get-config@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-1.0.4.tgz#e8c36b0937767ead32e16d157fabd8178c542587"
-  integrity sha512-WOnf1E0ceRHWy7apnmUFbKcJm2c3KOg4rNNUKNtBFCFp770tOTwv5LAYcqV4+HootPCsQYL7oFUd/0JLiZpMeg==
+ember-get-config@0.5.0, ember-get-config@^1.0.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.5.0.tgz#8195f3e4c0ff0742182c81ae54aad78d07a24bcf"
+  integrity sha512-y1osD6g8wV/BlDjuaN6OG5MT0iHY2X/yE38gUj/05uUIMIRfpcwOdWnFQHBiXIhDojvAJQTEF1VOYFIETQMkeQ==
   dependencies:
-    "@embroider/macros" "^0.50.0 || ^1.0.0"
+    broccoli-file-creator "^1.1.1"
     ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
 
 ember-inflector@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## Description

By trial and error, I discovered two issues that would prevent correctly deploying the app.

1. We need to pass the environment variable `ADDON_DOCS_UPDATE_LATEST=true` to `ember deploy production` if we want code changes to the demo application to take place. As a result, I think it makes more sense to pass the variable when a pull request is merged to `main`, rather than [when a tag is released](https://github.com/ember-intl/ember-intl/pull/1425).

2. `ember-cli-addon-docs` used to depend on `ember-get-config@v1.0.4`, which causes a runtime error in a brand-new, modern Ember app (`ember-source@v4.4.1`, `ember-auto-import@v2`).

    <img width="800" alt="" src="https://user-images.githubusercontent.com/16869656/174016543-88d07b8b-b33a-4fd1-957d-7ce6a1a725a9.png">

    Two pull requests that remove the dependency have been merged:

    - https://github.com/ember-learn/ember-cli-addon-docs/pull/1137
    - https://github.com/ember-learn/ember-cli-addon-docs/pull/1143

    However, the addon hasn't released a new version that would allow these pull requests to take effect. As a temporary measure, I pinned `ember-get-config` to `v0.5.0` (in order to revert the pull request `#1084` in https://github.com/ember-learn/ember-cli-addon-docs/releases/tag/v4.2.2)