### PR TITLE
Checked the Node tests on Windows in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,6 +133,27 @@ jobs:
         run: yarn test:node
 
 
+  test-node-windows:
+    name: Test (Node, Windows)
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn test:node
+
+
   deploy-documentation:
     name: Deploy documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why?

Retried #1757. Let's check if using Node 14 was the issue that had caused `yarn install` to stall.

Current findings:

- Even when Node 16 is used, running `yarn install` stalls on Windows in CI. It may be that the project dependencies are listed correctly?
