### PR TITLE
Added READMEs for docs and tests. Updated Getting Started.

### DIFF
--- a/.changeset/thick-spiders-attend.md
+++ b/.changeset/thick-spiders-attend.md
@@ -1,0 +1,11 @@
+---
+"test-ember-intl-node": patch
+"ember-intl": patch
+"my-v1-addon": patch
+"my-v2-addon": patch
+"test-app-for-ember-intl": patch
+"docs-app-for-ember-intl": patch
+"my-app": patch
+---
+
+Added READMEs for docs and tests. Updated Getting Started.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ember install ember-intl
     }
     ```
 
-- If you are using [`<template>` tag](https://github.com/ember-template-imports/ember-template-imports), you are good to go! Use the named import to consume things.
+- In [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports), use the named import to consume things from `ember-intl`.
 
     ```ts
     /* app/components/hello.gts */
@@ -46,7 +46,7 @@ ember install ember-intl
 
     const HelloComponent: TOC<HelloSignature> =
       <template>
-        <div data-test-message>
+        <div>
           {{t "hello.message" name=@name}}
         </div>
       </template>
@@ -59,15 +59,11 @@ ember install ember-intl
 
 ## Notable Features
 
-* 💵 Locale-aware numbers. Formatting of currencies, decimals, and percentages
-* 📅 Locale-aware dates and times formatting
-* 🕑 Locale-aware display of relative time. i.e, `"in 1 day"`, `"2 years ago"`, etc.
-* 💬 ICU Message Syntax. Pluralization and formatted segments (numbers, datetime, etc.)
-* 🌐 Support for 150+ languages
-* 🕵🏻 Translation linting (detects missing translations & translation argument mismatches)
-* 📜 Built largely on standards. [ICU message syntax][ICU] & [Native Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-* ⚡ Extensive Ember Service API and template helpers for formatting and translating
-* 🎉 [Advanced addon support](https://ember-intl.github.io/ember-intl/docs/advanced/addon-support) to provide translations to the host app
+* 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
+* 📚 Built on standards: [ICU message syntax][https://formatjs.io/docs/core-concepts/icu-syntax/] and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 🌐 Support for 150+ languages.
+* ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
+* ✅ Test helpers to check locale-dependent templates.
 
 
 ## Documentation
@@ -81,15 +77,3 @@ ember install ember-intl
 
 * Ember.js v3.28 or above
 * Node.js v16 or above
-
-
-## Migrating from ember-i18n
-
-There's an [ember-i18n-to-intl-migrator tool](https://github.com/DockYard/ember-i18n-to-intl-migrator) that is used to convert your translations files and application code to ember-intl.
-
-If you have any questions or issues, please open in [ember-i18n-to-intl-migrator/issues](https://github.com/DockYard/ember-i18n-to-intl-migrator/issues)
-
-[npm]: https://www.npmjs.org/package/ember-intl
-[npm-badge]: https://img.shields.io/npm/v/ember-intl.svg?style=flat-square
-[ember-version]: https://img.shields.io/badge/Ember-2.12%2B-brightgreen.svg
-[ICU]: https://formatjs.io/docs/core-concepts/icu-syntax

--- a/docs/ember-intl/README.md
+++ b/docs/ember-intl/README.md
@@ -1,0 +1,24 @@
+# docs-app-for-ember-intl
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`docs-app-for-ember-intl` is an Ember app. The [deployed site](https://ember-intl.github.io/) documents the API of `ember-intl`.
+
+
+## Local development
+
+```sh
+# Run the app
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```

--- a/docs/ember-intl/app/styles/app.css
+++ b/docs/ember-intl/app/styles/app.css
@@ -7,6 +7,10 @@ html {
   font-size: 16px;
 }
 
+.external-link {
+  color: var(--brand-primary);
+}
+
 .index-route.container {
   margin: 4rem auto;
   max-width: 50rem;

--- a/docs/ember-intl/app/templates/docs.hbs
+++ b/docs/ember-intl/app/templates/docs.hbs
@@ -8,13 +8,13 @@
     />
 
     <nav.item
-      @label="Runtime requirements"
-      @route="docs.getting-started.runtime-requirements"
+      @label="Quickstart"
+      @route="docs.getting-started.quickstart"
     />
 
     <nav.item
-      @label="Quickstart"
-      @route="docs.getting-started.quickstart"
+      @label="Runtime requirements"
+      @route="docs.getting-started.runtime-requirements"
     />
 
     <nav.section @label="Guide" />

--- a/docs/ember-intl/app/templates/docs/getting-started/index.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/index.md
@@ -1,40 +1,20 @@
 # Overview
 
 
-## What is Ember-Intl?
+## What is ember-intl?
 
-Ember-intl is an internationalization addon that unlocks **translating simple to complex messages** using built-in **pluralization rules**, **number and datetime formatting**, with support for **over 150 languages**
-
-Ember-intl is now entirely built on native [ECMAScript Internationalization APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) that are now supported by [all modern browsers](https://caniuse.com/#feat=internationalization).
+`ember-intl` is an addon that helps you internationalize your Ember projects. It is built upon the JavaScript-native [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl), which is supported by [all modern browsers](https://caniuse.com/#feat=internationalization).
 
 
-## Notable Features
+## Features
 
-* 💵 Locale-aware numbers: currencies, decimals, and percentages
-* 📅 Locale-aware date and time formatting
-* 🕑 Locale-aware display of relative time. i.e, `"in 1 day"`, `"2 years ago"`, etc.
-* 💬 Translations containing fragments of any of the above
-
-```icu
-Sale begins {start, date, medium}
-```
-
-also built-in pluralization:
-
-```icu
-You have {itemCount, plural,
-    =0 {no items}
-    one {# item}
-    other {# items}
-}
-```
-
+* 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
+* 📚 Built on standards: <a class="external-link" href="https://formatjs.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
 * 🌐 Support for 150+ languages.
-* 📜 Built on standards such as the [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax) & [Native Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
-* ⚡ Extensive Ember Service API and template helpers for formatting and translating.
-* 🎉 <DocsLink @route="docs.advanced.addon-support">Advanced addon support</DocsLink> to provide translations to the host app
+* ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
+* ✅ Test helpers to check locale-dependent templates.
 
 
-## Online Community Chat
+## Help Online
 
-Join the `topic-i18n` channel [here](https://discordapp.com/invite/zT3asNS) to ask questions and chat with community members in real-time.
+Join the `#topic-i18n` channel on [Ember Discord](https://discordapp.com/invite/zT3asNS). You can ask questions and chat with community members.

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
@@ -3,58 +3,56 @@
 
 ## 1. Install ember-intl
 
-```bash
+```sh
 ember install ember-intl
 ```
 
-This will create the following files:
+This will create a few files:
 
 * `app/formats.js`
-    <!-- default definitions of named formats -->
 * `config/ember-intl.js`
-    <!-- default ember-intl settings -->
 * `translations/en-us.yaml`
 
 
-## 2. Add your first translation
+## 2. Add a translation
 
-Create a translation key in `translations/en-us.yaml`
+Create a translation in `translations/en-us.yaml`.
 
 ```yaml
 hello:
-  world: Hello World!
+  message: "Hello, {name}!"
 ```
 
-In a template add the following:
+In a template, use the `{{t}}` helper to render the translation:
 
 ```hbs
-<!-- app/templates/application.hbs -->
-<h1>{{t "hello.world"}}</h1>
-
-{{outlet}}
+{{! app/templates/application.hbs }}
+<div>
+  {{t "hello.message" name="Zoey"}}
+</div>
 ```
 
 
-## 3. Add a new language
+## 3. Add a language
 
-Create a new translation file: `translations/fr-fr.yaml`
+Create the file `translations/de-de.yaml`.
 
 ```yaml
 hello:
-  world: "Bonjour tout le monde!"
+  message: "Hallo, {name}!"
 ```
 
+Note, you may also use `.yml` or `.json` for file extension.
 
-## 4. Configure ember-intl
 
-### Setting your applications runtime locale
+## 4. Configure project
 
-When your application boots, you want to tell ember-intl which locale it should be targeting.  One common approach, is to do this in your top-level `application` route's `beforeModel` hook.
+### Set your application's locale
 
-_Note:_ This is usually implemented with custom business logic - such as read it off a User model.
+When your application boots, you need to tell `ember-intl` which locale to use. The recommended approach is to do this in the `application` route's `beforeModel` hook.
 
 ```js
-// app/routes/application.js
+/* app/routes/application.js */
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
@@ -68,23 +66,53 @@ export default class ApplicationRoute extends Route {
 ```
 
 
-### Configure your template linter
+### Lint templates
 
-If your app uses `ember-cli-template-lint` (which is installed by default since ember-cli v3.4.1),
-it is strongly recommended that you add the `no-bare-strings` rule to your template linter.
-This rule will prevent you from using plain text strings in your templates (because they cannot be translated).
-
-To enable the template linter rule, edit the file `.template-lintrc.js` as follow:
+With [`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint), you can enable the [`no-bare-strings`](https://github.com/ember-template-lint/ember-template-lint/blob/v5.13.0/docs/rule/no-bare-strings.md) rule. This will help you check if hard-coded texts are present in a template.
 
 ```js
-// .template-lintrc.js
+/* .template-lintrc.js */
 'use strict';
 
 module.exports = {
-  extends: 'recommended',
-
+  extends: ['recommended'],
   rules: {
-    'no-bare-strings': true
-  }
+    'no-bare-strings': true,
+  },
 };
 ```
+
+You can also use [`ember-template-lint-plugin-prettier`](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) to format the template.
+
+
+### Lint translations
+
+With [`eslint-plugin-yml`](https://ota-meshi.github.io/eslint-plugin-yml/), you can enable a few rules to keep YAML files consistent.
+
+
+```js
+/* .eslintrc.js */
+'use strict';
+
+module.exports = {
+  extends: ['plugin:yml/standard'],
+  rules: {
+    'yml/file-extension': 'error',
+    'yml/key-name-casing': [
+      'error',
+      {
+        camelCase: false,
+        'kebab-case': true,
+        PascalCase: false,
+        SCREAMING_SNAKE_CASE: false,
+        snake_case: false,
+        ignores: ['^[a-z0-9\\.-]+$'],
+      },
+    ],
+    'yml/no-multiple-empty-lines': 'error',
+    'yml/sort-keys': 'error',
+  },
+};
+```
+
+You can also use [`prettier`](https://prettier.io/) to format the translation files.

--- a/docs/ember-intl/app/templates/index.md
+++ b/docs/ember-intl/app/templates/index.md
@@ -1,34 +1,27 @@
 <DocsHero
-  @byline="🌐 Internationalize your Ember apps."
-  @logo="ember"
+  @byline="Internationalize your Ember projects"
 />
 
 <div class="index-route container">
   <div>
     <h2 class="section-title">
-      Notable Features
+      Features
     </h2>
     <ul>
       <li>
-        💵 Locale-aware numbers. Formatting of currencies, decimals, and percentages.
+        🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
       </li>
       <li>
-        📅 Locale-aware dates and times formatting
-      </li>
-      <li>
-        🕑 Locale-aware display of relative time. i.e, <code>"in 1 day"</code>, <code>"2 years ago"</code>, etc.
+        📚 Built on standards: <a class="external-link" href="https://formatjs.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
       </li>
       <li>
         🌐 Support for 150+ languages.
       </li>
       <li>
-        📜 Built largely on standards. <a href="https://formatjs.io/docs/core-concepts/icu-syntax">ICU message syntax</a> & <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl">Native Intl API</a>.
+        ⚙️ Locale-aware helpers and <code>intl</code> service, to help you display translations, numbers, dates, etc.
       </li>
       <li>
-        ⚡ Extensive Ember Service API and template helpers for formatting and translating.
-      </li>
-      <li>
-        🎉 <DocsLink @route="docs.advanced.addon-support">Advanced addon support</DocsLink> to provide translations to the host app
+        ✅ Test helpers to check locale-dependent templates.
       </li>
     </ul>
   </div>

--- a/docs/my-app/README.md
+++ b/docs/my-app/README.md
@@ -1,0 +1,42 @@
+# my-app
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`my-app` is an Ember app. We use it to check that `ember-intl` is compatible with "bleeding-edge" Ember:
+
+- [Embroider on the strictest settings](https://github.com/embroider-build/embroider/#options) (including route splitting)
+- [TypeScript](https://www.typescriptlang.org/docs/) + [Glint](https://typed-ember.gitbook.io/glint/)
+- [`<template>` tag](https://github.com/ember-template-imports/ember-template-imports)
+
+In addition, the application tests serve as a living documentation that translations can be provided by apps, v1 addons, or v2 addons.
+
+
+## Local development
+
+Before starting the application, build the v2 addons (e.g. `my-v2-addon`) so that you can test the latest code.
+
+```sh
+# From the workspace root
+pnpm prepare
+
+# Change directory
+cd docs/my-app
+```
+
+Some useful commands:
+
+```sh
+# Run the app
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```

--- a/docs/my-v1-addon/README.md
+++ b/docs/my-v1-addon/README.md
@@ -1,0 +1,24 @@
+# my-v1-addon
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`my-v1-addon` is a v1 addon. We use it in [`my-app`](../my-app) to show that translations can be provided by v1 addons.
+
+
+## Local development
+
+```sh
+# Run the app
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```

--- a/docs/my-v1-addon/package.json
+++ b/docs/my-v1-addon/package.json
@@ -1,6 +1,7 @@
 {
   "name": "my-v1-addon",
   "version": "0.0.0",
+  "private": true,
   "description": "A v1 addon with ember-intl",
   "keywords": [
     "ember-addon"

--- a/docs/my-v2-addon/README.md
+++ b/docs/my-v2-addon/README.md
@@ -1,0 +1,24 @@
+# my-v2-addon
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`my-v2-addon` is a v2 addon. We use it in [`my-app`](../my-app) to show that translations can be provided by v2 addons.
+
+
+## Local development
+
+```sh
+# Run the addon
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -31,7 +31,7 @@ ember install ember-intl
     }
     ```
 
-- If you are using [`<template>` tag](https://github.com/ember-template-imports/ember-template-imports), you are good to go! Use the named import to consume things.
+- In [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports), use the named import to consume things from `ember-intl`.
 
     ```ts
     /* app/components/hello.gts */
@@ -46,7 +46,7 @@ ember install ember-intl
 
     const HelloComponent: TOC<HelloSignature> =
       <template>
-        <div data-test-message>
+        <div>
           {{t "hello.message" name=@name}}
         </div>
       </template>
@@ -59,15 +59,11 @@ ember install ember-intl
 
 ## Notable Features
 
-* 💵 Locale-aware numbers. Formatting of currencies, decimals, and percentages
-* 📅 Locale-aware dates and times formatting
-* 🕑 Locale-aware display of relative time. i.e, `"in 1 day"`, `"2 years ago"`, etc.
-* 💬 ICU Message Syntax. Pluralization and formatted segments (numbers, datetime, etc.)
-* 🌐 Support for 150+ languages
-* 🕵🏻 Translation linting (detects missing translations & translation argument mismatches)
-* 📜 Built largely on standards. [ICU message syntax][ICU] & [Native Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
-* ⚡ Extensive Ember Service API and template helpers for formatting and translating
-* 🎉 [Advanced addon support](https://ember-intl.github.io/ember-intl/docs/advanced/addon-support) to provide translations to the host app
+* 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
+* 📚 Built on standards: [ICU message syntax][https://formatjs.io/docs/core-concepts/icu-syntax/] and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 🌐 Support for 150+ languages.
+* ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
+* ✅ Test helpers to check locale-dependent templates.
 
 
 ## Documentation
@@ -81,15 +77,3 @@ ember install ember-intl
 
 * Ember.js v3.28 or above
 * Node.js v16 or above
-
-
-## Migrating from ember-i18n
-
-There's an [ember-i18n-to-intl-migrator tool](https://github.com/DockYard/ember-i18n-to-intl-migrator) that is used to convert your translations files and application code to ember-intl.
-
-If you have any questions or issues, please open in [ember-i18n-to-intl-migrator/issues](https://github.com/DockYard/ember-i18n-to-intl-migrator/issues)
-
-[npm]: https://www.npmjs.org/package/ember-intl
-[npm-badge]: https://img.shields.io/npm/v/ember-intl.svg?style=flat-square
-[ember-version]: https://img.shields.io/badge/Ember-2.12%2B-brightgreen.svg
-[ICU]: https://formatjs.io/docs/core-concepts/icu-syntax

--- a/packages/ember-intl/addon/-private/utils/missing-message.ts
+++ b/packages/ember-intl/addon/-private/utils/missing-message.ts
@@ -8,7 +8,7 @@ import { isEmpty } from '@ember/utils';
 export default function missingMessage(key: string, locales: string[]): string {
   if (isEmpty(locales)) {
     warn(
-      `[ember-intl] no locale has been set!  See: https://ember-intl.github.io/ember-intl/docs/quickstart#4-configure-ember-intl`,
+      `[ember-intl] No locale has been set. See https://ember-intl.github.io/ember-intl/docs/quickstart#4-configure-project`,
       false,
       {
         id: 'ember-intl-no-locale-set',

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -283,7 +283,7 @@ export default class IntlService extends Service {
   /** @public */
   setLocale(locale) {
     assert(
-      `[ember-intl] no locale has been set!  See: https://ember-intl.github.io/ember-intl/docs/quickstart#4-configure-ember-intl`,
+      `[ember-intl] No locale has been set. See https://ember-intl.github.io/ember-intl/docs/quickstart#4-configure-project`,
       locale,
     );
 

--- a/packages/ember-intl/blueprints/ember-intl/index.js
+++ b/packages/ember-intl/blueprints/ember-intl/index.js
@@ -28,8 +28,10 @@ module.exports = {
 
   afterInstall() {
     this.ui.writeLine(
-      "[ember-intl] Don't forget to configure your application.  " +
-        'Documentation: https://ember-intl.github.io/ember-intl/versions/master/docs/quickstart#4-configure-ember-intl',
+      [
+        "[ember-intl] Don't forget to configure your project.",
+        'See https://ember-intl.github.io/ember-intl/docs/quickstart#4-configure-project',
+      ].join(' '),
     );
   },
 };

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -1,13 +1,12 @@
 {
   "name": "ember-intl",
   "version": "6.5.0",
-  "description": "A internationalization toolbox for ambitious applications.",
+  "description": "Internationalization for Ember projects",
   "keywords": [
-    "ember-addon",
-    "i18n",
-    "ember-intl",
-    "ember-i18n",
     "ember",
+    "ember-addon",
+    "ember-intl",
+    "i18n",
     "internationalization"
   ],
   "homepage": "https://ember-intl.github.io/ember-intl/",

--- a/tests/ember-intl-node/README.md
+++ b/tests/ember-intl-node/README.md
@@ -1,0 +1,20 @@
+# test-ember-intl-node
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`test-ember-intl-node` is a Node project. We use it to unit-test the files in `blueprints` and `lib` folders in `ember-intl`.
+
+## Local development
+
+```sh
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```

--- a/tests/ember-intl/README.md
+++ b/tests/ember-intl/README.md
@@ -1,0 +1,27 @@
+# test-app-for-ember-intl
+
+1. [What is it?](#what-is-it)
+1. [Local development](#local-development)
+
+
+## What is it?
+
+`test-app-for-ember-intl` is an Ember app. We use it to check that `ember-intl` is compatible with various versions of these projects:
+
+- [Ember](https://emberjs.com/releases/) (long-term support, release, beta, canary)
+- [Embroider](https://github.com/embroider-build/embroider/) (safe, optimized)
+
+
+## Local development
+
+```sh
+# Run the app
+pnpm start
+
+# Lint files
+pnpm lint
+pnpm lint:fix
+
+# Run tests
+pnpm test
+```


### PR DESCRIPTION
## Why?

Some of the passages in `README.md` and the documentation had outdated references (e.g. `ember-i18n`, `ember-cli-template-lint`).

Now that the repository has several packages in `docs` and `tests`, I wanted to give a basic explanation of each package.
