### PR TITLE
chore: remove time-zone comment in format-list test

### DIFF
--- a/tests/unit/helpers/format-list-test.ts
+++ b/tests/unit/helpers/format-list-test.ts
@@ -19,7 +19,6 @@ module('format-list-test', function (hooks) {
     assert.expect(1);
     this.set('example', ['foo', 'bar']);
 
-    // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
     await render(hbs`{{format-list this.example}}`);
     assert.strictEqual(this.element.textContent, 'foo and bar');
   });


### PR DESCRIPTION
Hey there

I removed this unexpected time-zone comment within the format-list helper test.