### PR TITLE
Removed copyright comments

### DIFF
--- a/.changeset/friendly-stingrays-clean.md
+++ b/.changeset/friendly-stingrays-clean.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Removed copyright comments

--- a/ember-intl/addon/-private/formatters/-base.ts
+++ b/ember-intl/addon/-private/formatters/-base.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import type { SafeString } from '@ember/template/-private/handlebars';
 import type { IntlShape } from '@formatjs/intl';
 

--- a/ember-intl/addon/-private/formatters/format-date.ts
+++ b/ember-intl/addon/-private/formatters/format-date.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import type { FormatDateOptions, IntlShape } from '@formatjs/intl';
 
 import Formatter from './-base';

--- a/ember-intl/addon/-private/formatters/format-list.ts
+++ b/ember-intl/addon/-private/formatters/format-list.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import type { FormatListOptions, IntlShape } from '@formatjs/intl';
 
 import Formatter from './-base';

--- a/ember-intl/addon/-private/formatters/format-message.ts
+++ b/ember-intl/addon/-private/formatters/format-message.ts
@@ -1,7 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { htmlSafe, isHTMLSafe } from '@ember/template';
 import type { SafeString } from '@ember/template/-private/handlebars';

--- a/ember-intl/addon/-private/formatters/format-number.ts
+++ b/ember-intl/addon/-private/formatters/format-number.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import type { FormatNumberOptions, IntlShape } from '@formatjs/intl';
 
 import Formatter from './-base';

--- a/ember-intl/addon/-private/formatters/format-relative.ts
+++ b/ember-intl/addon/-private/formatters/format-relative.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import { assert } from '@ember/debug';
 import type { FormatRelativeTimeOptions, IntlShape } from '@formatjs/intl';
 

--- a/ember-intl/addon/-private/formatters/format-time.ts
+++ b/ember-intl/addon/-private/formatters/format-time.ts
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 import type { FormatDateOptions, IntlShape } from '@formatjs/intl';
 
 import Formatter from './-base';

--- a/ember-intl/addon/services/intl.js
+++ b/ember-intl/addon/services/intl.js
@@ -1,7 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
 import { getOwner } from '@ember/application';
 import { makeArray } from '@ember/array';
 import { assert } from '@ember/debug';

--- a/ember-intl/app/helpers/format-date.js
+++ b/ember-intl/app/helpers/format-date.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-date';

--- a/ember-intl/app/helpers/format-list.js
+++ b/ember-intl/app/helpers/format-list.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-list';

--- a/ember-intl/app/helpers/format-message.js
+++ b/ember-intl/app/helpers/format-message.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-message';

--- a/ember-intl/app/helpers/format-number.js
+++ b/ember-intl/app/helpers/format-number.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-number';

--- a/ember-intl/app/helpers/format-relative.js
+++ b/ember-intl/app/helpers/format-relative.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-relative';

--- a/ember-intl/app/helpers/format-time.js
+++ b/ember-intl/app/helpers/format-time.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/format-time';

--- a/ember-intl/app/helpers/t.js
+++ b/ember-intl/app/helpers/t.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/helpers/t';

--- a/ember-intl/app/services/intl.js
+++ b/ember-intl/app/services/intl.js
@@ -1,6 +1,1 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 export { default } from 'ember-intl/services/intl';

--- a/ember-intl/blueprints/ember-intl/index.js
+++ b/ember-intl/blueprints/ember-intl/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
 const { join } = require('node:path');
 
 module.exports = {

--- a/ember-intl/blueprints/translation/index.js
+++ b/ember-intl/blueprints/translation/index.js
@@ -1,10 +1,5 @@
 'use strict';
 
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 const SilentError = require('silent-error');
 const isValidLocaleFormat = require('../../lib/utils/is-valid-locale-format');
 

--- a/ember-intl/index.js
+++ b/ember-intl/index.js
@@ -1,10 +1,5 @@
 /* eslint-env node */
 
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 'use strict';
 
 const { existsSync } = require('node:fs');

--- a/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -1,8 +1,3 @@
-/**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
 const CachingWriter = require('broccoli-caching-writer');
 const stringify = require('json-stable-stringify');
 const extend = require('extend');

--- a/ember-intl/lib/broccoli/translation-reducer/utils/for-each-message.js
+++ b/ember-intl/lib/broccoli/translation-reducer/utils/for-each-message.js
@@ -1,9 +1,4 @@
 /**
- * Copyright 2015, Yahoo! Inc.
- * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
- */
-
-/**
  * Flattens the `messages` object and calls `fn` with a key describing
  * the path to the message and the message itself.
  */


### PR DESCRIPTION
## Why?

I think the copyright comments may be outdated (written in 2015, under a difference license). Let's point end-developers to `LICENSE.md` for a single source of truth.