### PR TITLE
Marked macros as deprecated

### DIFF
--- a/.changeset/silly-moles-pull.md
+++ b/.changeset/silly-moles-pull.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"docs-app": patch
+---
+
+Marked macros as deprecated

--- a/docs-app/app/templates/docs/guide/translating-text.md
+++ b/docs-app/app/templates/docs/guide/translating-text.md
@@ -97,6 +97,16 @@ this.intl.t('a_key_that_is_missing', {
 
 ## Computed Property Macros
 
+**Warning: Macros are deprecated and will be removed in `ember-intl@7.0.0`.** 
+
+
+### Migration guide
+
+In classic and Glimmer components, inject the `intl` service to access its methods.
+
+If you want to create a value that depends on other things, you can use the `@computed` decorator (i.e. create a computed property) in classic and the native getter in Glimmer components. Alternatively, you can use `ember-intl`'s helpers.
+
+
 ### t
 
 `t` is a computed property macro that makes it easy to define translated

--- a/ember-intl/addon/macros/intl.ts
+++ b/ember-intl/addon/macros/intl.ts
@@ -18,6 +18,15 @@ type KeyOrGetterFn<T> = string | GetterFn<T>;
  */
 const __intlInjectionName = `intl-${Date.now().toString(36)}`;
 
+/**
+ * @deprecated Will be removed in v7.
+ *
+ * In classic components, inject the `intl` service
+ * and create a computed property.
+ *
+ * In Glimmer components, inject the `intl` service
+ * and create a getter.
+ */
 export default function intl<T>(...args: KeyOrGetterFn<T>[]) {
   const getterFn = args.pop() as GetterFn<T>;
 

--- a/ember-intl/addon/macros/t.ts
+++ b/ember-intl/addon/macros/t.ts
@@ -64,6 +64,7 @@ type MacroOptions = {
 /**
  * Use this utility function to mark a value as a raw literal.
  *
+ * @deprecated Will be removed in `ember-intl@7.0.0`.
  * @param {*} value The value to mark as a raw literal.
  * @return The same value, but boxed in the `Raw` class so that the consuming
  *  macro understands that this value should be used as is.
@@ -72,6 +73,9 @@ export function raw<T>(value: T): Raw<T> {
   return new Raw(value);
 }
 
+/**
+ * @deprecated Will be removed in `ember-intl@7.0.0`.
+ */
 export default function t(key: string, options?: MacroOptions) {
   const hash = options || new EmptyObject();
 


### PR DESCRIPTION
## Why?

The macros are a remnant of classic components and had been created for a feature parity with `ember-i18n`.

- https://github.com/ember-intl/ember-intl/issues/392
- https://github.com/ember-intl/ember-intl/pull/393
- https://github.com/ember-intl/ember-intl/issues/625
- https://github.com/ember-intl/ember-intl/pull/626

In Octane, we can inject the `intl` service, then use native getters and `@tracked` to do the same thing. By removing the macros, we can maintain less code and more easily migrate the addon to v2 format.


## Solution?

I marked the `intl()`, `raw()`, and `t()` macros as deprecated (JSDoc), and updated the documentation page to warn users. The code will be removed in `ember-intl@v7.0.0`.


## Example of a migration

<details>

<summary>Before: <code>&lt;Macros&gt;</code> component</summary>

```ts
/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, ember/no-classic-classes, ember/no-classic-components, ember/no-computed-properties-in-native-classes, import/export */
import Component from '@ember/component';
import { computed } from '@ember/object';
import { inject as service, type Registry as Services } from '@ember/service';
import { intl, raw, t } from 'ember-intl/macros';

export default class MacrosComponent extends Component {
  @service declare intl: Services['intl'];

  tagName = '';

  @computed('intl.{locale,primaryLocale}')
  get fruits(): string[] {
    switch (this.intl.primaryLocale) {
      case 'de-de': {
        return ['Äpfel', 'Bananen', 'Orangen'];
      }

      case 'en-us': {
        return ['Apples', 'Bananas', 'Oranges'];
      }

      default: {
        throw new Error('Locale must be de-de or en-us.');
      }
    }
  }

  @intl('fruits', function (_intl: Services['intl']) {
    // @ts-expect-error: 'this' implicitly has type 'any' because it does not have a type annotation.
    return _intl.formatList(this.fruits);
  })
  declare outputForIntl: string;

  @t('components.macros-classic.hello.message', {
    name: 'name',
  })
  declare outputForT: string;

  @t('components.macros-classic.hello.message', {
    name: raw('name'),
  })
  declare outputForTWithRaw: string;
}
```

</details>

<details>

<summary>After: <code>&lt;Macros&gt;</code> component</summary>

```ts
import { inject as service, type Registry as Services } from '@ember/service';
import Component from '@glimmer/component';

export default class WithoutMacrosComponent extends Component {
  @service declare intl: Services['intl'];

  get fruits(): string[] {
    switch (this.intl.primaryLocale) {
      case 'de-de': {
        return ['Äpfel', 'Bananen', 'Orangen'];
      }

      case 'en-us': {
        return ['Apples', 'Bananas', 'Oranges'];
      }

      default: {
        throw new Error('Locale must be de-de or en-us.');
      }
    }
  }

  get outputForIntl(): string {
    return this.intl.formatList(this.fruits);
  }

  get outputForT(): string {
    return this.intl.t('components.macros-classic.hello.message', {
      name: this.args.name,
    });
  }

  get outputForTWithRaw(): string {
    return this.intl.t('components.macros-classic.hello.message', {
      name: 'name',
    });
  }
}
```

</details>
