### PR TITLE
fix: Filepath matching is overly-eager when namespace wrapping

### DIFF
--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -28,7 +28,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
     for (let addon of normalizedAddonNames) {
       let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
 
-      if (dirname.startsWith(addonPrefix)) {
+      if (`${dirname}/`.startsWith(`${addonPrefix}/`)) {
         prefix = addonPrefix;
         break;
       }

--- a/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
+++ b/tests-node/unit/broccoli/translation-reducer/wrap-with-namespace-if-needed.js
@@ -89,6 +89,13 @@ describe('wrapWithNamespaceIfNeeded', function () {
       '/tmp/broccoli_debug-output_path-l4iBcmcT',
       ['@a-scoped/addon', 'other-addon', 'an-addon'],
     ],
+    [
+      { a: true, b: false },
+      { a: true, b: false },
+      `/tmp/broccoli_debug-output_path-l4iBcmcT/${enums.addonNamespace}/foo-bar/en-us.json`,
+      '/tmp/broccoli_debug-output_path-l4iBcmcT',
+      ['foo', 'foo-bar'],
+    ],
   ].forEach(([object, expected, filepath, inputPath, addonNames]) => {
     it(`${JSON.stringify(object)} -> ${JSON.stringify(expected)}`, function () {
       expect(wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames)).to.deep.equal(expected);


### PR DESCRIPTION
When the `wrapWithNamespaceIfNeeded` function runs in a project that has two or more addons sharing an initial substring (e.g addons named `foo` and `foo-bar`), the filepath to addon prefix matching can match an addon to the incorrect filepath. This is because the final separator is not used in the match, resulting in `'/path/to/addon/foo-bar'.startsWith('path/to/addon/foo')` evaluating to `true`, which in turn results in an inappropriately wrapped namespace of `-bar`, causing translation path lookups to fail.

The solution is to take the final path separator into account for the filepath matching, so that `'/path/to/addon/foo-bar/'.startsWith('path/to/addon/foo'/)` correctly evaluates to `false`.