### PR TITLE
Improved DX and documentation

### DIFF
--- a/addon-test-support/-private/make-intl-helper.ts
+++ b/addon-test-support/-private/make-intl-helper.ts
@@ -48,5 +48,3 @@ export function makeIntlHelper(
     return fn(intl, ...args);
   };
 }
-
-export default makeIntlHelper;

--- a/addon-test-support/-private/make-intl-helper.ts
+++ b/addon-test-support/-private/make-intl-helper.ts
@@ -3,7 +3,7 @@ import type Evented from '@ember/object/evented';
 import type Service from '@ember/service';
 import type { TestContext } from '@ember/test-helpers';
 import { getContext } from '@ember/test-helpers';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 
 import type { ConditionalKeys, RemoveFirstFromTuple } from './type-utils';
 

--- a/addon-test-support/-private/pick-last-locale.ts
+++ b/addon-test-support/-private/pick-last-locale.ts
@@ -16,4 +16,3 @@ import last from 'lodash.last';
  */
 export const pickLastLocale = (locale: string | [string, ...string[]]) =>
   last(castArray(locale)) as string;
-export default pickLastLocale;

--- a/addon-test-support/add-translations.ts
+++ b/addon-test-support/add-translations.ts
@@ -2,8 +2,8 @@ import { get } from '@ember/object';
 import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
 
-import makeIntlHelper from './-private/make-intl-helper';
-import pickLastLocale from './-private/pick-last-locale';
+import { makeIntlHelper } from './-private/make-intl-helper';
+import { pickLastLocale } from './-private/pick-last-locale';
 
 // ! Because TypeScript seems to short-circuit overloaded functions when passed
 // as generics, including these overloads would not work with `makeIntlHelper`.

--- a/addon-test-support/add-translations.ts
+++ b/addon-test-support/add-translations.ts
@@ -1,5 +1,5 @@
 import { get } from '@ember/object';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
 
 import makeIntlHelper from './-private/make-intl-helper';

--- a/addon-test-support/set-locale.ts
+++ b/addon-test-support/set-locale.ts
@@ -1,4 +1,4 @@
-import makeIntlHelper from './-private/make-intl-helper';
+import { makeIntlHelper } from './-private/make-intl-helper';
 
 /**
  * Invokes the `setLocale` method of the `intl` service.

--- a/addon-test-support/setup-intl.ts
+++ b/addon-test-support/setup-intl.ts
@@ -1,6 +1,6 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 import type { TOptions } from 'ember-intl/services/intl';
 import type { Formats, Translations } from 'ember-intl/types';
 

--- a/addon-test-support/t.ts
+++ b/addon-test-support/t.ts
@@ -1,4 +1,4 @@
-import makeIntlHelper from './-private/make-intl-helper';
+import { makeIntlHelper } from './-private/make-intl-helper';
 
 /**
  * Invokes the `t` method of the `intl` service.

--- a/addon/-private/utils/is-array-equal.ts
+++ b/addon/-private/utils/is-array-equal.ts
@@ -4,7 +4,7 @@ import { isArray } from '@ember/array';
  * @private
  * @hide
  */
-export default function (a: any, b: any): boolean {
+export default function isArrayEqual(a: any, b: any): boolean {
   if (!isArray(a) || !isArray(b)) {
     return false;
   }

--- a/addon/-private/utils/normalize-locale.ts
+++ b/addon/-private/utils/normalize-locale.ts
@@ -2,7 +2,7 @@
  * @private
  * @hide
  */
-export default function (localeName: string): string | void {
+export default function normalizeLocale(localeName: string): string | void {
   if (typeof localeName === 'string') {
     return localeName.replace(/_/g, '-').toLowerCase();
   }

--- a/addon/-private/utils/parse.ts
+++ b/addon/-private/utils/parse.ts
@@ -1,12 +1,12 @@
-import { parse } from '@formatjs/icu-messageformat-parser';
+import { parse as _parse } from '@formatjs/icu-messageformat-parser';
 
 /**
  * @private
  * @hide
  */
-export default function parseString(string: string) {
+export default function parse(string: string) {
   // ! Sync with `lib/parse-options.js`
-  return parse(string, {
+  return _parse(string, {
     ignoreTag: true,
   });
 }

--- a/addon/helpers/-format-base.d.ts
+++ b/addon/helpers/-format-base.d.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 
-import IntlService from '../services/intl';
+import type IntlService from '../services/intl';
 
 export interface BaseHelperSignature<
   Value,

--- a/addon/helpers/format-date.d.ts
+++ b/addon/helpers/format-date.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatDate']>;
 

--- a/addon/helpers/format-date.js
+++ b/addon/helpers/format-date.js
@@ -5,7 +5,7 @@
 
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatDateHelper extends BaseHelper {
   allowEmpty = true;
 
   format(value, options) {

--- a/addon/helpers/format-list.d.ts
+++ b/addon/helpers/format-list.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatList']>;
 

--- a/addon/helpers/format-list.js
+++ b/addon/helpers/format-list.js
@@ -4,7 +4,7 @@
  */
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatListHelper extends BaseHelper {
   format(value, options) {
     return this.intl.formatList(value, options);
   }

--- a/addon/helpers/format-message.d.ts
+++ b/addon/helpers/format-message.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatMessage']>;
 

--- a/addon/helpers/format-message.js
+++ b/addon/helpers/format-message.js
@@ -5,7 +5,7 @@
 
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatMessageHelper extends BaseHelper {
   format(value, options) {
     return this.intl.formatMessage(value, options);
   }

--- a/addon/helpers/format-number.d.ts
+++ b/addon/helpers/format-number.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatNumber']>;
 

--- a/addon/helpers/format-number.js
+++ b/addon/helpers/format-number.js
@@ -5,7 +5,7 @@
 
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatNumberHelper extends BaseHelper {
   format(value, options) {
     return this.intl.formatNumber(value, options);
   }

--- a/addon/helpers/format-relative.d.ts
+++ b/addon/helpers/format-relative.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatRelative']>;
 

--- a/addon/helpers/format-relative.js
+++ b/addon/helpers/format-relative.js
@@ -5,7 +5,7 @@
 
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatRelativeHelper extends BaseHelper {
   format(params, hash) {
     return this.intl.formatRelative(params, hash);
   }

--- a/addon/helpers/format-time.d.ts
+++ b/addon/helpers/format-time.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['formatTime']>;
 

--- a/addon/helpers/format-time.js
+++ b/addon/helpers/format-time.js
@@ -4,7 +4,7 @@
  */
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class FormatTimeHelper extends BaseHelper {
   format(value, options) {
     return this.intl.formatTime(value, options);
   }

--- a/addon/helpers/t.d.ts
+++ b/addon/helpers/t.d.ts
@@ -1,5 +1,5 @@
-import IntlService from '../services/intl';
-import BaseHelper, { BaseHelperSignature } from './-format-base';
+import type IntlService from '../services/intl';
+import BaseHelper, { type BaseHelperSignature } from './-format-base';
 
 type Params = Parameters<IntlService['t']>;
 

--- a/addon/helpers/t.js
+++ b/addon/helpers/t.js
@@ -5,7 +5,7 @@
 
 import BaseHelper from './-format-base';
 
-export default class extends BaseHelper {
+export default class THelper extends BaseHelper {
   format(key, options) {
     return this.intl.t(key, options);
   }

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,2 +1,2 @@
 export * from './macros';
-export { default as Service } from './services/intl';
+export { default as IntlService } from './services/intl';

--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -1,10 +1,10 @@
-import { EmberRunTimer } from '@ember/runloop/types';
+import type { EmberRunTimer } from '@ember/runloop/types';
 import Service from '@ember/service';
 import type { SafeString } from '@ember/template/-private/handlebars';
-import FormatList from 'ember-intl/-private/formatters/format-list';
 
-import {
+import type {
   FormatDate,
+  FormatList,
   FormatMessage,
   FormatNumber,
   FormatRelative,

--- a/addon/services/intl.d.ts
+++ b/addon/services/intl.d.ts
@@ -129,3 +129,10 @@ export default class IntlService extends Service {
     time: FormatTime;
   };
 }
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    intl: IntlService;
+  }
+}

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -26,7 +26,7 @@ import hydrate from '../-private/utils/hydrate';
 import isArrayEqual from '../-private/utils/is-array-equal';
 import normalizeLocale from '../-private/utils/normalize-locale';
 
-export default class extends Service {
+export default class IntlService extends Service {
   /**
    * Returns an array of registered locale names
    *

--- a/addon/types.d.ts
+++ b/addon/types.d.ts
@@ -1,7 +1,7 @@
 import type { Formats as BaseFormats } from 'intl-messageformat';
 
-import { RelativeTimeFormatOptions } from './-private/formatters/format-relative';
-import { NestedStructure } from './-private/utils/flatten';
+import type { RelativeTimeFormatOptions } from './-private/formatters/format-relative';
+import type { NestedStructure } from './-private/utils/flatten';
 
 export interface Formats extends Partial<BaseFormats> {
   relative?: Record<string, RelativeTimeFormatOptions>;

--- a/tests/dummy/app/controllers/smoke.ts
+++ b/tests/dummy/app/controllers/smoke.ts
@@ -1,9 +1,8 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
-import type IntlService from 'ember-intl/services/intl';
+import { inject as service, type Registry as Services } from '@ember/service';
 
 export default class SmokeController extends Controller {
-  @service declare intl: IntlService;
+  @service declare intl: Services['intl'];
 
   get areNestedTranslationsWorking(): boolean {
     return this.intl.exists('smoke.parent.child');

--- a/tests/dummy/app/routes/application.ts
+++ b/tests/dummy/app/routes/application.ts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: IntlService;

--- a/tests/integration/helpers/format-date-test.ts
+++ b/tests/integration/helpers/format-date-test.ts
@@ -1,9 +1,9 @@
+import { type Registry as Services } from '@ember/service';
 import {
   render,
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import type IntlService from 'ember-intl/services/intl';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -25,7 +25,7 @@ module('Integration | Helper | format-date', function (hooks) {
   });
 
   test('invoke the formatDate directly', function (this: TestContext, assert) {
-    const intl = this.owner.lookup('service:intl') as IntlService;
+    const intl = this.owner.lookup('service:intl') as Services['intl'];
 
     const output = intl.formatDate(this.date, {
       locale: this.locale,

--- a/tests/integration/helpers/format-time-test.ts
+++ b/tests/integration/helpers/format-time-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 import type { TestContext as BaseTestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';

--- a/tests/integration/helpers/t-test.ts
+++ b/tests/integration/helpers/t-test.ts
@@ -1,6 +1,6 @@
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import type IntlService from 'ember-intl/services/intl';
+import type { IntlService } from 'ember-intl';
 import type { TestContext as BaseTestContext } from 'ember-intl/test-support';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';

--- a/tests/unit/formatters/format-relative-test.ts
+++ b/tests/unit/formatters/format-relative-test.ts
@@ -1,5 +1,5 @@
 import { createIntl, type OnErrorFn } from '@formatjs/intl';
-import FormatRelative from 'ember-intl/-private/formatters/format-relative';
+import { FormatRelative } from 'ember-intl/-private/formatters';
 import { module, test } from 'qunit';
 
 function getIntl(locale: string) {


### PR DESCRIPTION
## Why?

While updating `ember-intl` to `v6.0.0-beta.7` in a production project and fixing errors, I realized that we can improve DX (developer experience) in a couple of ways:

- Define the registry pattern so that developers can write `Services['intl']` to type the `intl` service. They may also import `IntlService` from `ember-intl`.

    ```ts
    // Option 1
    import { service, type Registry as Services } from '@ember/service';
    import Component from '@glimmer/component';

    class MyComponent extends Component {
      @service declare intl: Services['intl'];
    }
    ```

    ```ts
    // Option 2
    import { service } from '@ember/service';
    import type { IntlService } from 'ember-intl';
    import Component from '@glimmer/component';

    class MyComponent extends Component {
      @service declare intl: IntlService;
    }
    ```


- Rename the exported service to `IntlService` so that, because of auto-completion, developers don't accidentally write,

    ```ts
    import { Service } from 'ember-intl';
    ```

    when they really mean,

    ```ts
    import Service from '@ember/service';
    ```

I added the `breaking` label because of the 2nd change.
