### PR TITLE
Enable embroider-safe and embroider-optimized scenarios

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
           - 'ember-beta'
           - 'ember-canary'
           - 'ember-classic'
-          # - 'embroider-safe'
+          - 'embroider-safe'
           # - 'embroider-optimized'
     timeout-minutes: 7
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,7 +97,7 @@ jobs:
           - 'ember-canary'
           - 'ember-classic'
           - 'embroider-safe'
-          # - 'embroider-optimized'
+          - 'embroider-optimized'
     timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo


### PR DESCRIPTION
## Why?

I had to turn off the scenarios in #1777. Now that we have workspaces, it's a good time to check whether `ember-intl` can pass either or both scenarios.

