### PR TITLE
Enable embroider test scenarios (with allowedToFail set to true)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,8 +98,8 @@ jobs:
           - 'ember-beta'
           - 'ember-canary'
           - 'ember-classic'
-          # - 'embroider-safe'
-          # - 'embroider-optimized'
+          - 'embroider-safe'
+          - 'embroider-optimized'
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -82,7 +82,7 @@ jobs:
         run: yarn install --no-lockfile
 
       - name: Test
-        run: yarn test:ember
+        run: yarn test
 
 
   try-scenarios:
@@ -115,7 +115,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test
-        run: yarn test:ember-compatibility ${{ matrix.scenario }} --- yarn test:ember
+        run: yarn test:ember-compatibility ${{ matrix.scenario }} --- yarn test
 
 
   deploy-documentation:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -65,8 +65,8 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      embroiderSafe({ allowedToFail: true }),
+      embroiderOptimized({ allowedToFail: true }),
     ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
-    "@embroider/test-setup": "^1.8.0",
+    "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@glint/core": "^0.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,10 +1250,10 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-1.8.0.tgz#e96926f4367f7ae63e824eb8e26dba6c9b27e1e4"
-  integrity sha512-ooD7oDFH7/OMAtRuE4PKqNcjYLZAg/EF/tDaYY1xFGbllELm99bjp1s2Sr5UTsWxH8Pl69C+G4GJN2BJmGGOfA==
+"@embroider/test-setup@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-2.1.1.tgz#1cf613f479ed120fdc5d71cb834c8fb71514cce1"
+  integrity sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"


### PR DESCRIPTION
While looking at the repo, it seems that Embroider test scenarios were disabled/never activated.

This enables the two `embroiderSafe` and `embroiderOptimized`, and allows them to fail so it doesn't block the CI for now.

This should help https://github.com/ember-intl/ember-intl/issues/1747