### PR TITLE
Replaced the slash character with path.sep (account for Windows)

### DIFF
--- a/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -30,7 +30,7 @@ function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
     for (let addon of normalizedAddonNames) {
       let addonPrefix = `${path.sep}${enums.addonNamespace}${path.sep}${addon}`;
 
-      if (`${dirname}/`.startsWith(`${addonPrefix}/`)) {
+      if (`${dirname}${path.sep}`.startsWith(`${addonPrefix}${path.sep}`)) {
         prefix = addonPrefix;
         break;
       }


### PR DESCRIPTION
## Why?

Patches #1748.

In #1757, when I tried to set up CI to run the Node tests on Windows, I found that the `/` causes the tests to fail.


## Solution?

I replaced `/` with `path.sep`, like we had done in line 29 in #1725.

We really need to check the Node tests on Windows in CI. However, `yarn install` would stall in CI, a [problem that I might have faced back in #1725](https://github.com/ember-intl/ember-intl/pull/1725#issuecomment-1273384273). (See the possibly [related issue in `yarn`](https://github.com/yarnpkg/yarn/issues/4890).)

After releasing `6.0.0-beta.5`, consider replacing `yarn` with `pnpm` (`pnpm@v6` seemed to require Node 16 in CI).
