### PR TITLE
Temporarily cast the return type of the test helper t() to string

### DIFF
--- a/.changeset/stupid-phones-juggle.md
+++ b/.changeset/stupid-phones-juggle.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Temporarily cast the return type of the test helper t() to string

--- a/ember-intl/addon-test-support/t.ts
+++ b/ember-intl/addon-test-support/t.ts
@@ -12,7 +12,7 @@ import type { TOptions } from 'ember-intl/services/intl';
  * @param {object} [options]
  * @return {string}
  */
-export function t(key: string, options?: TOptions) {
+export function t(key: string, options?: TOptions): string {
   const { owner } = getContext() as TestContext;
 
   assert(
@@ -22,5 +22,5 @@ export function t(key: string, options?: TOptions) {
 
   const intl = owner.lookup('service:intl') as IntlService;
 
-  return intl.t(key, options);
+  return intl.t(key, options) as unknown as string;
 }


### PR DESCRIPTION
## Why?

After I installed `ember-intl@6.2.1` in a production app, I encountered TS errors in test files.

```sh
tests/integration/components/my-component.ts:59:23 - error TS2345: Argument of type 'string | SafeString' is not assignable to parameter of type 'string'.
  Type 'SafeString' is not assignable to type 'string'.

59   .hasText(t('some.key'));
```

The regression occurs in version `6.2.0`. Until `6.1.2`, a private method called [`makeIntlHelper()`](https://github.com/ember-intl/ember-intl/blob/v6.1.2/addon-test-support/-private/make-intl-helper.ts#L25-L31) had been used to create the test helper `t()`. That helper had the type of "sometimes `string`, and sometimes `string` or `SafeString`":

```ts
/**
 * Invokes the `t` method of the `intl` service.
 *
 * @function t
 * @param {string} key
 * @param {object} [options]
 * @return {string}
 */
declare const _default: {
    (key: string, options?: (import("../addon/services/intl").TOptions & {
        htmlSafe?: false;
    }) | undefined): string;
    (key: string, options: import("../addon/services/intl").TOptions & {
        htmlSafe: true;
    }): string | import("@ember/template/-private/handlebars").SafeString;
    (key: string, options?: import("../addon/services/intl").TOptions | undefined): string | import("@ember/template/-private/handlebars").SafeString;
};
export default _default;
```


## Solution?

Since `6.1.0`, a few type-related issues have been reported. Until we can fix the underlying issues, I will temporarily cast the return type of `t()` to be `string`.
