### PR TITLE
Added a quickstart for addons. Removed the page for common errors.

### DIFF
--- a/.changeset/rare-dancers-attack.md
+++ b/.changeset/rare-dancers-attack.md
@@ -1,0 +1,9 @@
+---
+"docs-app-for-ember-intl": minor
+"ember-intl": patch
+"my-v1-addon": patch
+"my-v2-addon": patch
+"my-app": patch
+---
+
+Added a quickstart for addons. Removed the page for common errors.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ember install ember-intl
 ## Notable Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
-* 📚 Built on standards: [ICU message syntax][https://formatjs.io/docs/core-concepts/icu-syntax/] and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 * 🌐 Support for 150+ languages.
 * ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
 * ✅ Test helpers to check locale-dependent templates.

--- a/README.md
+++ b/README.md
@@ -7,57 +7,10 @@
 
 ## Installation
 
-```sh
-ember install ember-intl
-```
-
-<details>
-
-<summary>Use Glint or <code>&lt;template&gt;</code> tag? ✨</summary>
-
-- Update your template registry to extend this addon's. Check the [Glint documentation](https://typed-ember.gitbook.io/glint/environments/ember/using-addons#using-glint-enabled-addons) for more information.
-
-    ```ts
-    /* types/index.d.ts */
-
-    import '@glint/environment-ember-loose';
-
-    import type EmberIntlRegistry from 'ember-intl/template-registry';
-
-    declare module '@glint/environment-ember-loose/registry' {
-      export default interface Registry extends EmberIntlRegistry, /* other addon registries */ {
-        // local entries
-      }
-    }
-    ```
-
-- In [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports), use the named import to consume things from `ember-intl`.
-
-    ```ts
-    /* app/components/hello.gts */
-    import type { TOC } from '@ember/component/template-only';
-    import { t } from 'ember-intl';
-
-    interface HelloSignature {
-      Args: {
-        name: string;
-      };
-    }
-
-    const HelloComponent: TOC<HelloSignature> =
-      <template>
-        <div>
-          {{t "hello.message" name=@name}}
-        </div>
-      </template>
-
-    export default HelloComponent;
-    ```
-
-</details>
+See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 
-## Notable Features
+## Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
 * 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).

--- a/docs/ember-intl/app/router.js
+++ b/docs/ember-intl/app/router.js
@@ -19,6 +19,7 @@ Router.map(function () {
 
     this.route('getting-started', { path: '/' }, function () {
       this.route('quickstart');
+      this.route('quickstart-addons');
       this.route('runtime-requirements');
     });
 

--- a/docs/ember-intl/app/router.js
+++ b/docs/ember-intl/app/router.js
@@ -13,10 +13,6 @@ Router.map(function () {
       this.route('addon-support');
     });
 
-    this.route('cookbook', function () {
-      this.route('common-errors');
-    });
-
     this.route('getting-started', { path: '/' }, function () {
       this.route('quickstart');
       this.route('quickstart-addons');

--- a/docs/ember-intl/app/templates/docs.hbs
+++ b/docs/ember-intl/app/templates/docs.hbs
@@ -8,8 +8,13 @@
     />
 
     <nav.item
-      @label="Quickstart"
+      @label="Quickstart (Apps)"
       @route="docs.getting-started.quickstart"
+    />
+
+    <nav.item
+      @label="Quickstart (Addons)"
+      @route="docs.getting-started.quickstart-addons"
     />
 
     <nav.item

--- a/docs/ember-intl/app/templates/docs.hbs
+++ b/docs/ember-intl/app/templates/docs.hbs
@@ -95,13 +95,6 @@
       @route="docs.helpers.format-list"
     />
 
-    <nav.section @label="Cookbook" />
-
-    <nav.item
-      @label="Common errors"
-      @route="docs.cookbook.common-errors"
-    />
-
     <nav.section @label="Advanced" />
 
     <nav.item

--- a/docs/ember-intl/app/templates/docs/advanced/addon-support.md
+++ b/docs/ember-intl/app/templates/docs/advanced/addon-support.md
@@ -1,9 +1,9 @@
 # Addon support
 
-By default, addons are supported out of the box. They need to implement a `/translations` folder at the root of your project (NOTE: a sibling to `app` _not_ a child). Then, the contents of the translation folder will be bundled with the translations of your host app.
+**Warning: This page pertains to v1 addons and may be outdated. The described feature may not be supported in v2 addons.**
 
 
-## Advanced Usage (treeForTranslations)
+## treeForTranslations
 
 In v3.0.0, a hook called `treeForTranslations` was introduced to support addons better.
 
@@ -27,8 +27,3 @@ module.exports = {
   }
 };
 ```
-
-
-## Overriding Translations
-
-The host application can always override addon translations. If the application implements a key that collides with an addon, then the application wins when bundling the translations. This is intended to allow host applications to override translations without having to modify an addon.

--- a/docs/ember-intl/app/templates/docs/cookbook/common-errors.md
+++ b/docs/ember-intl/app/templates/docs/cookbook/common-errors.md
@@ -1,7 +1,0 @@
-# Common errors
-
-## date value is not finite in DateTimeFormat.format()
-
-Browser vendors implement date/time parsing differently.  For example, the following will parse correctly in Chrome but fail in Firefox: `new Intl.DateTimeFormat().format('2015-04-21 20:47:31 GMT');`
-
-The solution is to ensure that the value you are passing in is in a format which is valid for the `Date` constructor.  This library currently does not try and normalize date strings outside of what the browser already implements.

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
@@ -74,28 +74,30 @@ In a template, use the `{{t}}` helper to render the translation.
 ```hbs
 {{! v1 addons: addon/components/hello.hbs }}
 <div>
-  {{t "hello.message" name="Zoey"}}
+  {{t "hello.message" name=@name}}
 </div>
 ```
 
 ```hbs
 {{! v2 addons: src/components/hello.hbs }}
 <div>
-  {{t "hello.message" name="Zoey"}}
+  {{t "hello.message" name=@name}}
 </div>
 ```
+
+Just like [in apps](./quickstart#2-add-a-translation), you can import the `{{t}}` helper in a `<template>`-tag component.
 
 Note, the consuming app can override the addon's translations. If the app uses the same key as the addon, then the app's translation always wins.
 
 
 ## 3. Add a language
 
-Follow [the same step for apps](./quickstart#3-add-a-language).
+Follow [step 3 for apps](./quickstart#3-add-a-language).
 
 
 ## 4. Configure project
 
-Follow [the same step for apps](./quickstart#4-configure-project). For brevity, only the differences are noted below.
+Follow [step 4 for apps](./quickstart#4-configure-project). For brevity, only the differences are noted below.
 
 
 ### Set your test app's locale (optional)

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
@@ -1,0 +1,124 @@
+# Quickstart (Addons)
+
+Addons need to publish a folder called `translations`. Note, `translations` is the name that your apps expect, unless configured otherwise.
+
+
+## 1. Install ember-intl
+
+### v1 addons
+
+You can use Ember CLI to install `ember-intl`.
+
+```sh
+ember install ember-intl
+```
+
+This will create a few files:
+
+* `tests/dummy/app/formats.js`
+* `tests/dummy/config/ember-intl.js`
+* `translations/en-us.yaml`
+
+Note the folder structure. Namely, `addon` and `translations` are siblings.
+
+```sh
+my-v1-addon
+├── addon
+└── translations
+```
+
+
+### v2 addons
+
+You can use your package manager to install `ember-intl` (as a dependency or peer dependency).
+
+```sh
+pnpm add ember-intl
+```
+
+Then, create the folder `translations` as a sibling to `src`.
+
+```sh
+my-v2-addon
+├── src
+└── translations
+```
+
+Lastly, add `translations` to the `files` field in `package.json`.
+
+```json
+/* package.json */
+{
+  "name": "my-v2-addon",
+  "files": [
+    "addon-main.cjs",
+    "declarations",
+    "dist",
+    "translations"
+  ]
+}
+```
+
+
+## 2. Add a translation
+
+Create a translation in `translations/en-us.yaml`.
+
+```yaml
+hello:
+  message: "Hello, {name}!"
+```
+
+In a template, use the `{{t}}` helper to render the translation.
+
+```hbs
+{{! v1 addons: addon/components/hello.hbs }}
+<div>
+  {{t "hello.message" name="Zoey"}}
+</div>
+```
+
+```hbs
+{{! v2 addons: src/components/hello.hbs }}
+<div>
+  {{t "hello.message" name="Zoey"}}
+</div>
+```
+
+Note, the consuming app can override the addon's translations. If the app uses the same key as the addon, then the app's translation always wins.
+
+
+## 3. Add a language
+
+Follow [the same step for apps](./quickstart#3-add-a-language).
+
+
+## 4. Configure project
+
+Follow [the same step for apps](./quickstart#4-configure-project). For brevity, only the differences are noted below.
+
+
+### Set your test app's locale (optional)
+
+If your test app is something more than "just tests," e.g. the app is also a documentation app, then you will want to set the locale in your test app.
+
+- v1 addons: `tests/dummy/app/routes/application.js`
+- v2 addons: `app/routes/application.js`
+
+
+### Glint
+
+Extend `ember-intl`'s template registry.
+
+- v1 addons: `types/global.d.ts`
+- v2 addons: `unpublished-development-types/index.d.ts`
+
+
+### Lint templates
+
+There are no differences.
+
+
+### Lint translations
+
+There are no differences.

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
@@ -34,6 +34,29 @@ In a template, use the `{{t}}` helper to render the translation:
 </div>
 ```
 
+In a [`<template>`-tag component](https://github.com/ember-template-imports/ember-template-imports), use the named import to consume the `{{t}}` helper.
+
+```ts
+/* app/components/hello.gts */
+import type { TOC } from '@ember/component/template-only';
+import { t } from 'ember-intl';
+
+interface HelloSignature {
+  Args: {
+    name: string;
+  };
+}
+
+const HelloComponent: TOC<HelloSignature> =
+  <template>
+    <div>
+      {{t "hello.message" name=@name}}
+    </div>
+  </template>
+
+export default HelloComponent;
+```
+
 
 ## 3. Add a language
 

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart.md
@@ -1,7 +1,9 @@
-# Quickstart
+# Quickstart (Apps)
 
 
 ## 1. Install ember-intl
+
+You can use Ember CLI to install `ember-intl`.
 
 ```sh
 ember install ember-intl
@@ -47,7 +49,7 @@ Note, you may also use `.yml` or `.json` for file extension.
 
 ## 4. Configure project
 
-### Set your application's locale
+### Set your app's locale
 
 When your application boots, you need to tell `ember-intl` which locale to use. The recommended approach is to do this in the `application` route's `beforeModel` hook.
 
@@ -61,6 +63,25 @@ export default class ApplicationRoute extends Route {
 
   beforeModel() {
     this.intl.setLocale(['en-us']);
+  }
+}
+```
+
+
+### Glint
+
+Update your template registry to extend this addon's. Check the [Glint documentation](https://typed-ember.gitbook.io/glint/environments/ember/using-addons#using-glint-enabled-addons) for more information.
+
+```ts
+/* types/my-app/index.d.ts */
+
+import '@glint/environment-ember-loose';
+
+import type EmberIntlRegistry from 'ember-intl/template-registry';
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry extends EmberIntlRegistry, /* other addon registries */ {
+    // local entries
   }
 }
 ```

--- a/docs/my-app/app/templates/index.hbs
+++ b/docs/my-app/app/templates/index.hbs
@@ -8,4 +8,8 @@
     <ComponentFromV1Addon />
     <ComponentFromV2Addon />
   </div>
+
+  <div data-test-output="Key to Overwrite">
+    {{t "routes.index.key-to-overwrite"}}
+  </div>
 </div>

--- a/docs/my-app/tests/acceptance/index-test.ts
+++ b/docs/my-app/tests/acceptance/index-test.ts
@@ -25,6 +25,10 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="V2 Addon"]')
         .hasText('Dies ist eine Komponente aus einem v2 Addon.');
+
+      assert
+        .dom('[data-test-output="Key to Overwrite"]')
+        .hasText('Die Apps Übersetzungen haben Vorrang.');
     });
   });
 
@@ -46,6 +50,10 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="V2 Addon"]')
         .hasText('This is a component from a v2 addon.');
+
+      assert
+        .dom('[data-test-output="Key to Overwrite"]')
+        .hasText("The app's translations take precedence.");
     });
   });
 });

--- a/docs/my-app/translations/routes/index/de-de.yml
+++ b/docs/my-app/translations/routes/index/de-de.yml
@@ -1,2 +1,3 @@
 routes.index:
+  key-to-overwrite: Die Apps Übersetzungen haben Vorrang.
   title: "Willkommen bei <code>ember-intl</code>"

--- a/docs/my-app/translations/routes/index/en-us.yml
+++ b/docs/my-app/translations/routes/index/en-us.yml
@@ -1,2 +1,3 @@
 routes.index:
+  key-to-overwrite: The app's translations take precedence.
   title: "Welcome to <code>ember-intl</code>"

--- a/docs/my-v1-addon/translations/routes/index/de-de.yml
+++ b/docs/my-v1-addon/translations/routes/index/de-de.yml
@@ -1,0 +1,2 @@
+routes.index:
+  key-to-overwrite: Das v1 Addons Übersetzungen haben Vorrang.

--- a/docs/my-v1-addon/translations/routes/index/en-us.yml
+++ b/docs/my-v1-addon/translations/routes/index/en-us.yml
@@ -1,0 +1,2 @@
+routes.index:
+  key-to-overwrite: The v1 addon's translations take precedence.

--- a/docs/my-v2-addon/translations/routes/index/de-de.yml
+++ b/docs/my-v2-addon/translations/routes/index/de-de.yml
@@ -1,0 +1,2 @@
+routes.index:
+  key-to-overwrite: Das v2 Addons Übersetzungen haben Vorrang.

--- a/docs/my-v2-addon/translations/routes/index/en-us.yml
+++ b/docs/my-v2-addon/translations/routes/index/en-us.yml
@@ -1,0 +1,2 @@
+routes.index:
+  key-to-overwrite: The v2 addon's translations take precedence.

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -60,7 +60,7 @@ ember install ember-intl
 ## Notable Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
-* 📚 Built on standards: [ICU message syntax][https://formatjs.io/docs/core-concepts/icu-syntax/] and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 * 🌐 Support for 150+ languages.
 * ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
 * ✅ Test helpers to check locale-dependent templates.

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -7,57 +7,10 @@
 
 ## Installation
 
-```sh
-ember install ember-intl
-```
-
-<details>
-
-<summary>Use Glint or <code>&lt;template&gt;</code> tag? ✨</summary>
-
-- Update your template registry to extend this addon's. Check the [Glint documentation](https://typed-ember.gitbook.io/glint/environments/ember/using-addons#using-glint-enabled-addons) for more information.
-
-    ```ts
-    /* types/index.d.ts */
-
-    import '@glint/environment-ember-loose';
-
-    import type EmberIntlRegistry from 'ember-intl/template-registry';
-
-    declare module '@glint/environment-ember-loose/registry' {
-      export default interface Registry extends EmberIntlRegistry, /* other addon registries */ {
-        // local entries
-      }
-    }
-    ```
-
-- In [`<template>`-tag components](https://github.com/ember-template-imports/ember-template-imports), use the named import to consume things from `ember-intl`.
-
-    ```ts
-    /* app/components/hello.gts */
-    import type { TOC } from '@ember/component/template-only';
-    import { t } from 'ember-intl';
-
-    interface HelloSignature {
-      Args: {
-        name: string;
-      };
-    }
-
-    const HelloComponent: TOC<HelloSignature> =
-      <template>
-        <div>
-          {{t "hello.message" name=@name}}
-        </div>
-      </template>
-
-    export default HelloComponent;
-    ```
-
-</details>
+See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 
-## Notable Features
+## Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
 * 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).


### PR DESCRIPTION
## Why?

It's difficult to find in the documentation site how to set up `ember-intl` for addons (v1 as well as v2).


## Solution?

I created a dedicated quickstart page for addons under `Getting Started`. I moved some existing content from `Advanced > Addon Support`.
