### PR TITLE
Removed try-typescript code from CI (unused)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,33 +113,6 @@ jobs:
         run: yarn test:ember-compatibility ${{ matrix.scenario }} --- yarn test:ember
 
 
-  # try-typescript:
-  #   name: Try TypeScript
-  #   runs-on: ubuntu-latest
-  #   needs: [lint, test-addon]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       scenario:
-  #         - 'typescript-3'
-  #   timeout-minutes: 10
-  #   steps:
-  #     - name: Check out a copy of the repo
-  #       uses: actions/checkout@v3
-
-  #     - name: Use Node.js ${{ env.NODE_VERSION }}
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         cache: 'yarn'
-  #         node-version: ${{ env.NODE_VERSION }}
-
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-
-  #     - name: Test
-  #       run: yarn test:ember-compatibility ${{ matrix.scenario }} --- yarn lint:types --project tsconfig.ts3.json
-
-
   deploy-documentation:
     name: Deploy documentation
     runs-on: ubuntu-latest

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -67,14 +67,6 @@ module.exports = async function () {
       },
       embroiderSafe(),
       embroiderOptimized(),
-      {
-        name: 'typescript-3',
-        npm: {
-          devDependencies: {
-            typescript: '^3.9.7',
-          },
-        },
-      },
     ],
   };
 };


### PR DESCRIPTION
## Description

When I had tried re-introducing the `try-typescript` job in #1686, the [continuous integration failed](https://github.com/ember-intl/ember-intl/runs/6841235200?check_suite_focus=true). I didn't investigate why.

```sh
=== Scenario: typescript-3 =====================================================

$ tsc --noEmit --project tsconfig.ts3.json
Error: addon/helpers/-format-base.d.ts(13,29): error TS1005: ',' expected.
Error: addon/helpers/-format-base.d.ts(13,52): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/evented.d.ts([57](https://github.com/ember-intl/ember-intl/runs/6841235200?check_suite_focus=true#step:5:58),22): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/evented.d.ts([58](https://github.com/ember-intl/ember-intl/runs/6841235200?check_suite_focus=true#step:5:59),13): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/index.d.ts(47,25): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/index.d.ts(48,17): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/index.d.ts(57,25): error TS1005: ',' expected.
Error: node_modules/@types/ember__application/node_modules/@types/ember__object/index.d.ts(58,13): error TS1005: ',' expected.
```

For now, I'm removing the relevant `ember-try` code to simplify the project. If we need to check TypeScript 3, we can make a new pull request.