### PR TITLE
Renamed deploy script to deploy-docs to avoid a name colllision with pnpm's deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -224,11 +224,11 @@ jobs:
 
       - name: Deploy the latest documentation
         if: github.ref == 'refs/heads/main'
-        run: pnpm deploy --activate --verbose
+        run: pnpm deploy-docs --activate --verbose
         env:
           # Rebuild the demo application
           ADDON_DOCS_UPDATE_LATEST: 'true'
 
       - name: Deploy the tagged documentation
         if: startsWith(github.ref, 'refs/tags/')
-        run: pnpm deploy --activate --verbose
+        run: pnpm deploy-docs --activate --verbose

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "changelog": "lerna-changelog",
-    "deploy": "ember deploy production",
+    "deploy-docs": "ember deploy production",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:glint": "glint",


### PR DESCRIPTION
## Background

After merging #1765, I saw that [continuous deployment failed](https://github.com/ember-intl/ember-intl/actions/runs/6231820295/job/16913993372).

```sh
Run pnpm deploy --activate --verbose
  pnpm deploy --activate --verbose
  shell: /usr/bin/bash -e {0}
  env:
    NODE_VERSION: 18
    ADDON_DOCS_VERSION_PATH: main
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    ADDON_DOCS_UPDATE_LATEST: true

  ERROR Unknown option: 'activate'
```

The line `pnpm deploy` was interpreted as "[run `pnpm`'s `deploy` command](https://pnpm.io/cli/deploy)," instead of "run the `deploy` script."
