### PR TITLE
fix: typos in docs

### DIFF
--- a/tests/dummy/app/templates/docs/cookbook/common-errors.md
+++ b/tests/dummy/app/templates/docs/cookbook/common-errors.md
@@ -4,4 +4,4 @@
 
 Browser vendors implement date/time parsing differently.  For example, the following will parse correctly in Chrome but fail in Firefox: `new Intl.DateTimeFormat().format('2015-04-21 20:47:31 GMT');`
 
-The solution is the ensure that the value you are passing in is in a format which is valid for the `Date` constructor.  This library currently does not try and normalize date strings outside of what the browser already implements.
+The solution is to ensure that the value you are passing in is in a format which is valid for the `Date` constructor.  This library currently does not try and normalize date strings outside of what the browser already implements.

--- a/tests/dummy/app/templates/docs/getting-started/quickstart.md
+++ b/tests/dummy/app/templates/docs/getting-started/quickstart.md
@@ -71,10 +71,10 @@ export default class ApplicationRoute extends Route {
 ### Configure your template linter
 
 If your app uses `ember-cli-template-lint` (which is installed by default since ember-cli v3.4.1),
-it is strongly recommanded that you add the `no-bare-strings` rule to your template linter.
+it is strongly recommended that you add the `no-bare-strings` rule to your template linter.
 This rule will prevent you from using plain text strings in your templates (because they cannot be translated).
 
-To enabled the template linter rule, edit the file `.template-lintrc.js` as follow:
+To enable the template linter rule, edit the file `.template-lintrc.js` as follow:
 
 ```js
 // .template-lintrc.js

--- a/tests/dummy/app/templates/docs/guide/translating-text.md
+++ b/tests/dummy/app/templates/docs/guide/translating-text.md
@@ -103,7 +103,7 @@ this.intl.t('a_key_that_is_missing', {
 computed properties. For example:
 
 ```js
-import Component from '@ember/component':
+import Component from '@ember/component';
 import { t } from 'ember-intl';
 
 export default Component.extend({
@@ -130,7 +130,7 @@ the `raw` function like in
 [`ember-macro-helpers`](https://github.com/kellyselden/ember-macro-helpers#raw).
 
 ```js
-import Component from '@ember/component':
+import Component from '@ember/component';
 import { raw, t } from 'ember-intl';
 
 export default Component.extend({
@@ -155,7 +155,7 @@ correct `raw` with `ember-intl` and `ember-awesome-macros` / `ember-macro-helper
 directly to access other methods from the `intl` service. It looks like this:
 
 ```js
-import Component from '@ember/component':
+import Component from '@ember/component';
 import { intl } from 'ember-intl';
 
 export default Component.extend({

--- a/tests/dummy/app/templates/docs/guide/translating-text.md
+++ b/tests/dummy/app/templates/docs/guide/translating-text.md
@@ -164,7 +164,7 @@ export default Component.extend({
 
   nowFormatted: intl('now', 'dateFormat', function(intl/*, propertyKey, instance */) {
     return intl.formatDate(this.now, {
-      format: this.format
+      format: this.dateFormat
     });
   })
 });


### PR DESCRIPTION


Hi there

I've spotted some typos in ember-intl's documentation and tried to resolve them.
