### PR TITLE
chore(types): enable `exactOptionalPropertyTypes`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "module": "es6",
     "experimentalDecorators": true,
     "skipLibCheck": true, // Don't check the types of dependencies
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "dummy/tests/*": ["tests/*"],
       "dummy/*": ["tests/dummy/app/*", "app/*"],


### PR DESCRIPTION
Follow up to #1715 for v6.

No code changes required to enforce this in v6.

@buschtoens 