### PR TITLE
Add Glint types

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: 
+on:
   push:
     branches:
       - main
@@ -35,6 +35,9 @@ jobs:
 
       - name: Lint
         run: yarn lint
+
+      - name: Glint
+        run: yarn glint
 
 
   test-addon:

--- a/addon/glint.d.ts
+++ b/addon/glint.d.ts
@@ -1,0 +1,19 @@
+import FormatDateHelper from 'ember-intl/helpers/format-date';
+import FormatListHelper from 'ember-intl/helpers/format-list';
+import FormatMessageHelper from 'ember-intl/helpers/format-message';
+import FormatNumberHelper from 'ember-intl/helpers/format-number';
+import FormatRelativeHelper from 'ember-intl/helpers/format-relative';
+import FormatTimeHelper from 'ember-intl/helpers/format-time';
+import THelper from 'ember-intl/helpers/t';
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'format-date': typeof FormatDateHelper;
+    'format-list': typeof FormatListHelper;
+    'format-message': typeof FormatMessageHelper;
+    'format-number': typeof FormatNumberHelper;
+    'format-relative': typeof FormatRelativeHelper;
+    'format-time': typeof FormatTimeHelper;
+    t: typeof THelper;
+  }
+}

--- a/addon/helpers/-format-base.d.ts
+++ b/addon/helpers/-format-base.d.ts
@@ -4,7 +4,7 @@ import IntlService from '../services/intl';
 
 export interface BaseHelperSignature<Value, Options extends Record<string, unknown>> {
   Args: {
-    Positional: [Value] | [Value, Options] | [];
+    Positional: [Value?, Options?];
     Named?: Options & { allowEmpty?: boolean };
   };
   Return: string;

--- a/addon/helpers/-format-base.d.ts
+++ b/addon/helpers/-format-base.d.ts
@@ -2,14 +2,21 @@ import Helper from '@ember/component/helper';
 
 import IntlService from '../services/intl';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export default abstract class AbstractHelper<V, O extends {} | undefined> extends Helper {
+export interface BaseHelperSignature<Value, Options extends Record<string, unknown>> {
+  Args: {
+    Positional: [Value] | [Value, Options] | [];
+    Named?: Options & { allowEmpty?: boolean };
+  };
+  Return: string;
+}
+
+export default abstract class AbstractHelper<Signature extends BaseHelperSignature> extends Helper<Signature> {
   readonly intl: IntlService;
   allowEmpty: boolean;
 
-  abstract format(value: V, namedOptions?: O): string;
+  abstract format(value: Signature['Args']['Positional'][0], namedOptions?: Signature['Args']['Named']): string;
 
-  compute(positional: [undefined], namedOptions: O & { allowEmpty: false }): never;
-  compute(positional: [undefined], namedOptions: O & { allowEmpty: true }): void;
-  compute(positional: [value: V, positionalOptions?: O], namedOptions: O & { allowEmpty?: boolean }): string | never;
+  compute(positional: [undefined], namedOptions: Signature['Args']['Named'] & { allowEmpty: false }): never;
+  compute(positional: [undefined], namedOptions: Signature['Args']['Named'] & { allowEmpty: true }): void;
+  compute(positional: Signature['Args']['Positional'], namedOptions: Signature['Args']['Named']): string | never;
 }

--- a/addon/helpers/format-date.d.ts
+++ b/addon/helpers/format-date.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatDate']>;
 
-export default class FormatDateHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatDateHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: true;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/format-list.d.ts
+++ b/addon/helpers/format-list.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatList']>;
 
-export default class FormatListHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatListHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/format-message.d.ts
+++ b/addon/helpers/format-message.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatMessage']>;
 
-export default class FormatMessageHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatMessageHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/format-number.d.ts
+++ b/addon/helpers/format-number.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatNumber']>;
 
-export default class FormatNumberHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatNumberHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/format-relative.d.ts
+++ b/addon/helpers/format-relative.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatRelative']>;
 
-export default class FormatRelativeHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatRelativeHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/format-time.d.ts
+++ b/addon/helpers/format-time.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatTime']>;
 
-export default class FormatTimeHelper extends BaseHelper<Params[0], Params[1]> {
+export default class FormatTimeHelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(value: Params[0], options?: Params[1]): string;

--- a/addon/helpers/t.d.ts
+++ b/addon/helpers/t.d.ts
@@ -1,9 +1,9 @@
 import IntlService from '../services/intl';
-import BaseHelper from './-format-base';
+import BaseHelper, { BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['t']>;
 
-export default class THelper extends BaseHelper<Params[0], Params[1]> {
+export default class THelper extends BaseHelper<BaseHelperSignature<Params[0], Params[1]>> {
   allowEmpty: false;
 
   format(key: Params[0], options?: Params[1]): string;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "@embroider/test-setup": "^1.8.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@glint/core": "^0.9.4",
+    "@glint/environment-ember-loose": "^0.9.4",
     "@types/ember-qunit": "^5.0.0",
     "@types/ember-resolver": "^5.0.11",
     "@types/ember__application": "^4.0.0",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,4 @@
+{{! @glint-nocheck }}
 <DocsHeader />
 
 {{outlet}}

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -1,3 +1,4 @@
+{{! @glint-nocheck }}
 <DocsViewer as |viewer|>
   <viewer.nav as |nav|>
     <nav.section

--- a/tests/dummy/app/templates/not-found.hbs
+++ b/tests/dummy/app/templates/not-found.hbs
@@ -1,3 +1,4 @@
+{{! @glint-nocheck }}
 <h1>404</h1>
 
 <p>

--- a/tests/unit/helpers/format-date-test.ts
+++ b/tests/unit/helpers/format-date-test.ts
@@ -26,7 +26,9 @@ module('format-date', function (hooks) {
 
   test('should render empty string for a null value', async function (assert) {
     assert.expect(1);
-    await render(hbs`{{format-date null}}`);
+    await render(hbs`
+      {{! @glint-expect-error }}
+      {{format-date null}}`);
     assert.strictEqual(this.element.textContent, '');
   });
 
@@ -44,7 +46,9 @@ module('format-date', function (hooks) {
 
   test('should render epoch date for a null value when allow empty is false', async function (assert) {
     assert.expect(1);
-    await render(hbs`{{format-date null allowEmpty=false}}`);
+    await render(hbs`
+      {{! @glint-expect-error }}
+      {{format-date null allowEmpty=false}}`);
     assert.strictEqual(this.element.textContent, new Intl.DateTimeFormat(locale).format(0));
   });
 

--- a/tests/unit/helpers/format-date-test.ts
+++ b/tests/unit/helpers/format-date-test.ts
@@ -27,7 +27,7 @@ module('format-date', function (hooks) {
   test('should render empty string for a null value', async function (assert) {
     assert.expect(1);
     await render(hbs`
-      {{! @glint-expect-error }}
+      {{~! @glint-expect-error ~}}
       {{format-date null}}`);
     assert.strictEqual(this.element.textContent, '');
   });
@@ -47,7 +47,7 @@ module('format-date', function (hooks) {
   test('should render epoch date for a null value when allow empty is false', async function (assert) {
     assert.expect(1);
     await render(hbs`
-      {{! @glint-expect-error }}
+      {{~! @glint-expect-error ~}}
       {{format-date null allowEmpty=false}}`);
     assert.strictEqual(this.element.textContent, new Intl.DateTimeFormat(locale).format(0));
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,9 @@
       "*": ["types/*"]
     }
   },
-  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"]
+  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"],
+  "glint": {
+    "environment": "ember-loose",
+    "checkStandaloneTemplates": false
+  }
 }

--- a/types/glint.d.ts
+++ b/types/glint.d.ts
@@ -1,0 +1,2 @@
+import '@glint/environment-ember-loose';
+import 'ember-intl/glint';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,7 +1432,7 @@
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/syntax@^0.84.0":
+"@glimmer/syntax@^0.84.0", "@glimmer/syntax@^0.84.2":
   version "0.84.2"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.84.2.tgz#a3f65e51eec20f6adb79c6159d1ad1166fa5bccd"
   integrity sha512-SPBd1tpIR9XeaXsXsMRCnKz63eLnIZ0d5G9QC4zIBFBC3pQdtG0F5kWeuRVCdfTIFuR+5WBMfk5jvg+3gbQhjg==
@@ -1492,6 +1492,51 @@
   integrity sha512-Cz0e/SrOo1gSNA0PXZRYI1WGmlQSAQCpiERBlXjjpwoLgiqx2kvsjfFiCUC/CfpsO6WN6wuPMeTFGJuhSSeL5A==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
+
+"@glint/config@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@glint/config/-/config-0.9.4.tgz#969b1d75e8c02ba92cca52e3e388aceadc150748"
+  integrity sha512-ip8lVWvdQYoxKQWessol9Lw8xwqp8y3DjKurXQqC9P9Hi2lnPQC2IoOAI565wRj8SnWrxBA1FCLVxtAWRGgADQ==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    minimatch "^3.0.4"
+    resolve "^1.17.0"
+    silent-error "^1.1.1"
+
+"@glint/core@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@glint/core/-/core-0.9.4.tgz#147b77313f8841948390c86298ae501891408e76"
+  integrity sha512-7n7nUV/kbRQ6y5AhWyO2NO1J79/h3zaBn2BJ1NXaguUvQY70/YvM15CeA4JfsrFjR8Yr2Y175QfP0Ug4MSD89Q==
+  dependencies:
+    "@glint/config" "^0.9.4"
+    "@glint/transform" "^0.9.4"
+    resolve "^1.17.0"
+    uuid "^8.3.2"
+    vscode-languageserver "^8.0.1"
+    vscode-languageserver-textdocument "^1.0.5"
+    vscode-uri "^3.0.2"
+    yargs "^17.5.1"
+
+"@glint/environment-ember-loose@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@glint/environment-ember-loose/-/environment-ember-loose-0.9.4.tgz#e95d1c64c0ab9866b8c8d46c590f3b915171eb31"
+  integrity sha512-70S8BwpfoOuoGRUvmsIF1be5vmYhzVzSnXRraa0UG6ZJm4WyrP1OqJEdl5sXTsKLsF/Gp8Fb5hc3dibP4GluNw==
+  dependencies:
+    "@glint/config" "^0.9.4"
+    "@glint/template" "^0.9.4"
+
+"@glint/template@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@glint/template/-/template-0.9.4.tgz#b1df5f379d569169abd26a3cf927a2510ea2fd7f"
+  integrity sha512-MiIcFyTT7SeXhkv0WK4/s/LW9Go1E2FGf8xu+4/1PeSPfSgAbEgRqIXHdtIreeFQhVrAwFFGff/+eHZkRgZWsA==
+
+"@glint/transform@^0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@glint/transform/-/transform-0.9.4.tgz#5350901b2b840dccbc160349fe88f9486002ecab"
+  integrity sha512-RgK+Rm2fs+djH5jur5KGTcOTWMoPMJx1GB/6ksIXBDq8jA4l4V0ZKZR/GQ5B2NBlfzf7UqWPRb0LNff7grAVHg==
+  dependencies:
+    "@glimmer/syntax" "^0.84.2"
+    "@glint/config" "^0.9.4"
 
 "@handlebars/parser@^2.1.0":
   version "2.1.0"
@@ -13939,6 +13984,41 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
+
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
+  dependencies:
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
+
+vscode-languageserver-textdocument@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz#16df468d5c2606103c90554ae05f9f3d335b771b"
+  integrity sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==
+
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+
+vscode-languageserver@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
+  dependencies:
+    vscode-languageserver-protocol "3.17.2"
+
+vscode-uri@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.3.tgz#a95c1ce2e6f41b7549f86279d19f47951e4f4d84"
+  integrity sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This adds Glint types for all ember-intl helpers and sets up Glint to run in CI to check invocations in tests.

The `format-date` unit tests include a couple of invocations with a value of `null`, which is invalid according to the types. I've marked those with `@glint-expect-error` for now.

CC: @dfreeman @chriskrycho