### PR TITLE
Fixed a memory leak. Ensured that registerDestructor is called when helpers are destroyed.

### DIFF
--- a/.changeset/lazy-dolls-thank.md
+++ b/.changeset/lazy-dolls-thank.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+---
+
+Fixed a memory leak. Ensured that registerDestructor is called when helpers are destroyed.

--- a/packages/ember-intl/addon/services/intl.js
+++ b/packages/ember-intl/addon/services/intl.js
@@ -333,7 +333,7 @@ export default class IntlService extends Service {
   onLocaleChanged(fn, context) {
     this._ee.on('localeChanged', fn, context);
 
-    registerDestructor(this, () => {
+    registerDestructor(context, () => {
       this._ee.off('localeChanged', fn, context);
     });
   }

--- a/tests/ember-intl/tests/unit/services/intl-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl-test.ts
@@ -1,3 +1,4 @@
+import Helper from '@ember/component/helper';
 import { registerWarnHandler } from '@ember/debug';
 import { isHTMLSafe } from '@ember/template';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
@@ -18,14 +19,16 @@ module('service:init initialization', function (hooks) {
   setupTest(hooks);
 
   test('it calls `setLocale` on init', async function (this: TestContext, assert) {
+    const Intl = this.owner.factoryFor('service:intl');
+
     const recompute = () => {
       assert.step('Recompute helper');
     };
 
-    const Intl = this.owner.factoryFor('service:intl');
+    const context = class THelper extends Helper {};
 
     // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    Intl.create().onLocaleChanged(recompute, undefined);
+    Intl.create().onLocaleChanged(recompute, context);
 
     await settled();
 
@@ -274,8 +277,10 @@ module('service:intl', function (hooks) {
       assert.step('Recompute helper');
     };
 
+    const context = class THelper extends Helper {};
+
     // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(recompute, undefined);
+    this.intl.onLocaleChanged(recompute, context);
 
     this.intl.setLocale(['de', 'en-us']);
 


### PR DESCRIPTION
Why?
Fix for the memory leak of https://github.com/ember-intl/ember-intl/issues/1848. 

Solution?
Currently, the destructor in ember-intl is not called when destroying a component that consumes the t-helper (and possibly other helpers as well). This PR fixes that. Not sure about possible other side effects.

Simpler fix than #1851

Best regards,
johan