### PR TITLE
Allowed the test helper addTranslations() to call settled() 

### DIFF
--- a/.changeset/tidy-cows-fetch.md
+++ b/.changeset/tidy-cows-fetch.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": minor
+"test-app": patch
+---
+
+Allowed the test helper addTranslations() to call settled()

--- a/ember-intl/addon-test-support/add-translations.ts
+++ b/ember-intl/addon-test-support/add-translations.ts
@@ -1,7 +1,6 @@
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
-import type { TestContext } from '@ember/test-helpers';
-import { getContext } from '@ember/test-helpers';
+import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
 
@@ -14,25 +13,28 @@ function pickLastLocale(localeName: string | string[]): string {
 }
 
 /**
- * Invokes the `addTranslations` method of the `intl` service. The first
- * parameter, the `localeName`, is optional and will default to the last
- * currently enabled locale. This means, that if you invoke this helper with
- * just translations, they will be added to the last locale and all other
- * locales will be tried before.
+ * Adds translations, as if the end-developer had somehow added them.
+ *
+ * The first parameter, `localeName`, is optional and defaults to
+ * the current locale (the last enabled locale). So if you invoke the
+ * test helper with just the translations, they will be added to the
+ * last locale and all other locales will be tried before.
  *
  * @function addTranslations
  * @param {string} [localeName]
  * @param {object} translations
  */
-export function addTranslations(translations: Translations): void;
-export function addTranslations(
+export async function addTranslations(
+  translations: Translations,
+): Promise<void>;
+export async function addTranslations(
   localeName: string,
   translations: Translations,
-): void;
-export function addTranslations(
+): Promise<void>;
+export async function addTranslations(
   localeNameOrTranslations: string | Translations,
   translations?: Translations,
-): void {
+): Promise<void> {
   const { owner } = getContext() as TestContext;
 
   assert(
@@ -48,8 +50,12 @@ export function addTranslations(
 
     intl.addTranslations(localeName, translations);
 
+    await settled();
+
     return;
   }
 
   intl.addTranslations(localeNameOrTranslations, translations!);
+
+  await settled();
 }

--- a/ember-intl/addon-test-support/add-translations.ts
+++ b/ember-intl/addon-test-support/add-translations.ts
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { get } from '@ember/object';
 import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
@@ -44,18 +43,18 @@ export async function addTranslations(
 
   const intl = owner.lookup('service:intl') as IntlService;
 
+  let _localeName: string;
+  let _translations: Translations;
+
   if (typeof localeNameOrTranslations === 'object') {
-    const localeName = pickLastLocale(get(intl, 'locale'));
-    const translations = localeNameOrTranslations;
-
-    intl.addTranslations(localeName, translations);
-
-    await settled();
-
-    return;
+    _localeName = pickLastLocale(intl.locale);
+    _translations = localeNameOrTranslations;
+  } else {
+    _localeName = localeNameOrTranslations;
+    _translations = translations!;
   }
 
-  intl.addTranslations(localeNameOrTranslations, translations!);
+  intl.addTranslations(_localeName, _translations);
 
   await settled();
 }

--- a/ember-intl/addon-test-support/add-translations.ts
+++ b/ember-intl/addon-test-support/add-translations.ts
@@ -37,8 +37,8 @@ export async function addTranslations(
   const { owner } = getContext() as TestContext;
 
   assert(
-    'The current test context has no owner. Did you forget to call `setupTest(hooks)`, `setupContext(this)` or some other test helper?',
-    typeof owner === 'object' && typeof owner.lookup === 'function',
+    'The current test has no owner. To use `addTranslations()`, make sure to call `setupTest()`, `setupRenderingTest()`, or `setupApplicationTest()`.',
+    owner,
   );
 
   const intl = owner.lookup('service:intl') as IntlService;

--- a/ember-intl/addon-test-support/set-locale.ts
+++ b/ember-intl/addon-test-support/set-locale.ts
@@ -12,8 +12,8 @@ export async function setLocale(localeName: string | string[]): Promise<void> {
   const { owner } = getContext() as TestContext;
 
   assert(
-    'The current test context has no owner. Did you forget to call `setupTest(hooks)`, `setupContext(this)` or some other test helper?',
-    typeof owner === 'object' && typeof owner.lookup === 'function',
+    'The current test has no owner. To use `setLocale()`, make sure to call `setupTest()`, `setupRenderingTest()`, or `setupApplicationTest()`.',
+    owner,
   );
 
   const intl = owner.lookup('service:intl') as IntlService;

--- a/ember-intl/addon-test-support/setup-intl.ts
+++ b/ember-intl/addon-test-support/setup-intl.ts
@@ -1,5 +1,7 @@
-import type { TestContext as BaseTestContext } from '@ember/test-helpers';
-import { settled } from '@ember/test-helpers';
+import {
+  settled,
+  type TestContext as BaseTestContext,
+} from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { TOptions } from 'ember-intl/services/intl';
 import type { Formats, Translations } from 'ember-intl/types';

--- a/ember-intl/addon-test-support/t.ts
+++ b/ember-intl/addon-test-support/t.ts
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
-import type { TestContext } from '@ember/test-helpers';
-import { getContext } from '@ember/test-helpers';
+import { getContext, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { TOptions } from 'ember-intl/services/intl';
 
@@ -16,8 +15,8 @@ export function t(key: string, options?: TOptions): string {
   const { owner } = getContext() as TestContext;
 
   assert(
-    'The current test context has no owner. Did you forget to call `setupTest(hooks)`, `setupContext(this)` or some other test helper?',
-    typeof owner === 'object' && typeof owner.lookup === 'function',
+    'The current test has no owner. To use `t()`, make sure to call `setupTest()`, `setupRenderingTest()`, or `setupApplicationTest()`.',
+    owner,
   );
 
   const intl = owner.lookup('service:intl') as IntlService;

--- a/test-app/app/components/lazy-hello.hbs
+++ b/test-app/app/components/lazy-hello.hbs
@@ -1,0 +1,3 @@
+<div data-test-message>
+  {{t "lazy-hello.message" name=@name}}
+</div>

--- a/test-app/app/components/lazy-hello.ts
+++ b/test-app/app/components/lazy-hello.ts
@@ -1,0 +1,17 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface LazyHelloSignature {
+  Args: {
+    name: string;
+  };
+}
+
+const LazyHelloComponent = templateOnlyComponent<LazyHelloSignature>();
+
+export default LazyHelloComponent;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    LazyHello: typeof LazyHelloComponent;
+  }
+}

--- a/test-app/tests/integration/components/lazy-hello-test.ts
+++ b/test-app/tests/integration/components/lazy-hello-test.ts
@@ -1,0 +1,207 @@
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { addTranslations, setupIntl, t } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+module('Integration | Component | lazy-hello', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('en-us', function (nestedHooks) {
+    setupIntl(nestedHooks);
+
+    test('Translations are loaded before the component is rendered', async function (assert) {
+      addTranslations({
+        'lazy-hello': {
+          message: 'Hello, {name}!',
+        },
+      });
+
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      assert
+        .dom('[data-test-message]')
+        .hasText('Hello, Zoey!', 'We can write assertions against a string.')
+        .doesNotIncludeText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'We should not see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'We can write assertions against the test helper t().',
+        );
+    });
+
+    test('Translations are loaded after the component is rendered', async function (assert) {
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      assert
+        .dom('[data-test-message]')
+        .doesNotIncludeText(
+          'Hello, Zoey!',
+          'Before translations are loaded, we cannot write assertions against a string.',
+        )
+        .hasText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'Before translations are loaded, we should see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'Before translations are loaded, we can write assertions against the test helper t().',
+        );
+
+      addTranslations({
+        'lazy-hello': {
+          message: 'Hello, {name}!',
+        },
+      });
+
+      await settled();
+
+      assert
+        .dom('[data-test-message]')
+        .hasText(
+          'Hello, Zoey!',
+          'After translations are loaded, we can write assertions against a string.',
+        )
+        .doesNotIncludeText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'After translations are loaded, we should not see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'After translations are loaded, we can write assertions against the test helper t().',
+        );
+    });
+
+    test('When translations are loaded after rendering, we need to call settled() to see the effect', async function (assert) {
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      addTranslations({
+        'lazy-hello': {
+          message: 'Hello, {name}!',
+        },
+      });
+
+      assert
+        .dom('[data-test-message]')
+        .doesNotIncludeText(
+          'Hello, Zoey!',
+          'BUG: After translations are loaded, we still cannot write assertions against a string.',
+        )
+        .hasText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'BUG: After translations are loaded, we still see the missing-message string.',
+        )
+        .doesNotIncludeText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'BUG: After translations are loaded, we no longer can write assertions against the test helper t().',
+        );
+    });
+  });
+
+  module('de-de', function (nestedHooks) {
+    setupIntl(nestedHooks, 'de-de');
+
+    test('Translations are loaded before the component is rendered', async function (assert) {
+      addTranslations('de-de', {
+        'lazy-hello': {
+          message: 'Hallo, {name}!',
+        },
+      });
+
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      assert
+        .dom('[data-test-message]')
+        .hasText('Hallo, Zoey!', 'We can write assertions against a string.')
+        .doesNotIncludeText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'We should not see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'We can write assertions against the test helper t().',
+        );
+    });
+
+    test('Translations are loaded after the component is rendered', async function (assert) {
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      assert
+        .dom('[data-test-message]')
+        .doesNotIncludeText(
+          'Hallo, Zoey!',
+          'Before translations are loaded, we cannot write assertions against a string.',
+        )
+        .hasText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'Before translations are loaded, we should see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'Before translations are loaded, we can write assertions against the test helper t().',
+        );
+
+      addTranslations('de-de', {
+        'lazy-hello': {
+          message: 'Hallo, {name}!',
+        },
+      });
+
+      await settled();
+
+      assert
+        .dom('[data-test-message]')
+        .hasText(
+          'Hallo, Zoey!',
+          'After translations are loaded, we can write assertions against a string.',
+        )
+        .doesNotIncludeText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'After translations are loaded, we should not see the missing-message string.',
+        )
+        .hasText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'After translations are loaded, we can write assertions against the test helper t().',
+        );
+    });
+
+    test('When translations are loaded after rendering, we need to call settled() to see the effect', async function (assert) {
+      await render(hbs`
+        <LazyHello @name="Zoey" />
+      `);
+
+      addTranslations('de-de', {
+        'lazy-hello': {
+          message: 'Hallo, {name}!',
+        },
+      });
+
+      assert
+        .dom('[data-test-message]')
+        .doesNotIncludeText(
+          'Hallo, Zoey!',
+          'BUG: After translations are loaded, we still cannot write assertions against a string.',
+        )
+        .hasText(
+          't:lazy-hello.message:("name":"Zoey")',
+          'BUG: After translations are loaded, we still see the missing-message string.',
+        )
+        .doesNotIncludeText(
+          t('lazy-hello.message', { name: 'Zoey' }),
+          'BUG: After translations are loaded, we no longer can write assertions against the test helper t().',
+        );
+    });
+  });
+});

--- a/test-app/tests/integration/components/lazy-hello-test.ts
+++ b/test-app/tests/integration/components/lazy-hello-test.ts
@@ -1,4 +1,4 @@
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { addTranslations, setupIntl, t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
@@ -11,7 +11,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
     setupIntl(nestedHooks);
 
     test('Translations are loaded before the component is rendered', async function (assert) {
-      addTranslations({
+      await addTranslations({
         'lazy-hello': {
           message: 'Hello, {name}!',
         },
@@ -54,13 +54,11 @@ module('Integration | Component | lazy-hello', function (hooks) {
           'Before translations are loaded, we can write assertions against the test helper t().',
         );
 
-      addTranslations({
+      await addTranslations({
         'lazy-hello': {
           message: 'Hello, {name}!',
         },
       });
-
-      await settled();
 
       assert
         .dom('[data-test-message]')
@@ -78,7 +76,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
         );
     });
 
-    test('When translations are loaded after rendering, we need to call settled() to see the effect', async function (assert) {
+    test('When translations are loaded after rendering, we need to add await to see the effect', async function (assert) {
       await render(hbs`
         <LazyHello @name="Zoey" />
       `);
@@ -93,15 +91,15 @@ module('Integration | Component | lazy-hello', function (hooks) {
         .dom('[data-test-message]')
         .doesNotIncludeText(
           'Hello, Zoey!',
-          'BUG: After translations are loaded, we still cannot write assertions against a string.',
+          "Because we didn't add `await`, we still cannot write assertions against a string.",
         )
         .hasText(
           't:lazy-hello.message:("name":"Zoey")',
-          'BUG: After translations are loaded, we still see the missing-message string.',
+          "Because we didn't add `await`, we still see the missing-message string.",
         )
         .doesNotIncludeText(
           t('lazy-hello.message', { name: 'Zoey' }),
-          'BUG: After translations are loaded, we no longer can write assertions against the test helper t().',
+          "Because we didn't add `await`, we no longer can write assertions against the test helper t().",
         );
     });
   });
@@ -110,7 +108,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
     setupIntl(nestedHooks, 'de-de');
 
     test('Translations are loaded before the component is rendered', async function (assert) {
-      addTranslations('de-de', {
+      await addTranslations('de-de', {
         'lazy-hello': {
           message: 'Hallo, {name}!',
         },
@@ -153,13 +151,11 @@ module('Integration | Component | lazy-hello', function (hooks) {
           'Before translations are loaded, we can write assertions against the test helper t().',
         );
 
-      addTranslations('de-de', {
+      await addTranslations('de-de', {
         'lazy-hello': {
           message: 'Hallo, {name}!',
         },
       });
-
-      await settled();
 
       assert
         .dom('[data-test-message]')
@@ -177,7 +173,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
         );
     });
 
-    test('When translations are loaded after rendering, we need to call settled() to see the effect', async function (assert) {
+    test('When translations are loaded after rendering, we need to add await to see the effect', async function (assert) {
       await render(hbs`
         <LazyHello @name="Zoey" />
       `);
@@ -192,15 +188,15 @@ module('Integration | Component | lazy-hello', function (hooks) {
         .dom('[data-test-message]')
         .doesNotIncludeText(
           'Hallo, Zoey!',
-          'BUG: After translations are loaded, we still cannot write assertions against a string.',
+          "Because we didn't add `await`, we still cannot write assertions against a string.",
         )
         .hasText(
           't:lazy-hello.message:("name":"Zoey")',
-          'BUG: After translations are loaded, we still see the missing-message string.',
+          "Because we didn't add `await`, we still see the missing-message string.",
         )
         .doesNotIncludeText(
           t('lazy-hello.message', { name: 'Zoey' }),
-          'BUG: After translations are loaded, we no longer can write assertions against the test helper t().',
+          "Because we didn't add `await`, we no longer can write assertions against the test helper t().",
         );
     });
   });

--- a/test-app/tests/integration/test-helpers/index-test.ts
+++ b/test-app/tests/integration/test-helpers/index-test.ts
@@ -62,7 +62,7 @@ module('Integration | Test Helpers', function (hooks) {
         `locale was switched with 'setLocale'`,
       );
 
-      addTranslations({
+      await addTranslations({
         some: {
           german: {
             translation: 'Guten Tag.',
@@ -76,7 +76,7 @@ module('Integration | Test Helpers', function (hooks) {
       );
 
       const englishLocale = 'en-us';
-      addTranslations(englishLocale, {
+      await addTranslations(englishLocale, {
         some: {
           english: {
             translation: 'Good day, sir.',
@@ -159,7 +159,7 @@ module('Integration | Test Helpers', function (hooks) {
       test('hooks were properly executed and translations have been added (1)', async function (this: TestContext, assert) {
         const ENGLISH_LOCALE = 'en-us';
 
-        addTranslations(ENGLISH_LOCALE, {
+        await addTranslations(ENGLISH_LOCALE, {
           some: {
             translation: 'The {foo} is a lie.',
             nested_translation: '{count, plural, =1 {Cake} other {Cakes}}',


### PR DESCRIPTION
## Why?

Similarly to `setLocale()` as described in #1817, the test helper `addTranslations()` doesn't really help end-developers write tests.

Depending on how an end-developer lazily loads translations, they will need to add `await settled();` (or possibly use something from `@ember/runloop`) so that adding translations has an effect on their application.


## Solution?

I allowed the test helper to call `settled()` so that end-developers don't have to.

In most cases, this change shouldn't break their tests. End-developers will want to search their test files for `addTranslations(` and `ember-intl/test-support`, then migrate code as follows:

```diff
- import { render, settled } from '@ember/test-helpers';
+ import { render } from '@ember/test-helpers';
import { hbs } from 'ember-cli-htmlbars';
import { addTranslations, setupIntl } from 'ember-intl/test-support';
import { setupRenderingTest } from 'ember-qunit';
import { module, test } from 'qunit';

module('Integration | Component | lazy-hello', function (hooks) {
  setupRenderingTest(hooks);
  setupIntl(hooks);

  test('it renders', async function (assert) {
    await render(hbs`
      <LazyHello @name="Zoey" />
    `);

    assert
      .dom('[data-test-message]')
      .doesNotIncludeText(
        'Hello, Zoey!',
        'Before translations are loaded, we cannot write assertions against a string.',
      )
      .hasText(
        't:lazy-hello.message:("name":"Zoey")',
        'Before translations are loaded, we should see the missing-message string.',
      )
      .hasText(
        t('lazy-hello.message', { name: 'Zoey' }),
        'Before translations are loaded, we can write assertions against the test helper t().',
      );

-     addTranslations({
-       'lazy-hello': {
-         message: 'Hello, {name}!',
-       },
-     });
-     await settled();
+     await addTranslations({
+       'lazy-hello': {
+         message: 'Hello, {name}!',
+       },
+     });

    assert
      .dom('[data-test-message]')
      .hasText(
        'Hello, Zoey!',
        'After translations are loaded, we can write assertions against a string.',
      )
      .doesNotIncludeText(
        't:lazy-hello.message:("name":"Zoey")',
        'After translations are loaded, we should not see the missing-message string.',
      )
      .hasText(
        t('lazy-hello.message', { name: 'Zoey' }),
        'After translations are loaded, we can write assertions against the test helper t().',
      );
  });
});
```

I will update the documentations for testing in a separate pull request.