### PR TITLE
Allow nested folder structure on Windows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,6 +61,26 @@ jobs:
         run: yarn test
 
 
+  test-addon-windows:
+    name: Test addon (windows-latest)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn test
+
+
   test-floating-dependencies:
     name: Test floating dependencies
     runs-on: ubuntu-latest
@@ -119,7 +139,7 @@ jobs:
   deploy-documentation:
     name: Deploy documentation
     runs-on: ubuntu-latest
-    needs: [lint, test-addon, test-floating-dependencies, try-scenarios]
+    needs: [lint, test-addon, test-addon-windows, test-floating-dependencies, try-scenarios]
     timeout-minutes: 10
     # Only run on pushes to the main branch or a tag (i.e. ignore pull requests and cron)
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,7 +105,6 @@ jobs:
   try-scenarios:
     name: Try scenarios
     runs-on: ubuntu-latest
-    needs: [lint, test-addon]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -61,26 +61,6 @@ jobs:
         run: yarn test
 
 
-  test-addon-windows:
-    name: Test addon (windows-latest)
-    runs-on: windows-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out a copy of the repo
-        uses: actions/checkout@v3
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Test
-        run: yarn test
-
-
   test-floating-dependencies:
     name: Test floating dependencies
     runs-on: ubuntu-latest
@@ -138,7 +118,7 @@ jobs:
   deploy-documentation:
     name: Deploy documentation
     runs-on: ubuntu-latest
-    needs: [lint, test-addon, test-addon-windows, test-floating-dependencies, try-scenarios]
+    needs: [lint, test-addon, test-floating-dependencies, try-scenarios]
     timeout-minutes: 10
     # Only run on pushes to the main branch or a tag (i.e. ignore pull requests and cron)
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))

--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -16,12 +16,16 @@ const enums = require('../../enums');
  * @private
  */
 function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
-  let dirname = path.dirname(filepath).replace(inputPath, '');
+  const normalizedFilePath = path.normalize(filepath);
+  const normalizedInputPath = path.normalize(inputPath);
+  const normalizedAddonNames = addonNames.map(path.normalize);
+
+  let dirname = path.dirname(normalizedFilePath).replace(normalizedInputPath, '');
 
   if (dirname) {
     let prefix = path.sep;
 
-    for (let addon of addonNames) {
+    for (let addon of normalizedAddonNames) {
       let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
 
       if (dirname.startsWith(addonPrefix)) {

--- a/tests-node/unit/broccoli/translation-reducer/index-test.js
+++ b/tests-node/unit/broccoli/translation-reducer/index-test.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const hasUnicode = require('has-unicode');
 const { createBuilder, createTempDir } = require('broccoli-test-helper');
 const TranslationReducer = require('../../../../lib/broccoli/translation-reducer');
 
@@ -322,10 +323,13 @@ describe('translation-reducer', function () {
       });
 
       return build(createBuilder(subject), () => {
-        expect(logs).to.have.lengthOf(1);
-        expect(logs).to.deep.equal([
-          `🇦🇰  ypk-us-ak: Unable to detect language data for "ypk". Language code is either unknown or invalid.`,
-        ]);
+        const supportsUnicode = hasUnicode();
+
+        const expectedValue = supportsUnicode
+          ? ['🇦🇰  ypk-us-ak: Unable to detect language data for "ypk". Language code is either unknown or invalid.']
+          : ['ypk-us-ak: Unable to detect language data for "ypk". Language code is either unknown or invalid.'];
+
+        expect(logs).to.deep.equal(expectedValue);
       });
     });
 


### PR DESCRIPTION
Fixes #1451 and supercedes #1648. Credit goes to @tfloxolodeiro.

The problem arises from the format of the `filepath`, `inputPath` and the `addonNames`, which are in the format `/tmp/broccoli_debug-output_path-l4iBcmcT/en-us.json`. The problem with this is that in Windows the `path.sep` is `\\`, and not `/`, like in POSIX. Because of this the paths are then incorrectly parsed.

To fix this I use the `normalize` method of the `path` module, that normalizes the path according to the OS it is running on. With this the previous path is being converted, in Windows, to `\\tmp\\broccoli_debug-output_path-l4iBcmcT\\en-us.json`, which is then correctly parsed.