### PR TITLE
Temporarily skipped embroider-safe and embroider-optimized scenarios

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,8 +71,8 @@ jobs:
           - 'ember-beta'
           - 'ember-canary'
           - 'ember-classic'
-          - 'embroider-safe'
-          - 'embroider-optimized'
+          # - 'embroider-safe'
+          # - 'embroider-optimized'
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -81,8 +81,8 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe({ allowedToFail: true }),
-      embroiderOptimized({ allowedToFail: true }),
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };


### PR DESCRIPTION
## Why?

Since CI was last run on July 1, something from the dependencies seems to have changed. The `embroider-optimized` scenario (as well as `embroider-safe`) hangs indefinitely, both in CI for #1776 as well as locally. We can see this problem occur from the CI run for this pull request's 1st commit (note, no code was changed).


## Solution?

In #1749, we had added the two scenarios to CI but configured `ember-try` so that failing tests would still result in a passing CI. I think an incorrectly passing CI doesn't provide us (maintainers as well as end-developers) useful information.

To unblock #1776, I will temporarily skip running `embroider-safe` and `embroider-optimized` scenarios in CI.
