### PR TITLE
Limited TypeScript v4 support to 4.8 and 4.9. Expanded TS support to 5.x.

### DIFF
--- a/addon-test-support/-private/pick-last-locale.ts
+++ b/addon-test-support/-private/pick-last-locale.ts
@@ -1,9 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore We don't want to bring along extra baggage, when installed in a
-// host project.
+// @ts-expect-error: We don't want to bring along extra baggage, when installed
+// in a host project.
 import castArray from 'lodash.castarray';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error: same as above
 import last from 'lodash.last';
 
 /**

--- a/addon-test-support/-private/serialize-translation.ts
+++ b/addon-test-support/-private/serialize-translation.ts
@@ -1,6 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore We don't want to bring along extra baggage, when installed in a
-// host project.
+// @ts-expect-error We don't want to bring along extra baggage, when installed
+// in a host project.
 import omit from 'lodash.omit';
 
 /**

--- a/addon/-private/error-types.ts
+++ b/addon/-private/error-types.ts
@@ -7,8 +7,7 @@ import { ErrorCode } from 'intl-messageformat';
  * @private
  * @hide
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore If the consuming project uses `--isolatedModules`, `const enums`
+// If the consuming project uses `--isolatedModules`, `const enums`
 // may not be used. Since `ember-cli-babel` does not care for `const enums`
 // _anyway_ , this is not an issue.
 export const MISSING_INTL_API = ErrorCode.MISSING_INTL_API;

--- a/addon/-private/formatters/format-message.ts
+++ b/addon/-private/formatters/format-message.ts
@@ -35,14 +35,12 @@ function escapeOptions<T extends Record<string, unknown>>(object?: T) {
       // formatter won't know what to do with it. Instead, we cast
       // the SafeString to a regular string using `toHTML`.
       // Since it was already marked as safe we should *not* escape it.
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error: see comment above
       escapedOpts[key] = val.toHTML();
     } else if (typeof val === 'string') {
       escapedOpts[key] = escapeExpression(val);
     } else {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error: see comment above
       escapedOpts[key] = val; // copy as-is
     }
   });

--- a/addon/macros/intl.ts
+++ b/addon/macros/intl.ts
@@ -130,8 +130,7 @@ export default function intl<T>(
   ) {
     if (!this[__intlInjectionName]) {
       defineProperty(this, __intlInjectionName, {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore: https://github.com/typed-ember/ember-cli-typescript/issues/1471
+        // @ts-expect-error: https://github.com/typed-ember/ember-cli-typescript/issues/1471
         value: getOwner(this).lookup('service:intl'),
         enumerable: false,
       });

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "webpack": "^5.88.1"
   },
   "peerDependencies": {
-    "typescript": "4"
+    "typescript": "^4.8.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "qunit-dom": "^2.0.0",
     "testdouble": "^3.18.0",
     "testdouble-qunit": "^3.0.3",
-    "typescript": "^4.7.4",
+    "typescript": "^5.2.2",
     "webpack": "^5.88.1"
   },
   "peerDependencies": {

--- a/tests/integration/helpers/format-date-test.ts
+++ b/tests/integration/helpers/format-date-test.ts
@@ -78,7 +78,7 @@ module('Integration | Helper | format-date', function (hooks) {
 
   test('it should return a formatted string from a date string', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-date this.dateString timeZone='UTC'}}
     `);
 
@@ -87,7 +87,7 @@ module('Integration | Helper | format-date', function (hooks) {
 
   test('it should return a formatted string from a timestamp', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-date this.date timeZone='UTC'}}
     `);
 
@@ -95,7 +95,7 @@ module('Integration | Helper | format-date', function (hooks) {
   });
 
   test('it should return a formatted string of just the date', async function (this: TestContext, assert) {
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-date
         this.date
         hour="numeric"

--- a/tests/integration/helpers/format-message-(html)-test.ts
+++ b/tests/integration/helpers/format-message-(html)-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { htmlSafe } from '@ember/template';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -147,7 +146,7 @@ module('Integration | Helper | format-message (HTML)', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       '<strong>Hello Jason</strong>',
     );
@@ -159,7 +158,7 @@ module('Integration | Helper | format-message (HTML)', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       '&lt;em&gt;BAR&lt;/em&gt;',
     );
@@ -171,7 +170,7 @@ module('Integration | Helper | format-message (HTML)', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       '<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>',
     );
@@ -181,7 +180,7 @@ module('Integration | Helper | format-message (HTML)', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       '<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>',
     );

--- a/tests/integration/helpers/format-message-test.ts
+++ b/tests/integration/helpers/format-message-test.ts
@@ -1,10 +1,20 @@
 import { findAll, render, rerender } from '@ember/test-helpers';
 import { tracked } from '@glimmer/tracking';
 import { hbs } from 'ember-cli-htmlbars';
-import type { TestContext } from 'ember-intl/test-support';
+import type { TestContext as BaseTestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+
+interface TestContext extends BaseTestContext {
+  census_date?: number;
+  city?: string;
+  harvests?: { count: number; person: string }[];
+  instance?: SomeClass;
+  population?: number;
+  timeZone?: string;
+  translation?: string;
+}
 
 class SomeClass {
   @tracked someCondition = true;
@@ -85,7 +95,7 @@ module('Integration | Helper | format-message', function (hooks) {
         '{city} has a population of {population, number, integer} as of {census_date, date, long}.',
     });
 
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-message
         this.translation
         city=this.city
@@ -112,7 +122,7 @@ module('Integration | Helper | format-message', function (hooks) {
         '{city} hat eine Bevölkerung von {population, number, integer} zum {census_date, date, long}.',
     });
 
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-message
         this.translation
         city=this.city
@@ -139,7 +149,7 @@ module('Integration | Helper | format-message', function (hooks) {
         '{person} harvested {count, plural, one {# apple} other {# apples}}.',
     });
 
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{#each this.harvests as |harvest|}}
         <div data-test-output>
           {{format-message this.translation person=harvest.person count=harvest.count}}
@@ -200,7 +210,7 @@ module('Integration | Helper | format-message', function (hooks) {
   }, assert) {
     this.instance = new SomeClass();
 
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-message this.instance.translation}}
     `);
 

--- a/tests/integration/helpers/format-number-test.ts
+++ b/tests/integration/helpers/format-number-test.ts
@@ -166,8 +166,7 @@ module('Integration | Helper | format-number', function (hooks) {
     this.intl.setLocale('de-de');
     await rerender();
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore: this.element exists
+    // @ts-expect-error: this.element exists
     const value = escape(this.element.textContent!.trim());
 
     assert.true(

--- a/tests/integration/helpers/format-time-test.ts
+++ b/tests/integration/helpers/format-time-test.ts
@@ -1,9 +1,7 @@
-import {
-  render,
-  type TestContext as BaseTestContext,
-} from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type IntlService from 'ember-intl/services/intl';
+import type { TestContext as BaseTestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -11,7 +9,6 @@ import { module, test } from 'qunit';
 interface TestContext extends BaseTestContext {
   date: number;
   dateString: string;
-  intl: IntlService;
 }
 
 module('Integration | Helper | format-time', function (hooks) {
@@ -78,7 +75,7 @@ module('Integration | Helper | format-time', function (hooks) {
 
   test('it should return a formatted string from a date string', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-time this.dateString timeZone='UTC'}}
     `);
 
@@ -87,7 +84,7 @@ module('Integration | Helper | format-time', function (hooks) {
 
   test('it should return a formatted string formatted with formatConfig key', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-time this.dateString format='example'}}
     `);
 
@@ -96,7 +93,7 @@ module('Integration | Helper | format-time', function (hooks) {
 
   test('it should return a formatted string formatted using formatConfig key with inline locale', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-time this.dateString locale='de' format='example'}}
     `);
 
@@ -105,7 +102,7 @@ module('Integration | Helper | format-time', function (hooks) {
 
   test('it should return a formatted string from a timestamp', async function (this: TestContext, assert) {
     // Must provide `timeZone` because: https://github.com/ember-intl/ember-intl/issues/21
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-time this.date timeZone='UTC'}}
     `);
 
@@ -113,7 +110,7 @@ module('Integration | Helper | format-time', function (hooks) {
   });
 
   test('it should return a formatted string of just the time', async function (this: TestContext, assert) {
-    await render(hbs`
+    await render<TestContext>(hbs`
       {{format-time this.date hour='numeric' minute='numeric' timeZone='UTC'}}
     `);
 

--- a/tests/integration/helpers/t-test.ts
+++ b/tests/integration/helpers/t-test.ts
@@ -1,17 +1,14 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import {
-  render,
-  settled,
-  type TestContext as BaseTestContext,
-} from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type IntlService from 'ember-intl/services/intl';
+import type { TestContext as BaseTestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {
-  intl: IntlService;
+  translatedGreeting?: string;
 }
 
 module('Integration | Helper | t', function (hooks) {
@@ -236,7 +233,7 @@ module('Integration | Helper | t', function (hooks) {
 
     this.intl.setLocale(['en-us']);
 
-    await render(hbs`{{this.translatedGreeting}}`);
+    await render<TestContext>(hbs`{{this.translatedGreeting}}`);
 
     assert.dom().hasText('Hello');
 

--- a/tests/integration/helpers/t-test.ts
+++ b/tests/integration/helpers/t-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type IntlService from 'ember-intl/services/intl';
@@ -75,7 +74,7 @@ module('Integration | Helper | t', function (hooks) {
     assert.dom('em').exists({ count: 0 });
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       `<strong>Hello &lt;em&gt;Jason&lt;/em&gt; 42,000</strong>`,
     );
@@ -90,7 +89,7 @@ module('Integration | Helper | t', function (hooks) {
     assert.dom('em').exists({ count: 0 });
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).innerHTML.trim(),
       `<a href="/foo">&lt;em&gt;Jason&lt;/em&gt;</a>`,
     );
@@ -102,7 +101,7 @@ module('Integration | Helper | t', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).textContent.trim(),
       `<strong>Hello Jason 42</strong>`,
     );
@@ -114,7 +113,7 @@ module('Integration | Helper | t', function (hooks) {
     `);
 
     assert.strictEqual(
-      // @ts-ignore: this.element exists
+      // @ts-expect-error: this.element exists
       (this.element as HTMLElement).textContent.trim(),
       `<strong>Hello Jason 39.99</strong>`,
     );

--- a/tests/unit/formatters/format-relative-test.ts
+++ b/tests/unit/formatters/format-relative-test.ts
@@ -1,4 +1,4 @@
-import { createIntl, OnErrorFn } from '@formatjs/intl';
+import { createIntl, type OnErrorFn } from '@formatjs/intl';
 import FormatRelative from 'ember-intl/-private/formatters/format-relative';
 import { module, test } from 'qunit';
 

--- a/tests/unit/macros/t-test.ts
+++ b/tests/unit/macros/t-test.ts
@@ -111,8 +111,7 @@ module('Unit | Macros | t', function (hooks) {
     }).create();
 
     setOwner(object, {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: Type 'IntlService' is not assignable to type 'DIRegistry[Type][Name]'.
+      // @ts-expect-error: Type 'IntlService' is not assignable to type 'DIRegistry[Type][Name]'.
       lookup: (name: string) => {
         assert.strictEqual(
           name,

--- a/tests/unit/services/intl-test.ts
+++ b/tests/unit/services/intl-test.ts
@@ -18,8 +18,7 @@ module('service:init initialization', function (hooks) {
     const localeChanged = td.func();
     const Intl = this.owner.factoryFor('service:intl');
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore: https://github.com/typed-ember/ember-cli-typescript/issues/1471
+    // @ts-expect-error: https://github.com/typed-ember/ember-cli-typescript/issues/1471
     const unsubscribe = Intl.create().onLocaleChanged(localeChanged);
     next(() => {
       assert.verify(localeChanged());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "alwaysStrict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "importsNotUsedAsValues": "error", // enforces type imports when imports are not used as values
+    "verbatimModuleSyntax": true, // enforces type imports when imports are not used as values
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14587,10 +14587,10 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.0.tgz#4a8f512d06fc995167c703a3592219901db8bc79"
   integrity sha512-LQPKVXK8QrBBkL/zclE6YgSWn0I8ew5m0Lf+XL00IwMhlotqRLlzHV+BRrljVQIc+NohUAuQP7mg4HQwrx5Xbg==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
## Why?

Resolves https://github.com/ember-intl/ember-intl/issues/1774
So that consumers can use TS 5 without warnings

## Solution?

* expands (optional) peerDep range to TS 5
* uses TS 5 in the project
* fixes any issues that came up
  * replaced deprecated tsconfig option
  * provided TestContext to render calls that use context ie `await render<TestContext>(...)`
* replaced `@ts-ignore` directives with `@ts-expect-error`, the latter is better as it will error if the type error is fixed - making sure the dev removes the directive when able to do so. It also doesn't require ignoring an eslint rule.