### PR TITLE
Deprecate Ember 3.24 and Node 14

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CI: true
-  NODE_VERSION: 14
+  NODE_VERSION: 16
 
 jobs:
   lint:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,7 +63,6 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - 'ember-lts-3.24'
           - 'ember-lts-3.28'
           - 'ember-lts-4.4'
           - 'ember-lts-4.8'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ ember install ember-intl
 - [4.x (legacy)](https://ember-intl.github.io/ember-intl/versions/v4.4.0/)
 
 
+## Compatibility
+
+* Ember.js v3.28 or above
+* Node.js v16 or above
+
+
 ## Migrating from ember-i18n
 
 There's an [ember-i18n-to-intl-migrator tool](https://github.com/DockYard/ember-i18n-to-intl-migrator) that is used to convert your translations files and application code to ember-intl.

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,14 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     }
   },
   "engines": {
-    "node": "14.* || >= 16"
+    "node": "16.* || >= 18"
   },
   "changelog": {
     "labels": {


### PR DESCRIPTION
## Why?

Node dropped support for `14.x` on April 30. By using Node 16 as the minimum version, the floating dependencies check may pass again, and we can update some of the development dependencies to the latest.

Similarly, Ember has dropped support for `3.24` and `3.28`. But, for now, we'll continue to support `3.28`, but only by running the tests in CI.
