### PR TITLE
Updated documentation for testing

### DIFF
--- a/.changeset/afraid-jokes-wash.md
+++ b/.changeset/afraid-jokes-wash.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"docs-app": patch
+---
+
+Updated documentation for testing

--- a/docs-app/app/templates/docs/guide/testing.md
+++ b/docs-app/app/templates/docs/guide/testing.md
@@ -1,47 +1,38 @@
 # Testing
 
-ember-intl provides some convenience test helpers for easy mocking of
-translations and running assertions against translated strings.
+With `ember-intl`'s test helpers, you can check translations under various conditions easily.
 
 
 ## setupIntl(hooks, [locale], [translations])
 
-This helper does two main things:
+In rendering and unit tests, you must add `setupIntl(hooks)` if they depend on `ember-intl`, e.g. you used the `{{t}}` helper in the template, or injected the `intl` service in the class.
 
-- It makes the `intl` service available as `this.intl` in your current test
-  context for easier access.
-- It registers a custom `missing-message` util, that deterministically
-  serializes all not explicitly defined translations. This allows you to focus
-  on the actual logic in your tests and not on providing / mocking translations.
+You can also use `setupIntl()` to set the locale and stub translations. This setup runs as a part of the test module's `beforeEach` hook (e.g. before a component is rendered).
 
-It can be invoked in four different ways.
+In application tests, it's not necessary to call `setupIntl(hooks)`. The only time you might do this is to run a test module with a particular locale.
 
 
 ### setupIntl(hooks)
 
-Just injects `intl` into the context and enables deterministic serialization of
-missing translations. Also take a look at the [`t` helper](#t-key-options-)
-further down, that makes asserting against these translations a breeze.
+The syntax helps you check the default case. That is, what does the user see with the default locale and the translations as provided?
 
-```js
+```ts
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('setupIntl demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it serializes missing translations and injects the `intl` service', async function (assert) {
+  test('it renders', async function (assert) {
     await render(hbs`
-      {{t "some.translation" someVariable="Hello"}}
+      <Hello @name="Zoey" />
     `);
 
-    assert.dom().hasText('t:some.translation:("someVariable":"Hello")');
-
-    assert.strictEqual(this.intl, this.owner.resolve('service:intl'));
+    assert.dom('[data-test-message]').hasText('Hello, Zoey!');
   });
 });
 ```
@@ -49,21 +40,25 @@ module('setupIntl demo', function (hooks) {
 
 ### setupIntl(hooks, locale)
 
-Does what `setupIntl(hooks)` does and also sets the locale. You can also use
-[`setLocale(locale)`](#setlocale-locale-) for that.
+The syntax helps you check the translations for a specific locale.
 
-```js
+```ts
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('setupIntl demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
+  setupIntl(hooks, 'de-de');
 
-  test('it sets the locale', async function (assert) {
-    assert.deepEqual(this.intl.locale, ['en-us']);
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Hello @name="Zoey" />
+    `);
+
+    assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
   });
 });
 ```
@@ -71,42 +66,29 @@ module('setupIntl demo', function (hooks) {
 
 ### setupIntl(hooks, translations)
 
-Does what `setupIntl(hooks)` does and adds translations to the active locale.
-You can also use [`addTranslations([locale], translations)`](#addtranslations-locale-translations-)
-for that.
+The syntax helps you stub the translations for the default locale.
 
-```js
+```ts
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('setupIntl demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, {
-    some: {
-      mocked: {
-        translations: 'Hello {thing}',
-      },
+    hello: {
+      message: 'What\'s up, ${name}?',
     },
   });
 
   test('it renders', async function (assert) {
     await render(hbs`
-      {{t "some.mocked.translation" thing="world"}}
+      <Hello @name="Zoey" />
     `);
 
-    assert.dom().hasText('Hello world');
-
-    // stuff that is not explicitly mocked uses fallback serialization
-    await render(hbs`
-      {{t "some.translation" someVariable="Hello"}}
-    `);
-
-    assert.dom().hasText('t:some.translation:("someVariable":"Hello")');
-
-    assert.strictEqual(this.intl, this.owner.resolve('service:intl'));
+    assert.dom('[data-test-message]').hasText('What\'s up, Zoey?');
   });
 });
 ```
@@ -114,45 +96,29 @@ module('setupIntl demo', function (hooks) {
 
 ### setupIntl(hooks, locale, translations)
 
-Combination of the previous two. Sets the locale and also adds the translations.
-You can also use [`setLocale(locale)`](#setlocale-locale-) and
-[`addTranslations([locale], translations)`](#addtranslations-locale-translations-)
-for that.
+The syntax helps you stub the translations for a specific locale.
 
-```js
+```ts
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('setupIntl demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us', {
-    some: {
-      mocked: {
-        translations: 'Hello {thing}',
-      },
+  setupIntl(hooks, 'de-de', {
+    hello: {
+      message: 'Na, ${name}?',
     },
   });
 
-  test('it sets the locale and mocks the translations', async function (assert) {
-    assert.deepEqual(this.intl.locale, ['en-us']);
-
+  test('it renders', async function (assert) {
     await render(hbs`
-      {{t "some.mocked.translation" thing="world"}}
+      <Hello @name="Zoey" />
     `);
 
-    assert.dom().hasText('Hello world');
-
-    // stuff that is not explicitly mocked uses fallback serialization
-    await render(hbs`
-      {{t "some.translation" someVariable="Hello"}}
-    `);
-
-    assert.dom().hasText('t:some.translation:("someVariable":"Hello")');
-
-    assert.strictEqual(this.intl, this.owner.resolve('service:intl'));
+    assert.dom('[data-test-message]').hasText('Na, Zoey?');
   });
 });
 ```
@@ -160,26 +126,29 @@ module('setupIntl demo', function (hooks) {
 
 ## setLocale(locale)
 
-Behaves as if you called `setLocale(locale)` on the `intl` service.
+Updates the locale as if the user had changed their preferred language.
 
-```js
+```ts
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl, setLocale } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('setLocale demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it sets the locale', async function (assert) {
-    setLocale('en-us');
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Hello @name="Zoey" />
+    `);
 
-    assert.deepEqual(this.intl.locale, ['en-us']);
+    assert.dom('[data-test-message]').hasText('Hello, Zoey!');
 
-    setLocale('de-de');
+    await setLocale('de-de');
 
-    assert.deepEqual(this.intl.locale, ['de-de']);
+    assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
   });
 });
 ```
@@ -187,43 +156,41 @@ module('setLocale demo', function (hooks) {
 
 ## addTranslations([locale], translations)
 
-Behaves as if you called `addTranslations(locale, translations)` on the `intl`
-service. For your convenience you can omit the `locale` parameter and it will
-default to the last currently active locale, meaning that if your current
-locales were `['en-ca', 'en-gb', 'en-us']`, the translations would be added to
-`'en-us'`.
+Updates the translations as if you had somehow added them (e.g. via lazy loading).
 
-```js
+The first parameter, `locale`, is optional and defaults to the last currently active locale. For example, if the current locales are `['en-ca', 'en-gb', 'en-us']`, then the translations will be added to `'en-us'` by default.
+
+```ts
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { addTranslations, setupIntl, setLocale } from 'ember-intl/test-support';
+import { addTranslations, setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('addTranslations demo', function (hooks) {
+module('Integration | Component | lazy-hello', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it adds the translations', async function (assert) {
-    setLocale(['en-ca', 'en-gb', 'en-us']);
+  test('Lazily loaded translations', async function (assert) {
+    await render(hbs`
+      <LazyHello @name="Zoey" />
+    `);
 
-    addTranslations({
-      translation: {
-        on: {
-          enUs: "What?",
-        },
+    assert
+      .dom('[data-test-message]')
+      .doesNotIncludeText('Hello, Zoey!')
+      .hasText('t:lazy-hello.message:("name":"Zoey")');
+
+    await addTranslations({
+      'lazy-hello': {
+        message: 'Hello, {name}!',
       },
     });
 
-    addTranslations('en-ca', {
-      translation: {
-        on: {
-          enCa: 'Eh?',
-        },
-      },
-    });
-
-    assert.true(this.intl.exists('en-us', 'translation.on.enUs'));
-    assert.true(this.intl.exists('en-ca', 'translation.on.enCa'));
+    assert
+      .dom('[data-test-message]')
+      .hasText('Hello, Zoey!')
+      .doesNotIncludeText('t:lazy-hello.message:("name":"Zoey")');
   });
 });
 ```
@@ -231,34 +198,31 @@ module('addTranslations demo', function (hooks) {
 
 ## t(key, [options])
 
-The `t` helper is a shortcut for accessing the `t` method on the `intl` service.
-In combination with the fallback serialization behavior of `setupIntl(hooks)`,
-it becomes especially useful, because you now don't need to worry about how to
-provide translations or mock them for tests.
+Use this test helper if you don't need to check the actual value of a translation, or you _can't_ get the value because of how your project is set up. It returns what the `intl` service's `t()` method would return.
 
-Your case can now focus on testing what you actually want to test: that the
-correct translation is rendered with the correct variables. And not that the
-translation messages are there and correctly interpolated by ember-intl.
+In most cases, we recommend _not_ using this test helper. In essence, you are writing an idempotent statement (`t()` is equal to `t()`), which may be considered useless.
 
-```js
+When possible, pass the actual value to an `.hasText()` or `.includesText()` assertion. This way, you know what your app displayed at a given point of time. If the translation is changed later, you can get immediate feedback from failing assertions. (Was the change correct?)
+
+```ts
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl, t } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('t demo', function (hooks) {
+module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test('it is a shortcut for accessing translations', async function (assert) {
+  test('it renders', async function (assert) {
     await render(hbs`
-      {{t "some.translation" someVariable="Hello"}}
+      <Hello @name="Zoey" />
     `);
 
-    assert.dom().hasText(
-      t('some.translation', { someVariable: 'Hello' })
-    );
+    assert
+      .dom('[data-test-message]')
+      .hasText(t('hello.message', { name: 'Zoey' }));
   });
 });
 ```
@@ -266,13 +230,15 @@ module('t demo', function (hooks) {
 
 ## Guarding against errors
 
-If you have a dynamic, variable driven usage of the `t` helper, you might see an error like `helper requires value attribute`. This might commonly happen in testing environments, where you might not have ensured every single variable has a value, and are trying to test something else entirely. To allow for empty values, you can use `allowEmpty` on the helper itself or you can set it globally for all helpers, by defining you own helper.
+You will likely encounter a runtime error when a helper like `{{t}}` is used without the required data. Such error can perhaps more likely happen in tests, because you didn't initialize all inputs (e.g. a component's arguments).
+
+To prevent runtime errors, you can pass the `allowEmpty` option to the helper (i.e. per invocation). Alternatively, you might overwrite the helper (avoid this approach if possible).
 
 ```js
 // app/helpers/t.js
-import Helper from 'ember-intl/helpers/t';
+import THelper from 'ember-intl/helpers/t';
 
-export default class extends Helper {
+export default class extends THelper {
   allowEmpty = true;
 }
 ```

--- a/ember-intl/addon-test-support/add-translations.ts
+++ b/ember-intl/addon-test-support/add-translations.ts
@@ -3,35 +3,36 @@ import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
 
-function pickLastLocale(localeName: string | string[]): string {
-  if (typeof localeName === 'string') {
-    return localeName;
+function pickLastLocale(locale: string | string[]): string {
+  if (typeof locale === 'string') {
+    return locale;
   }
 
-  return localeName[localeName.length - 1]!;
+  return locale[locale.length - 1]!;
 }
 
 /**
- * Adds translations, as if the end-developer had somehow added them.
+ * Updates the translations as if you had somehow added them (e.g.
+ * via lazy loading).
  *
- * The first parameter, `localeName`, is optional and defaults to
- * the current locale (the last enabled locale). So if you invoke the
- * test helper with just the translations, they will be added to the
- * last locale and all other locales will be tried before.
+ * The first parameter, `locale`, is optional and defaults to the last
+ * currently active locale. For example, if the current locales are
+ * `['en-ca', 'en-gb', 'en-us']`, then the translations will be added
+ * to `'en-us'` by default.
  *
  * @function addTranslations
- * @param {string} [localeName]
+ * @param {string} [locale]
  * @param {object} translations
  */
 export async function addTranslations(
   translations: Translations,
 ): Promise<void>;
 export async function addTranslations(
-  localeName: string,
+  locale: string,
   translations: Translations,
 ): Promise<void>;
 export async function addTranslations(
-  localeNameOrTranslations: string | Translations,
+  localeOrTranslations: string | Translations,
   translations?: Translations,
 ): Promise<void> {
   const { owner } = getContext() as TestContext;
@@ -43,18 +44,18 @@ export async function addTranslations(
 
   const intl = owner.lookup('service:intl') as IntlService;
 
-  let _localeName: string;
+  let _locale: string;
   let _translations: Translations;
 
-  if (typeof localeNameOrTranslations === 'object') {
-    _localeName = pickLastLocale(intl.locale);
-    _translations = localeNameOrTranslations;
+  if (typeof localeOrTranslations === 'object') {
+    _locale = pickLastLocale(intl.locale);
+    _translations = localeOrTranslations;
   } else {
-    _localeName = localeNameOrTranslations;
+    _locale = localeOrTranslations;
     _translations = translations!;
   }
 
-  intl.addTranslations(_localeName, _translations);
+  intl.addTranslations(_locale, _translations);
 
   await settled();
 }

--- a/ember-intl/addon-test-support/set-locale.ts
+++ b/ember-intl/addon-test-support/set-locale.ts
@@ -3,7 +3,7 @@ import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 
 /**
- * Update the locale, as if the end-user had changed it.
+ * Updates the locale as if the user had changed their preferred language.
  *
  * @function setLocale
  * @param {string|string[]} localeName


### PR DESCRIPTION
## Why?

In #1817 and #1818, I updated the test helpers `setLocale()` and `addTranslations()` so that they may be more useful to end-developers.

The documentation for testing hasn't been updated in a while. In particular, the texts for `setupIntl()` covered too much of implementation details.


## Solution?

I updated the texts so that they explain more clearly why a particular test helper, with a particular set of inputs, is useful.

The code examples now show the same component `<Hello>` (plus a lazy-loaded variation `<LazyHello>`) so that readers don't need to switch context.
