### PR TITLE
test: backport await settled in test setupIntl() to fix race condition with fake timers

### DIFF
--- a/addon-test-support/setup-intl.ts
+++ b/addon-test-support/setup-intl.ts
@@ -1,5 +1,6 @@
 import addTranslations from './add-translations';
 import { missingMessage } from './-private/serialize-translation';
+import { settled } from '@ember/test-helpers';
 import type { TestContext as BaseTestContext } from 'ember-test-helpers';
 import type IntlService from 'ember-intl/services/intl';
 import type { TOptions } from 'ember-intl/services/intl';
@@ -64,7 +65,7 @@ export default function setupIntl(
     translations = translationsOrOptions as Translations | undefined;
   }
 
-  hooks.beforeEach(function (this: TestContext) {
+  hooks.beforeEach(async function (this: TestContext) {
     if (typeof options?.missingMessage === 'function') {
       this.owner.register('util:intl/missing-message', options.missingMessage);
     } else if ((options?.missingMessage ?? true) === true) {
@@ -76,11 +77,14 @@ export default function setupIntl(
     if (options?.formats) {
       this.intl.set('formats', options.formats);
     }
+
+    await settled();
   });
 
   if (locale) {
-    hooks.beforeEach(function (this: TestContext) {
+    hooks.beforeEach(async function (this: TestContext) {
       this.intl.setLocale(locale!);
+      await settled();
     });
   }
 


### PR DESCRIPTION
Apply changes from https://github.com/ember-intl/ember-intl/pull/1616 to v5.x branch