### PR TITLE
Add new test-helper: getIntlService

### DIFF
--- a/addon-test-support/get-intl-service.ts
+++ b/addon-test-support/get-intl-service.ts
@@ -1,0 +1,46 @@
+import type EngineInstance from '@ember/engine/instance';
+import { getContext, TestContext } from '@ember/test-helpers';
+import type IntlService from 'ember-intl/services/intl';
+
+/**
+ * Helper that provides the instance of the intl service for use during tests.
+ *
+ * @example
+ * ```js
+ * import { module, test } from 'qunit';
+ * import { setupRenderingTest } from 'ember-qunit';
+ * import { setupIntl, getIntlService } from 'ember-intl/test-support';
+ *
+ * module('My Module', function (hooks) {
+ *   setupRenderingTest(hooks);
+ *   setupIntl(hooks);
+ *
+ *   test('my test', async function (assert) {
+ *     let intlService = getIntlService();
+ *
+ *     intlService.t('my-translation-key')
+ *   });
+ * });
+ * ```
+ *
+ * @example
+ * The owner can be passed to `getIntlService`
+ * ```js
+ *   test('my test', async function (assert) {
+ *     let intlService = getIntlService(this.owner);
+ *
+ *     intlService.t('my-translation-key')
+ *   });
+ * ```
+ *
+ * @param {EngineInstance} [owner] a specific owner can be passed, otherwise the owner will be guessed via `getContext`
+ */
+export function getIntlService(owner?: unknown) {
+  let _owner = owner as EngineInstance;
+
+  if (!owner) {
+    _owner = (getContext() as TestContext).owner;
+  }
+
+  return _owner.lookup('service:intl') as IntlService;
+}

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -1,4 +1,5 @@
 export { default as addTranslations } from './add-translations';
+export { getIntlService } from './get-intl-service';
 export { default as setLocale } from './set-locale';
 export type { IntlTestContext, TestContext } from './setup-intl';
 export { default as setupIntl } from './setup-intl';

--- a/tests/unit/services/intl-test.ts
+++ b/tests/unit/services/intl-test.ts
@@ -4,7 +4,7 @@ import { next } from '@ember/runloop';
 import { isHTMLSafe } from '@ember/template';
 import { settled } from '@ember/test-helpers';
 import type { TOptions } from 'ember-intl/services/intl';
-import type { TestContext } from 'ember-intl/test-support';
+import { getIntlService, TestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -32,6 +32,12 @@ module('service:init initialization', function (hooks) {
 module('service:intl', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks, LOCALE, {}, { missingMessage: false });
+
+  test('getIntlService returns the intl service', function (assert) {
+    const service = this.owner.lookup('service:intl');
+    assert.strictEqual(getIntlService(), service);
+    assert.strictEqual(getIntlService(this.owner), service);
+  });
 
   test('should return a number if the translation is a number', function (this: TestContext, assert) {
     this.intl.addTranslations(LOCALE, {


### PR DESCRIPTION
the current way to use the intl service in tests is to use `this.intl` on the test context via `setupIntl` -- this provides a nice convenience, but can be intrusive in typecsript codebases as it requires that the `this` type for each test use the custom `TestContext` provided by ember-intl.

Because modifying `this` in typecsript can be a bit annoying (and bug/error prone), I've found it best to avoid using `this` altogether in typescript tests -- which happens to align nicely with where the framework is going with Polaris, and `<template>` syntax in tests (with things being able to be directly accessed via scope, rather than proxied through `this`).

This PR adds a new test-helper, `getIntlService`, which returns the `IntlService` with the correct type.

```ts
   import { module, test } from 'qunit';
   import { setupRenderingTest } from 'ember-qunit';
   import { setupIntl, getIntlService } from 'ember-intl/test-support';
  
   module('My Module', function (hooks) {
     setupRenderingTest(hooks);
     setupIntl(hooks);
  
     test('my test', async function (assert) {
       let intlService = getIntlService();
  
       intlService.t('my-translation-key')
     });
   });
``` 
This allows folks to have a correctly typed version of the intl service as well as avoid `this` :partying_face: 