### PR TITLE
Allowed the intl service to handle removing event listeners

### DIFF
--- a/.changeset/shaggy-rivers-search.md
+++ b/.changeset/shaggy-rivers-search.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app": patch
+---
+
+Allowed the intl service to handle removing event listeners

--- a/ember-intl/addon/helpers/format-date.ts
+++ b/ember-intl/addon/helpers/format-date.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatDateHelper extends Helper<FormatDateSignature> {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/format-list.ts
+++ b/ember-intl/addon/helpers/format-list.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatListHelper extends Helper<FormatListSignature> {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/format-message.ts
+++ b/ember-intl/addon/helpers/format-message.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatMessageHelper extends Helper<FormatMessageSignature> 
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/format-number.ts
+++ b/ember-intl/addon/helpers/format-number.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatNumberHelper extends Helper<FormatNumberSignature> {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/format-relative.ts
+++ b/ember-intl/addon/helpers/format-relative.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatRelativeHelper extends Helper<FormatRelativeSignature
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/format-time.ts
+++ b/ember-intl/addon/helpers/format-time.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class FormatTimeHelper extends Helper<FormatTimeSignature> {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/helpers/t.ts
+++ b/ember-intl/addon/helpers/t.ts
@@ -1,5 +1,4 @@
 import Helper from '@ember/component/helper';
-import { registerDestructor } from '@ember/destroyable';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -26,10 +25,8 @@ export default class THelper extends Helper<TSignature> {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    registerDestructor(this, () => {
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(this.recompute, this);
-    });
+    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
+    this.intl.onLocaleChanged(this.recompute, this);
   }
 
   compute(

--- a/ember-intl/addon/services/intl.d.ts
+++ b/ember-intl/addon/services/intl.d.ts
@@ -129,7 +129,7 @@ export default class IntlService extends Service {
     time: FormatTime;
   };
 
-  private onLocaleChanged(fn: any, context: any): () => void;
+  private onLocaleChanged(fn: any, context: any): void;
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your services.

--- a/ember-intl/addon/services/intl.js
+++ b/ember-intl/addon/services/intl.js
@@ -1,6 +1,7 @@
 import { getOwner } from '@ember/application';
 import { makeArray } from '@ember/array';
 import { assert } from '@ember/debug';
+import { registerDestructor } from '@ember/destroyable';
 import { dependentKeyCompat } from '@ember/object/compat';
 import { cancel, next } from '@ember/runloop';
 import Service from '@ember/service';
@@ -342,14 +343,13 @@ export default class IntlService extends Service {
    * @private
    * @param fn
    * @param context
-   * @returns {Function} unsubscribed from localeChanged
    */
   onLocaleChanged(fn, context) {
     this._ee.on('localeChanged', fn, context);
 
-    return () => {
+    registerDestructor(this, () => {
       this._ee.off('localeChanged', fn, context);
-    };
+    });
   }
 }
 


### PR DESCRIPTION
## Why?

After installing `ember-intl@6.3.1`, I saw that CI for a production app failed due to "lookup errors":

<details>

<summary>Example 1</summary>

```sh
actual: >
  null
stack: >
  Error: Can not call `.lookup` after the owner has been destroyed
    at Container.lookup
    at Class.lookup
    at FormatNumberHelper.getInjection
    at untrack
    at ComputedProperty.get
    at FormatNumberHelper.getter [as intl]
```

</details>

<details>

<summary>Example 2</summary>

```sh
actual: >
  null
stack: >
  Error: Can not call `.lookup` after the owner has been destroyed
    at Container.lookup
    at Class.lookup
    at THelper.getInjection
    at untrack
    at ComputedProperty.get
    at THelper.getter [as intl]
```

</details>

The bug happens in `v6.3.0`, when I decided to use [`registerDestructor()` from `@ember/destroyable`](https://api.emberjs.com/ember/5.4/functions/@ember%2Fdestroyable/registerDestructor), instead of [the `willDestroy()` hook from the `Helper` class](https://api.emberjs.com/ember/5.4/classes/Helper/methods/destroy?anchor=destroy).


## Solution?

Since the `intl` service is the one who emits the `localeChanged` event, I think it's better if the service is responsible for adding and removing the event listeners (instead of the helpers). So I moved the `registerDestructor` code to the `intl` service.
