### PR TITLE
fix(types): allow `exactOptionalPropertyTypes`

### DIFF
--- a/addon/-private/formatters/-base.ts
+++ b/addon/-private/formatters/-base.ts
@@ -47,7 +47,7 @@ export default abstract class FormatterBase<KnownOptions extends {}> {
   }
 
   get options(): readonly (keyof KnownOptions)[] {
-    return ([] as unknown[]) as readonly (keyof KnownOptions)[];
+    return [] as unknown[] as readonly (keyof KnownOptions)[];
   }
 
   /**
@@ -66,9 +66,8 @@ export default abstract class FormatterBase<KnownOptions extends {}> {
     const found = {} as { [K in keyof O & keyof KnownOptions]: O[K] };
 
     for (const key in options) {
-      if (this.options.includes((key as unknown) as keyof O & keyof KnownOptions)) {
-        found[(key as unknown) as keyof O & keyof KnownOptions] =
-          options[(key as unknown) as keyof O & keyof KnownOptions];
+      if (this.options.includes(key as unknown as keyof O & keyof KnownOptions)) {
+        found[key as unknown as keyof O & keyof KnownOptions] = options[key as unknown as keyof O & keyof KnownOptions];
       }
     }
 

--- a/addon/-private/formatters/format-relative.ts
+++ b/addon/-private/formatters/format-relative.ts
@@ -64,9 +64,9 @@ type RelativeTimeFormatStyle = 'long' | 'short' | 'narrow';
  * [Specification](https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat).
  */
 export interface RelativeTimeFormatOptions {
-  unit?: RelativeTimeFormatUnit;
-  numeric?: RelativeTimeFormatNumeric;
-  style?: RelativeTimeFormatStyle;
+  unit?: RelativeTimeFormatUnit | undefined;
+  numeric?: RelativeTimeFormatNumeric | undefined;
+  style?: RelativeTimeFormatStyle | undefined;
 }
 
 const RELATIVE_TIME_OPTIONS = ['numeric', 'style', 'unit'] as readonly (keyof RelativeTimeFormatOptions)[];

--- a/addon/-private/utils/empty-object.ts
+++ b/addon/-private/utils/empty-object.ts
@@ -18,4 +18,4 @@ EmptyObject.prototype = proto;
  * @private
  * @hide
  */
-export default (EmptyObject as unknown) as { new (): Record<string, unknown> };
+export default EmptyObject as unknown as { new (): Record<string, unknown> };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "baseUrl": ".",
     "module": "es6",
     "experimentalDecorators": true,
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "dummy/tests/*": ["tests/*"],
       "dummy/*": ["tests/dummy/app/*", "app/*"],


### PR DESCRIPTION
v5.x is not currently compatible with apps that have [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) enabled. This turns that option on here and updates the types of `RelativeTimeFormatOptions` to be compatible.

The reason why this is required is that the `& keyof KnownOptions` restriction here:
https://github.com/ember-intl/ember-intl/blob/daad6f592fdd7e52f01df058e43c0a4f847149f6/addon/-private/formatters/-base.ts#L61
forces the return type to include `| undefined` for each option key.

@ijlee2 @buschtoens 