### PR TITLE
Required locale in setupIntl()

### DIFF
--- a/.changeset/honest-ravens-vanish.md
+++ b/.changeset/honest-ravens-vanish.md
@@ -1,0 +1,13 @@
+---
+"ember-intl": major
+"my-app-with-lazy-loaded-translations": patch
+"my-app-with-namespace-from-folders": patch
+"my-classic-app": patch
+"my-v1-engine": patch
+"my-v1-addon": patch
+"test-app-for-ember-intl": patch
+"docs-app-for-ember-intl": patch
+"my-app": patch
+---
+
+Required locale in setupIntl()

--- a/docs/ember-intl/app/templates/docs/guide/testing.md
+++ b/docs/ember-intl/app/templates/docs/guide/testing.md
@@ -3,44 +3,16 @@
 With `ember-intl`'s test helpers, you can check translations under various conditions easily.
 
 
-## setupIntl(hooks, [locale], [translations])
+## setupIntl(hooks, locale, [translations])
 
-In rendering and unit tests, you must add `setupIntl(hooks)` if they depend on `ember-intl`, e.g. you used the `{{t}}` helper in the template, or injected the `intl` service in the class.
+In rendering and unit tests, you should add `setupIntl()` if they depend on `ember-intl`, e.g. you used the `{{t}}` helper in the template, or injected the `intl` service in the class.
 
-You can also use `setupIntl()` to set the locale and stub translations. This setup runs as a part of the test module's `beforeEach` hook (e.g. before a component is rendered).
-
-In application tests, it's not necessary to call `setupIntl(hooks)`. The only time you might do this is to run a test module with a particular locale.
-
-
-### setupIntl(hooks)
-
-The syntax helps you check the default case. That is, what does the user see with the default locale and the translations as provided?
-
-```ts
-import { render } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
-import { setupRenderingTest } from 'ember-qunit';
-import { module, test } from 'qunit';
-
-module('Integration | Component | hello', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
-
-  test('it renders', async function (assert) {
-    await render(hbs`
-      <Hello @name="Zoey" />
-    `);
-
-    assert.dom('[data-test-message]').hasText('Hello, Zoey!');
-  });
-});
-```
+In application tests, it's not necessary to call `setupIntl()`. The only time you might do this is to run a test module with a particular locale.
 
 
 ### setupIntl(hooks, locale)
 
-The syntax helps you check the translations for a specific locale.
+The default syntax helps you check the translations for a specific locale.
 
 ```ts
 import { render } from '@ember/test-helpers';
@@ -64,39 +36,9 @@ module('Integration | Component | hello', function (hooks) {
 ```
 
 
-### setupIntl(hooks, translations)
-
-The syntax helps you stub the translations for the default locale.
-
-```ts
-import { render } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
-import { setupRenderingTest } from 'ember-qunit';
-import { module, test } from 'qunit';
-
-module('Integration | Component | hello', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks, {
-    hello: {
-      message: 'What\'s up, {name}?',
-    },
-  });
-
-  test('it renders', async function (assert) {
-    await render(hbs`
-      <Hello @name="Zoey" />
-    `);
-
-    assert.dom('[data-test-message]').hasText('What\'s up, Zoey?');
-  });
-});
-```
-
-
 ### setupIntl(hooks, locale, translations)
 
-The syntax helps you stub the translations for a specific locale.
+You can pass a translation object to stub the translations for a specific locale.
 
 ```ts
 import { render } from '@ember/test-helpers';
@@ -137,7 +79,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`
@@ -169,7 +111,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | lazy-hello', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('Lazily loaded translations', async function (assert) {
     await render(hbs`
@@ -213,7 +155,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | hello', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -20,7 +20,6 @@ This command has been removed, because the blueprints only addressed the simple 
 How translation files are created will be left up to the end-developers.
 
 
-
 ### Removed `@intl` and `@t` macros
 
 The macros are a remnant of classic components and `ember-i18n`. They are not necessary in Octane, and prevent us from mainintaing and updating `ember-intl` more easily.
@@ -55,7 +54,7 @@ export default class MyComponent extends Component {
 After:
 
 ```ts
-import { inject as service, type Registry as Services } from '@ember/service';
+import { type Registry as Services, service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
@@ -93,7 +92,7 @@ Before:
 ```ts
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { inject as service, type Registry as Services } from '@ember/service';
+import { type Registry as Services, service } from '@ember/service';
 
 export default class MyComponent extends Component {
   @service declare intl: Services['intl'];
@@ -120,7 +119,7 @@ export default class MyComponent extends Component {
 After:
 
 ```ts
-import { inject as service, type Registry as Services } from '@ember/service';
+import { type Registry as Services, service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class MyComponent extends Component {
@@ -142,4 +141,64 @@ export default class MyComponent extends Component {
     }
   }
 }
+```
+
+
+### Required locale in test helpers
+
+Before `v7`, `ember-intl` allowed you to write `setupIntl(hooks)`. Your tests would somehow pass, even though you didn't specify under which locale the tests make sense.
+
+By favoring convenience and assuming that most apps target USA, we also created problems that became visible in `v6`:
+
+- `'en-us'` is always present in the `intl` service's `locales`, even when the app doesn't support the `en-us` locale.
+- `setupIntl()` needs to support 4 variations, increasing complexity and maintenance cost.
+
+To solve these issues and encourage writing code that is explicit, `setupIntl()` now requires you to specify the locale. To migrate code, use find-and-replace-all in your text editor.
+
+```diff
+module('Integration | Component | hello', function (hooks) {
+  setupRenderingTest(hooks);
+-   setupIntl(hooks);
++   setupIntl(hooks, 'en-us');
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <Hello @name="Zoey" />
+    `);
+
+    assert.dom('[data-test-message]').hasText('Hello, Zoey!');
+  });
+});
+```
+
+Note, if you want to test multiple locales, you can use nested modules.
+
+```ts
+module('Integration | Component | hello', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('de-de', function (nestedHooks) {
+    setupIntl(nestedHooks, 'de-de');
+
+    test('it renders', async function (assert) {
+      await render(hbs`
+        <Hello @name="Zoey" />
+      `);
+
+      assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
+    });
+  });
+
+  module('en-us', function (nestedHooks) {
+    setupIntl(nestedHooks, 'en-us');
+
+    test('it renders', async function (assert) {
+      await render(hbs`
+        <Hello @name="Zoey" />
+      `);
+
+      assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
+    });
+  });
+});
 ```

--- a/docs/ember-intl/tests/helpers/index.ts
+++ b/docs/ember-intl/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/ember-intl/tests/integration/components/locale-switcher-test.ts
+++ b/docs/ember-intl/tests/integration/components/locale-switcher-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | locale-switcher', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/my-app-with-lazy-loaded-translations/tests/helpers/index.ts
+++ b/docs/my-app-with-lazy-loaded-translations/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/my-app-with-lazy-loaded-translations/tests/integration/components/select-locale-test.ts
+++ b/docs/my-app-with-lazy-loaded-translations/tests/integration/components/select-locale-test.ts
@@ -9,7 +9,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | select-locale', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/my-app-with-namespace-from-folders/tests/helpers/index.ts
+++ b/docs/my-app-with-namespace-from-folders/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/my-app-with-namespace-from-folders/tests/integration/components/select-locale-test.ts
+++ b/docs/my-app-with-namespace-from-folders/tests/integration/components/select-locale-test.ts
@@ -9,7 +9,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | select-locale', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/my-app/tests/helpers/index.ts
+++ b/docs/my-app/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/my-app/tests/integration/components/select-locale-test.ts
+++ b/docs/my-app/tests/integration/components/select-locale-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | select-locale', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/my-classic-app/tests/helpers/index.ts
+++ b/docs/my-classic-app/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/my-classic-app/tests/integration/components/select-locale-test.ts
+++ b/docs/my-classic-app/tests/integration/components/select-locale-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | select-locale', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`

--- a/docs/my-v1-addon/tests/helpers/index.ts
+++ b/docs/my-v1-addon/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/docs/my-v1-engine/tests/helpers/index.ts
+++ b/docs/my-v1-engine/tests/helpers/index.ts
@@ -31,7 +31,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/packages/ember-intl/addon-test-support/setup-intl.ts
+++ b/packages/ember-intl/addon-test-support/setup-intl.ts
@@ -35,12 +35,13 @@ export interface SetupIntlOptions {
  * to explicitly add any translations and can just rely on the implicit
  * serialization. See the docs for detailed examples.
  *
- * Besides the `hooks` object you can also pass a `locale` string or array to
- * set the locale, as well as an object of `translations`, if you do want to
- * bootstrap translations. Both arguments are optional.
+ * In addition to the `hooks` object, you must specify the locale
+ * under which your tests make sense.
+ *
+ * You may pass a `translations` object to stub the translations.
  *
  * @param {object} hooks
- * @param {string} [localeOrTranslations]
+ * @param {string} [locale]
  * @param {object} [translations]
  * @param {object} [options]
  */
@@ -49,34 +50,7 @@ export function setupIntl(
   locale: string | string[],
   translations?: Translations,
   options?: SetupIntlOptions,
-): void;
-export function setupIntl(
-  hooks: NestedHooks,
-  translations?: Translations,
-  options?: SetupIntlOptions,
-): void;
-export function setupIntl(
-  hooks: NestedHooks,
-  localeOrTranslations?: string | string[] | Translations,
-  translationsOrOptions?: Translations | SetupIntlOptions,
-  options?: SetupIntlOptions,
-) {
-  let locale: string | string[] | undefined;
-  let translations: Translations | undefined;
-  if (
-    typeof localeOrTranslations === 'object' &&
-    !Array.isArray(localeOrTranslations)
-  ) {
-    translations = localeOrTranslations;
-    localeOrTranslations = undefined;
-    if (typeof translationsOrOptions === 'object') {
-      options = translationsOrOptions;
-    }
-  } else {
-    locale = localeOrTranslations;
-    translations = translationsOrOptions as Translations | undefined;
-  }
-
+): void {
   hooks.beforeEach(async function (this: TestContext) {
     if (typeof options?.missingMessage === 'function') {
       this.owner.register('util:intl/missing-message', options.missingMessage);
@@ -96,9 +70,7 @@ export function setupIntl(
 
     this.intl = this.owner.lookup('service:intl') as IntlService;
 
-    if (locale) {
-      this.intl.setLocale(locale);
-    }
+    this.intl.setLocale(locale);
 
     if (translations) {
       addTranslations(translations);

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -120,10 +120,8 @@ export default class IntlService extends Service {
   constructor() {
     super(...arguments);
 
-    const initialLocale = this.locale || ['en-us'];
     this._intls = {};
     this._ee = new EventEmitter();
-    this.setLocale(initialLocale);
 
     this._owner = getOwner(this);
 

--- a/packages/ember-intl/tests/helpers/index.ts
+++ b/packages/ember-intl/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/ember-intl/tests/helpers/index.ts
+++ b/tests/ember-intl/tests/helpers/index.ts
@@ -24,7 +24,7 @@ function setupApplicationTest(hooks: NestedHooks, options?: SetupTestOptions) {
   // This is also a good place to call test setup functions coming
   // from other addons:
   //
-  // setupIntl(hooks); // ember-intl
+  // setupIntl(hooks, 'en-us'); // ember-intl
   // setupMirage(hooks); // ember-cli-mirage
 }
 

--- a/tests/ember-intl/tests/integration/components/lazy-hello-test.ts
+++ b/tests/ember-intl/tests/integration/components/lazy-hello-test.ts
@@ -8,7 +8,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
   setupRenderingTest(hooks);
 
   module('en-us', function (nestedHooks) {
-    setupIntl(nestedHooks);
+    setupIntl(nestedHooks, 'en-us');
 
     test('Translations are loaded before the component is rendered', async function (assert) {
       await addTranslations({

--- a/tests/ember-intl/tests/integration/test-helpers/index-test.ts
+++ b/tests/ember-intl/tests/integration/test-helpers/index-test.ts
@@ -16,8 +16,8 @@ interface TestContext extends BaseTestContext {
 module('Integration | Test Helpers', function (hooks) {
   setupRenderingTest(hooks);
 
-  module('setupIntl(hooks)', function (hooks) {
-    setupIntl(hooks);
+  module('setupIntl(hooks, locale)', function (hooks) {
+    setupIntl(hooks, 'en-us');
 
     test('hooks were properly executed and helpers work', async function (this: TestContext, assert) {
       assert.strictEqual(
@@ -99,7 +99,7 @@ module('Integration | Test Helpers', function (hooks) {
 
   module('setupIntl(hooks, translations)', function () {
     module('With default locale', function (hooks) {
-      setupIntl(hooks, {
+      setupIntl(hooks, 'en-us', {
         some: {
           translation: 'The cake is a lie.',
         },
@@ -154,7 +154,7 @@ module('Integration | Test Helpers', function (hooks) {
   module(
     'setupIntl(hooks, translations) for nested translations',
     function (hooks) {
-      setupIntl(hooks);
+      setupIntl(hooks, 'en-us');
 
       test('hooks were properly executed and translations have been added (1)', async function (this: TestContext, assert) {
         const ENGLISH_LOCALE = 'en-us';

--- a/tests/ember-intl/tests/unit/services/intl-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl-test.ts
@@ -18,7 +18,7 @@ interface TestContext extends BaseTestContext {
 module('service:init initialization', function (hooks) {
   setupTest(hooks);
 
-  test('it calls `setLocale` on init', async function (this: TestContext, assert) {
+  test('it does not call `setLocale` on init', async function (this: TestContext, assert) {
     const Intl = this.owner.factoryFor('service:intl');
 
     const recompute = () => {
@@ -32,7 +32,7 @@ module('service:init initialization', function (hooks) {
 
     await settled();
 
-    assert.verifySteps(['Recompute helper']);
+    assert.verifySteps([]);
   });
 });
 


### PR DESCRIPTION
## Why?

We can solve a few issues when we ask end-developers to specify the locale in `setupIntl()`:

- Close #1789 (a bug report).
- Reduce call variations from 4 to 2 (reduces the package size and maintenance cost).
- Encourage people to write code that is explicit (helps onboard new developers).


## Solution?

When I removed lines [123](https://github.com/ember-intl/ember-intl/blob/v7.0.0-beta.3/packages/ember-intl/addon/services/intl.js#L123) and [126](https://github.com/ember-intl/ember-intl/blob/v7.0.0-beta.3/packages/ember-intl/addon/services/intl.js#L126), I saw that only the tests where I hadn't specified the locale would fail. This led me to conclude that the two lines had been introduced in the past, just so that we could write `setupIntl(hooks)` (type as few characters as possible).

After removing the two lines, I confirmed that [`locales`](https://github.com/ember-intl/ember-intl/blob/v7.0.0-beta.3/packages/ember-intl/addon/services/intl.js#L37-L39) no longer lists `'en-us'` by default.

By requiring the locale in `setupIntl()`, I was able to refactor code and simplify the file `addon-test-support/setup-intl.ts`. There will be a separate pull request, where `addTranslations()` will also require the locale.


## Notes

I traced when we had begun to implicitly set `'en-us'` in the `intl`'s service to https://github.com/ember-intl/ember-intl/commit/b75fd17caf961eaca608a33cc43030906ba71447 and https://github.com/ember-intl/ember-intl/commit/b05b5102360f1a9e4fb994bb1aa01e8d57a8b3ce. Furthermore, the bug in #1789 seemed to have appeared after #1530 (when the `intl` service had been rewritten as a native class).
