### PR TITLE
set importsNotUsedAsValues

### DIFF
--- a/addon-test-support/add-translations.ts
+++ b/addon-test-support/add-translations.ts
@@ -2,7 +2,7 @@ import { get } from '@ember/object';
 import makeIntlHelper from './-private/make-intl-helper';
 import pickLastLocale from './-private/pick-last-locale';
 import type IntlService from 'ember-intl/services/intl';
-import { Translations } from 'ember-intl/types';
+import type { Translations } from 'ember-intl/types';
 
 // ! Because TypeScript seems to short-circuit overloaded functions when passed
 // as generics, including these overloads would not work with `makeIntlHelper`.

--- a/addon-test-support/setup-intl.ts
+++ b/addon-test-support/setup-intl.ts
@@ -4,7 +4,7 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import type IntlService from 'ember-intl/services/intl';
 import type { TOptions } from 'ember-intl/services/intl';
-import { Formats, Translations } from 'ember-intl/types';
+import type { Formats, Translations } from 'ember-intl/types';
 
 export interface IntlTestContext {
   intl: IntlService;

--- a/addon/-private/formatters/-base.ts
+++ b/addon/-private/formatters/-base.ts
@@ -5,7 +5,7 @@
 
 import type { SafeString } from '@ember/template/-private/handlebars';
 import type { Formats } from '../../types';
-import { IntlShape } from '@formatjs/intl';
+import type { IntlShape } from '@formatjs/intl';
 
 export type ValueOf<ObjectType, ValueType extends keyof ObjectType = keyof ObjectType> = ObjectType[ValueType];
 

--- a/addon/-private/formatters/format-date.ts
+++ b/addon/-private/formatters/format-date.ts
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { FormatDateOptions, IntlShape } from '@formatjs/intl';
+import type { FormatDateOptions, IntlShape } from '@formatjs/intl';
 
 import Formatter from './-base';
 /**

--- a/addon/-private/formatters/format-list.ts
+++ b/addon/-private/formatters/format-list.ts
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { FormatListOptions, IntlShape } from '@formatjs/intl';
+import type { FormatListOptions, IntlShape } from '@formatjs/intl';
 import Formatter from './-base';
 
 /**

--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -8,8 +8,8 @@ import Ember from 'ember';
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 import type { SafeString } from '@ember/template/-private/handlebars';
 import Formatter from './-base';
-import { IntlShape, MessageDescriptor } from '@formatjs/intl';
-import { PrimitiveType } from 'intl-messageformat';
+import type { IntlShape, MessageDescriptor } from '@formatjs/intl';
+import type { PrimitiveType } from 'intl-messageformat';
 const {
   Handlebars: {
     // @ts-expect-error Upstream types are incomplete.

--- a/addon/-private/formatters/format-number.ts
+++ b/addon/-private/formatters/format-number.ts
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { FormatNumberOptions, IntlShape } from '@formatjs/intl';
+import type { FormatNumberOptions, IntlShape } from '@formatjs/intl';
 import Formatter from './-base';
 
 /**

--- a/addon/-private/formatters/format-relative.ts
+++ b/addon/-private/formatters/format-relative.ts
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { FormatRelativeTimeOptions, IntlShape } from '@formatjs/intl';
+import type { FormatRelativeTimeOptions, IntlShape } from '@formatjs/intl';
 import { assert } from '@ember/debug';
 import Formatter from './-base';
 

--- a/addon/-private/formatters/format-time.ts
+++ b/addon/-private/formatters/format-time.ts
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import { FormatDateOptions, IntlShape } from '@formatjs/intl';
+import type { FormatDateOptions, IntlShape } from '@formatjs/intl';
 import Formatter from './-base';
 
 /**

--- a/tests/integration/test-helpers-test.ts
+++ b/tests/integration/test-helpers-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { get } from '@ember/object';
 import { setupIntl, t, setLocale, addTranslations } from 'ember-intl/test-support';
-import { TestContext } from 'ember-intl/test-support';
+import type { TestContext } from 'ember-intl/test-support';
 
 module('Integration | Test Helpers', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/unit/helpers/format-relative-test.ts
+++ b/tests/unit/helpers/format-relative-test.ts
@@ -3,7 +3,9 @@ import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import formatRelativehelper from 'ember-intl/helpers/format-relative';
-import { setupIntl, TestContext } from 'ember-intl/test-support';
+import { setupIntl } from 'ember-intl/test-support';
+
+import type { TestContext } from 'ember-intl/test-support';
 
 module('format-relative', function (hooks) {
   setupRenderingTest(hooks);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "alwaysStrict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
+    "importsNotUsedAsValues": "error", // enforces type imports when imports are not used as values
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
in typescript projects, whenever typescript decides it needs to verify types of libraries, if `importsNotUsedAsValues` is set in the parent project, ember-intl will error because it has had inconsistent imports.

Using type imports helps communicate which imports are removed at build time.