### PR TITLE
Allowed the test helper setLocale() to call settled()

### DIFF
--- a/.changeset/eleven-foxes-shout.md
+++ b/.changeset/eleven-foxes-shout.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": minor
+"test-app": patch
+---
+
+Allowed the test helper setLocale() to call settled()

--- a/ember-intl/addon-test-support/set-locale.ts
+++ b/ember-intl/addon-test-support/set-locale.ts
@@ -1,15 +1,14 @@
 import { assert } from '@ember/debug';
-import type { TestContext } from '@ember/test-helpers';
-import { getContext } from '@ember/test-helpers';
+import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 
 /**
- * Invokes the `setLocale` method of the `intl` service.
+ * Update the locale, as if the end-user had changed it.
  *
  * @function setLocale
  * @param {string|string[]} localeName
  */
-export function setLocale(localeName: string | string[]): void {
+export async function setLocale(localeName: string | string[]): Promise<void> {
   const { owner } = getContext() as TestContext;
 
   assert(
@@ -20,4 +19,6 @@ export function setLocale(localeName: string | string[]): void {
   const intl = owner.lookup('service:intl') as IntlService;
 
   intl.setLocale(localeName);
+
+  await settled();
 }

--- a/test-app/tests/acceptance/smoke-tests-test.ts
+++ b/test-app/tests/acceptance/smoke-tests-test.ts
@@ -1,4 +1,4 @@
-import { settled, visit } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import { setLocale } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'test-app/tests/helpers';
@@ -9,9 +9,7 @@ module('Acceptance | smoke-tests', function (hooks) {
   module('de-de', function () {
     test('We can see translations', async function (assert) {
       await visit('/smoke-tests');
-
-      setLocale(['de-de']);
-      await settled();
+      await setLocale(['de-de']);
 
       assert
         .dom('[data-test-field="Format Number"]')

--- a/test-app/tests/integration/helpers/format-date/input-is-a-date-test.ts
+++ b/test-app/tests/integration/helpers/format-date/input-is-a-date-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: Date;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('23.1.2014');
     });

--- a/test-app/tests/integration/helpers/format-date/input-is-a-string-test.ts
+++ b/test-app/tests/integration/helpers/format-date/input-is-a-string-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: string;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('23.1.2014');
     });

--- a/test-app/tests/integration/helpers/format-date/input-is-an-integer-test.ts
+++ b/test-app/tests/integration/helpers/format-date/input-is-an-integer-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: number;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('23.1.2014');
     });

--- a/test-app/tests/integration/helpers/format-list/input-is-an-array-of-strings-test.ts
+++ b/test-app/tests/integration/helpers/format-list/input-is-an-array-of-strings-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   list: string[];
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('apples, bananas und oranges');
     });

--- a/test-app/tests/integration/helpers/format-message/input-is-an-icu-message-syntax-test.ts
+++ b/test-app/tests/integration/helpers/format-message/input-is-an-icu-message-syntax-test.ts
@@ -6,9 +6,9 @@ import {
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type { IntlService } from 'ember-intl';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 class Population {
   @service declare intl: IntlService;
@@ -84,7 +84,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert
         .dom('[data-test-output]')

--- a/test-app/tests/integration/helpers/format-message/input-is-an-icu-message-syntax-with-html-code-test.ts
+++ b/test-app/tests/integration/helpers/format-message/input-is-an-icu-message-syntax-with-html-code-test.ts
@@ -7,9 +7,9 @@ import {
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type { IntlService } from 'ember-intl';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 class Royalty {
   @service declare intl: IntlService;
@@ -80,7 +80,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert
         .dom('[data-test-output]')

--- a/test-app/tests/integration/helpers/format-number/input-is-a-currency-test.ts
+++ b/test-app/tests/integration/helpers/format-number/input-is-a-currency-test.ts
@@ -6,9 +6,9 @@ import {
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type { IntlService } from 'ember-intl';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 class Currency {
   @service declare intl: IntlService;
@@ -73,7 +73,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText(/12\.345\.678,90\s€/);
     });

--- a/test-app/tests/integration/helpers/format-number/input-is-a-number-test.ts
+++ b/test-app/tests/integration/helpers/format-number/input-is-a-number-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   number: number;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('12.345.678,9');
     });

--- a/test-app/tests/integration/helpers/format-number/input-is-a-percentage-test.ts
+++ b/test-app/tests/integration/helpers/format-number/input-is-a-percentage-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   number: number;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText(/123\s%/);
     });

--- a/test-app/tests/integration/helpers/format-number/input-is-a-unit-test.ts
+++ b/test-app/tests/integration/helpers/format-number/input-is-a-unit-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   number: number;
@@ -48,7 +48,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('1,235 Kilometer pro Stunde');
     });

--- a/test-app/tests/integration/helpers/format-relative/input-is-a-number-test.ts
+++ b/test-app/tests/integration/helpers/format-relative/input-is-a-number-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   number: number;
@@ -44,7 +44,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('vor 1 Jahr');
     });

--- a/test-app/tests/integration/helpers/format-time/input-is-a-date-test.ts
+++ b/test-app/tests/integration/helpers/format-time/input-is-a-date-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: Date;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('18:00');
     });

--- a/test-app/tests/integration/helpers/format-time/input-is-a-string-test.ts
+++ b/test-app/tests/integration/helpers/format-time/input-is-a-string-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: string;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('18:00');
     });

--- a/test-app/tests/integration/helpers/format-time/input-is-an-integer-test.ts
+++ b/test-app/tests/integration/helpers/format-time/input-is-an-integer-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   date: number;
@@ -38,7 +38,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('18:00');
     });

--- a/test-app/tests/integration/helpers/t/data-provided-as-an-object-test.ts
+++ b/test-app/tests/integration/helpers/t/data-provided-as-an-object-test.ts
@@ -3,9 +3,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   data: {
@@ -61,7 +61,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert
         .dom('[data-test-output]')

--- a/test-app/tests/integration/helpers/t/input-is-a-translation-key-test.ts
+++ b/test-app/tests/integration/helpers/t/input-is-a-translation-key-test.ts
@@ -1,8 +1,8 @@
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 module(
   'Integration | Helper | t > input is a translation key',
@@ -27,7 +27,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert.dom('[data-test-output]').hasText('Hallo Welt!');
     });

--- a/test-app/tests/integration/helpers/t/translation-has-html-code-test.ts
+++ b/test-app/tests/integration/helpers/t/translation-has-html-code-test.ts
@@ -4,9 +4,9 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
-import { setupRenderingTest, updateLocale } from 'test-app/tests/helpers';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 
 interface TestContext extends BaseTestContext {
   name: string;
@@ -64,7 +64,7 @@ module(
         </div>
       `);
 
-      await updateLocale('de-de');
+      await setLocale('de-de');
 
       assert
         .dom('[data-test-output]')

--- a/test-app/tests/integration/test-helpers/index-test.ts
+++ b/test-app/tests/integration/test-helpers/index-test.ts
@@ -55,7 +55,7 @@ module('Integration | Test Helpers', function (hooks) {
         `locale was not '${germanLocale} before switching to it`,
       );
 
-      setLocale('de-de');
+      await setLocale('de-de');
       assert.deepEqual(
         this.intl.locale,
         [germanLocale],
@@ -88,7 +88,7 @@ module('Integration | Test Helpers', function (hooks) {
         'addTranslations: if explicit locale give, does not add the translations to currently active locale',
       );
 
-      setLocale(englishLocale);
+      await setLocale(englishLocale);
       assert.strictEqual(
         this.intl.t('some.english.translation'),
         'Good day, sir.',


### PR DESCRIPTION
## Why?

The test helper `setLocale()`, provided until `v6.3.2`, doesn't really help end-developers write rendering and application tests.

While it does hide implementation details (an end-developer doesn't need to know that they are looking up the `intl` service and calling the service's `setLocale()` method), it requires the end-developer to add `await settled();` (or possibly use something from `@ember/runloop`) so that changing the locale has an effect on their application.

From the 1st commit of this pull request, we can see that we have to call `settled()` after `this.intl.setLocale()`—at least, with the _current_ implementation of `ember-intl`. (That is, in future versions, this may not be required.)


## Solution?

I allowed the test helper to call `settled()` so that end-developers don't have to.

In most cases, this change shouldn't break their tests. End-developers will want to search their test files for `setLocale(` and `ember-intl/test-support`, then migrate code as follows:

```diff
- import { render, settled } from '@ember/test-helpers';
+ import { render } from '@ember/test-helpers';
import { hbs } from 'ember-cli-htmlbars';
import { setLocale, setupIntl } from 'ember-intl/test-support';
import { setupRenderingTest } from 'ember-qunit';
import { module, test } from 'qunit';

module('Integration | Component | hello', function (hooks) {
  setupRenderingTest(hooks);
  setupIntl(hooks);

  test('it renders', async function (assert) {
    await render(hbs`
      <Hello @name="Zoey" />
    `);

    assert.dom('[data-test-message]').hasText('Hello, Zoey!');

-     setLocale('de-de');
-     await settled();
+     await setLocale('de-de');

    assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
  });
});
```

I will update the documentations for testing in a separate pull request.