### PR TITLE
Rewrote tests for macros

### DIFF
--- a/ember-intl/addon/macros/intl.ts
+++ b/ember-intl/addon/macros/intl.ts
@@ -15,7 +15,7 @@ export type GetterFn<T, C = unknown> = (
  * @private
  * @hide
  */
-export const __intlInjectionName = `intl-${Date.now().toString(
+const __intlInjectionName = `intl-${Date.now().toString(
   36,
 )}` as 'intl-PRIVATE-SYMBOL';
 

--- a/test-app/app/components/macros.hbs
+++ b/test-app/app/components/macros.hbs
@@ -1,0 +1,11 @@
+<div data-test-output="intl">
+  {{this.outputForIntl}}
+</div>
+
+<div data-test-output="t">
+  {{this.outputForT}}
+</div>
+
+<div data-test-output="t-with-raw">
+  {{this.outputForTWithRaw}}
+</div>

--- a/test-app/app/components/macros.ts
+++ b/test-app/app/components/macros.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, ember/no-classic-classes, ember/no-classic-components, ember/no-computed-properties-in-native-classes, import/export */
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service, type Registry as Services } from '@ember/service';
+import type { IntlService } from 'ember-intl';
+import { intl, raw, t } from 'ember-intl/macros';
+
+interface MacrosSignature {
+  Args: {
+    fruits?: string[];
+    name: string;
+  };
+}
+
+type MacrosArgs = MacrosSignature['Args'];
+
+export default interface MacrosComponent extends Component<MacrosArgs> {}
+export default class MacrosComponent extends Component<MacrosSignature> {
+  @service declare intl: Services['intl'];
+
+  tagName = '';
+
+  @computed('intl.{locale,primaryLocale}')
+  get fruits(): string[] {
+    switch (this.intl.primaryLocale) {
+      case 'de-de': {
+        return ['Äpfel', 'Bananen', 'Orangen'];
+      }
+
+      case 'en-us': {
+        return ['Apples', 'Bananas', 'Oranges'];
+      }
+
+      default: {
+        throw new Error('Locale must be de-de or en-us.');
+      }
+    }
+  }
+
+  @intl('fruits', function (_intl: IntlService) {
+    // @ts-expect-error: 'this' implicitly has type 'any' because it does not have a type annotation.
+    return _intl.formatList(this.fruits);
+  })
+  declare outputForIntl: string;
+
+  @t('components.macros-classic.hello.message', {
+    name: 'name',
+  })
+  declare outputForT: string;
+
+  @t('components.macros-classic.hello.message', {
+    name: raw('name'),
+  })
+  declare outputForTWithRaw: string;
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    Macros: MacrosComponent;
+  }
+}

--- a/test-app/app/components/macros.ts
+++ b/test-app/app/components/macros.ts
@@ -12,9 +12,6 @@ interface MacrosSignature {
   };
 }
 
-type MacrosArgs = MacrosSignature['Args'];
-
-export default interface MacrosComponent extends Component<MacrosArgs> {}
 export default class MacrosComponent extends Component<MacrosSignature> {
   @service declare intl: Services['intl'];
 

--- a/test-app/tests/integration/components/macros-test.ts
+++ b/test-app/tests/integration/components/macros-test.ts
@@ -1,0 +1,96 @@
+import { setOwner } from '@ember/application';
+import {
+  render,
+  settled,
+  type TestContext as BaseTestContext,
+} from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+import { hbs } from 'ember-cli-htmlbars';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+class User {
+  @tracked _name = 'Zoey';
+
+  get name(): string {
+    return this._name;
+  }
+
+  set name(name: string) {
+    this._name = name;
+  }
+}
+
+interface TestContext extends BaseTestContext {
+  user: User;
+}
+
+module('Integration | Component | macros', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function (this: TestContext) {
+    this.user = new User();
+
+    // Allow injecting the intl service
+    setOwner(this.user, this.owner);
+  });
+
+  test('it renders', async function (this: TestContext, assert) {
+    await render<TestContext>(hbs`
+      {{! @glint-nocheck }}
+      <Macros
+        @name={{this.user.name}}
+      />
+    `);
+
+    assert
+      .dom('[data-test-output="intl"]')
+      .hasText('Apples, Bananas, and Oranges');
+
+    assert.dom('[data-test-output="t"]').hasText('Hello, Zoey!');
+
+    assert.dom('[data-test-output="t-with-raw"]').hasText('Hello, name!');
+  });
+
+  test('we can update the arguments', async function (this: TestContext, assert) {
+    await render<TestContext>(hbs`
+      {{! @glint-nocheck }}
+      <Macros
+        @name={{this.user.name}}
+      />
+    `);
+
+    this.user.name = 'Tomster';
+
+    await settled();
+
+    assert
+      .dom('[data-test-output="intl"]')
+      .hasText('Apples, Bananas, and Oranges');
+
+    assert.dom('[data-test-output="t"]').hasText('Hello, Tomster!');
+
+    assert.dom('[data-test-output="t-with-raw"]').hasText('Hello, name!');
+  });
+
+  test('we can switch the locale', async function (this: TestContext, assert) {
+    await render<TestContext>(hbs`
+      {{! @glint-nocheck }}
+      <Macros
+        @name={{this.user.name}}
+      />
+    `);
+
+    await setLocale('de-de');
+
+    assert
+      .dom('[data-test-output="intl"]')
+      .hasText('Äpfel, Bananen und Orangen');
+
+    assert.dom('[data-test-output="t"]').hasText('Hallo, Zoey!');
+
+    assert.dom('[data-test-output="t-with-raw"]').hasText('Hallo, name!');
+  });
+});

--- a/test-app/tests/unit/macros/intl-test.ts
+++ b/test-app/tests/unit/macros/intl-test.ts
@@ -1,136 +1,151 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { setOwner } from '@ember/application';
-import EmberObject, { getProperties, set } from '@ember/object';
+import EmberObject, { set } from '@ember/object';
 import { run } from '@ember/runloop';
-import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import { intl } from 'ember-intl/macros';
-import { __intlInjectionName } from 'ember-intl/macros/intl';
-import type {} from 'ember-intl/test-support';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-interface TestContext extends BaseTestContext {
-  ContainerObject: typeof EmberObject;
-  intl: IntlService;
-}
+class ContainerObject extends EmberObject {}
 
-module('Unit | Macros | intl', function (hooks) {
+module('Unit | Macro | intl', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  hooks.beforeEach(function (this: TestContext) {
-    const { owner } = this;
+  test('looks up the intl service through the owner and injects the service invisibly', function (assert) {
+    const intlService = this.owner.lookup('service:intl');
 
-    // eslint-disable-next-line ember/no-classic-classes
-    this.ContainerObject = EmberObject.extend({
-      init() {
-        this._super();
-        setOwner(this, owner);
-      },
-    });
-  });
+    const emberObject = ContainerObject.extend({
+      someProperty: intl(function (_intl: IntlService) {
+        assert.strictEqual(_intl, intlService);
 
-  test('looks up the intl service through the owner and injects the service invisibly', function (this: TestContext, assert) {
-    const object = this.ContainerObject.extend({
-      property: intl((intl) =>
-        assert.strictEqual(
-          intl,
-          this.intl,
-          'service is accessible in CP callback',
-        ),
-      ),
-    }).create();
-
-    object.property;
-
-    assert.ok(
-      Object.getOwnPropertyNames(object).includes(__intlInjectionName),
-      'service is injected',
-    );
-    assert.notOk(
-      Object.keys(object).includes(__intlInjectionName),
-      'service is non-enumerable',
-    );
-  });
-
-  test('does not use or clobber the pre-existing intl injection', function (this: TestContext, assert) {
-    const IDENTITY = {};
-
-    const object = this.ContainerObject.extend({
-      intl: IDENTITY,
-      property: intl((intl) => assert.strictEqual(intl, this.intl)),
-    }).create();
-
-    object.property;
-
-    assert.strictEqual(object.intl, IDENTITY);
-  });
-
-  test('passes the propertyKey, context, and binds to it', function (this: TestContext, assert) {
-    const object = this.ContainerObject.extend({
-      property: intl(function (_intl, propertyKey, ctx) {
-        assert.strictEqual(propertyKey, 'property', 'passes propertyKey');
-        assert.strictEqual(ctx, object, 'passes context');
-        assert.strictEqual(this, object, 'binds to the instance');
+        assert.step('Called intl()');
       }),
     }).create();
 
-    object.property;
+    setOwner(emberObject, this.owner);
+
+    emberObject.get('someProperty');
+
+    const propertyNames = Object.getOwnPropertyNames(emberObject);
+    const keys = Object.keys(emberObject);
+
+    assert.true(
+      propertyNames.some((name) => name.includes('intl-')),
+      'service is injected',
+    );
+
+    assert.false(
+      keys.some((name) => name.includes('intl-')),
+      'service is non-enumerable',
+    );
+
+    assert.verifySteps(['Called intl()']);
   });
 
-  test('uses the return value of the passed function as the computed property value', function (this: TestContext, assert) {
+  test('does not use or clobber the pre-existing intl injection', function (assert) {
+    const intlService = this.owner.lookup('service:intl');
+
     const IDENTITY = {};
 
-    const object = this.ContainerObject.extend({
-      property: intl(() => IDENTITY),
+    const emberObject = ContainerObject.extend({
+      intl: IDENTITY,
+
+      someProperty: intl(function (_intl: IntlService) {
+        assert.strictEqual(_intl, intlService);
+
+        assert.step('Called intl()');
+      }),
     }).create();
 
-    assert.strictEqual(object.property, IDENTITY);
+    setOwner(emberObject, this.owner);
+
+    emberObject.get('someProperty');
+
+    assert.strictEqual(emberObject.get('intl'), IDENTITY);
+
+    assert.verifySteps(['Called intl()']);
   });
 
-  test('listens for locale changes', function (this: TestContext, assert) {
-    this.intl.setLocale(['en-us']);
+  test('passes the propertyKey, context, and binds to it', function (assert) {
+    const emberObject = ContainerObject.extend({
+      someProperty: intl(function (
+        _intl: IntlService,
+        propertyKey: string,
+        ctx: any,
+      ) {
+        assert.strictEqual(propertyKey, 'someProperty');
 
-    const object = this.ContainerObject.extend({
-      property: intl((intl) => intl.locale),
+        assert.strictEqual(ctx, emberObject, 'passes context');
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore: 'this' implicitly has type 'any' because it does not have a type annotation.
+        assert.strictEqual(this, emberObject, 'binds to the instance');
+
+        assert.step('Called intl()');
+      }),
     }).create();
 
-    assert.deepEqual(object.property, ['en-us']);
+    setOwner(emberObject, this.owner);
 
-    run(() => this.intl.setLocale(['de-de']));
-    assert.deepEqual(object.property, ['de-de']);
+    emberObject.get('someProperty');
+
+    assert.verifySteps(['Called intl()']);
   });
 
-  test('accpets further dependent keys', function (this: TestContext, assert) {
-    const dependencies = { dependencyA: 1, dependencyB: 2, dependencyC: 3 };
-    const dependencyKeys = Object.keys(
-      dependencies,
-    ) as (keyof typeof dependencies)[];
+  test('uses the return value of the passed function as the computed property value', function (assert) {
+    const emberObject = ContainerObject.extend({
+      someProperty: intl(function () {
+        return 'some-value';
+      }),
+    }).create();
 
-    const object = this.ContainerObject.extend({
-      ...dependencies,
-      // ! TypeScript can't deal with spreading here, so we specify the keys explicitly
-      property: intl(
-        'dependencyA',
-        'dependencyB',
-        'dependencyC',
-        (_intl, _propertyKey, ctx) =>
-          getProperties(ctx as any, ...dependencyKeys),
+    setOwner(emberObject, this.owner);
+
+    assert.strictEqual(emberObject.get('someProperty'), 'some-value');
+  });
+
+  test('listens for locale changes', async function (assert) {
+    const emberObject = ContainerObject.extend({
+      someProperty: intl((_intl: IntlService) => {
+        return _intl.locale;
+      }),
+    }).create();
+
+    setOwner(emberObject, this.owner);
+
+    assert.deepEqual(emberObject.get('someProperty'), ['en-us']);
+
+    await setLocale('de-de');
+
+    assert.deepEqual(emberObject.get('someProperty'), ['de-de']);
+  });
+
+  test('accpets further dependent keys', function (assert) {
+    const emberObject = ContainerObject.extend({
+      key1: 1,
+      key2: 2,
+
+      someProperty: intl(
+        'key1',
+        'key2',
+        function (_intl: IntlService, _propertyKey: string, ctx: any) {
+          return [ctx.key1, ctx.key2].join(', ');
+        },
       ),
     }).create();
 
-    assert.deepEqual(object.property, dependencies);
+    setOwner(emberObject, this.owner);
 
-    run(() => set(object, 'dependencyA', 4));
-    assert.deepEqual(object.property, getProperties(object, ...dependencyKeys));
+    assert.strictEqual(emberObject.get('someProperty'), '1, 2');
 
-    run(() => set(object, 'dependencyB', 5));
-    assert.deepEqual(object.property, getProperties(object, ...dependencyKeys));
+    emberObject.set('key1', 3);
 
-    run(() => set(object, 'dependencyC', 6));
-    assert.deepEqual(object.property, getProperties(object, ...dependencyKeys));
+    assert.strictEqual(emberObject.get('someProperty'), '3, 2');
+
+    run(() => set(emberObject, 'key2', 4));
+
+    assert.strictEqual(emberObject.get('someProperty'), '3, 4');
   });
 });

--- a/test-app/tests/unit/macros/t-test.ts
+++ b/test-app/tests/unit/macros/t-test.ts
@@ -1,139 +1,77 @@
 import { setOwner } from '@ember/application';
 import EmberObject from '@ember/object';
-import { run } from '@ember/runloop';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
-import type { IntlService } from 'ember-intl';
 import { raw, t } from 'ember-intl';
-import { addTranslations, setupIntl } from 'ember-intl/test-support';
+import { addTranslations, setLocale, setupIntl } from 'ember-intl/test-support';
 import { setupTest } from 'ember-qunit';
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
+
+class ContainerObject extends EmberObject {}
 
 interface TestContext extends BaseTestContext {
-  ContainerObject: typeof EmberObject;
-  intl: IntlService;
-  object: EmberObject;
+  emberObject: EmberObject;
 }
 
-module('Unit | Macros | t', function (hooks) {
+module('Unit | Macro | t', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks, {
-    'no.interpolations': 'text with no interpolations',
+    'no.interpolations': 'Hello',
     'with.interpolations': 'Clicks: {clicks}',
     'with.two.interpolations': 'Coordinates: {x}, {y}',
   });
 
   hooks.beforeEach(function (this: TestContext) {
-    const { owner } = this;
-
-    this.ContainerObject = class extends EmberObject {
-      constructor() {
-        // eslint-disable-next-line prefer-rest-params
-        super(...arguments);
-        setOwner(this, owner);
-      }
-    };
-
-    this.object = this.ContainerObject.extend({
+    this.emberObject = ContainerObject.extend({
       numberClicks: 9,
-      tMacroProperty1: t('no.interpolations'),
-      tMacroProperty2: t('with.interpolations', { clicks: 'numberClicks' }),
-    }).create();
-  });
-
-  test('defines a computed property that translates without interpolations', function (this: TestContext, assert) {
-    assert.strictEqual(
-      this.object.get('tMacroProperty1'),
-      'text with no interpolations',
-    );
-  });
-
-  test('defines a computed property that translates with interpolations', function (this: TestContext, assert) {
-    assert.strictEqual(this.object.get('tMacroProperty2'), 'Clicks: 9');
-  });
-
-  /*
-    FIXME:
-
-    This test, even when marked as a TODO (using `todo` from `@ember/test-helpers`),
-    can be picked up by `ember-try` and fail continuous integration.
-
-    According to @buschtoens, the failure may be due to an intentional change upstream
-    in Ember.js.
-
-    https://github.com/ember-intl/ember-intl/pull/1634/commits/0a39222961cf446b9c8169805cf8e3f56f51976e
-
-    Consider deleting the test.
-  */
-  skip('allows property to be overridden', function (this: TestContext, assert) {
-    this.object.set('tMacroProperty2', 'A new value');
-    assert.strictEqual(this.object.get('tMacroProperty2'), 'A new value');
-  });
-
-  test('defines a computed property with dependencies', function (this: TestContext, assert) {
-    run(this.object, 'set', 'numberClicks', 13);
-    assert.strictEqual(this.object.get('tMacroProperty2'), 'Clicks: 13');
-  });
-
-  test('defines a computed property that depends on the locale', function (this: TestContext, assert) {
-    addTranslations('es', {
-      'no.interpolations': 'texto sin interpolaciones',
-    });
-
-    assert.strictEqual(
-      this.object.get('tMacroProperty1'),
-      'text with no interpolations',
-    );
-    run(() => this.intl.setLocale(['es']));
-    assert.strictEqual(
-      this.object.get('tMacroProperty1'),
-      'texto sin interpolaciones',
-    );
-  });
-
-  test('defines a computed property that accepts static and dynamic values', function (this: TestContext, assert) {
-    const object = this.ContainerObject.extend({
       yCoord: 4,
-      macroProperty: t('with.two.interpolations', { x: raw(10), y: 'yCoord' }),
+
+      output1: t('no.interpolations'),
+
+      output2: t('with.interpolations', {
+        clicks: 'numberClicks',
+      }),
+
+      output3: t('with.two.interpolations', {
+        x: raw(10),
+        y: 'yCoord',
+      }),
     }).create();
-    assert.strictEqual(object.get('macroProperty'), 'Coordinates: 10, 4');
-    run(object, 'set', 'yCoord', 13);
-    assert.strictEqual(object.get('macroProperty'), 'Coordinates: 10, 13');
+
+    setOwner(this.emberObject, this.owner);
   });
 
-  test('looks up the intl service through the owner, if it is not injected, and still watches locale changes', function (this: TestContext, assert) {
-    addTranslations('es', {
-      'no.interpolations': 'texto sin interpolaciones',
+  test('it works', function (this: TestContext, assert) {
+    assert.strictEqual(this.emberObject.get('output1'), 'Hello');
+    assert.strictEqual(this.emberObject.get('output2'), 'Clicks: 9');
+    assert.strictEqual(this.emberObject.get('output3'), 'Coordinates: 10, 4');
+  });
+
+  test('updates when a dependency key changes value', function (this: TestContext, assert) {
+    this.emberObject.set('numberClicks', 15);
+    this.emberObject.set('yCoord', -15);
+
+    assert.strictEqual(this.emberObject.get('output1'), 'Hello');
+    assert.strictEqual(this.emberObject.get('output2'), 'Clicks: 15');
+    assert.strictEqual(this.emberObject.get('output3'), 'Coordinates: 10, -15');
+  });
+
+  test('updates when the locale changes', async function (this: TestContext, assert) {
+    await addTranslations('es', {
+      'no.interpolations': 'Hola',
     });
 
-    // eslint-disable-next-line ember/no-classic-classes
-    const object = EmberObject.extend({
-      macroProperty: t('no.interpolations'),
-    }).create();
+    await setLocale(['es']);
 
-    // @ts-expect-error: Argument of type '{ lookup: (name: string) => IntlService; }' is not assignable to parameter of type 'Owner'. Type '{ lookup: (name: string) => IntlService; }' is missing the following properties from type 'Owner': register, factoryFor
-    setOwner(object, {
-      lookup: (name: string) => {
-        assert.strictEqual(
-          name,
-          'service:intl',
-          'looks up the service through the owner',
-        );
-        return this.intl;
-      },
-    });
+    assert.strictEqual(this.emberObject.get('output1'), 'Hola');
 
     assert.strictEqual(
-      object.get('macroProperty'),
-      'text with no interpolations',
-      'translates the text',
+      this.emberObject.get('output2'),
+      't:with.interpolations:("clicks":9)',
     );
 
-    run(() => this.intl.setLocale(['es']));
-
     assert.strictEqual(
-      object.get('macroProperty'),
-      'texto sin interpolaciones',
-      'updates, when the locale changes',
+      this.emberObject.get('output3'),
+      't:with.two.interpolations:("x":10,"y":4)',
     );
   });
 });

--- a/test-app/translations/de-de.yaml
+++ b/test-app/translations/de-de.yaml
@@ -1,3 +1,8 @@
+components:
+  macros-classic:
+    hello:
+      message: "Hallo, {name}!"
+
 routes:
   application:
     title: ember-intl

--- a/test-app/translations/en-us.yaml
+++ b/test-app/translations/en-us.yaml
@@ -1,3 +1,8 @@
+components:
+  macros-classic:
+    hello:
+      message: "Hello, {name}!"
+
 routes:
   application:
     title: ember-intl

--- a/test-app/types/global.d.ts
+++ b/test-app/types/global.d.ts
@@ -4,7 +4,7 @@ declare module 'ember-intl' {
 }
 
 declare module 'ember-intl/macros' {
-  export { intl } from 'ember-intl/macros';
+  export { intl, raw, t } from 'ember-intl/macros';
 }
 
 declare module 'ember-intl/services/intl' {


### PR DESCRIPTION
## Why?

The existing tests don't really show how the macros are to be used (in classic components), so I added rendering tests and rewrote the unit tests. These tests should help me fix type errors later.

(Note, the macros will likely be deprecated and removed in `v7.0.0`.)