### PR TITLE
Removed @types/htmlbars-inline-precompile from devDependencies

### DIFF
--- a/.changeset/stale-gifts-allow.md
+++ b/.changeset/stale-gifts-allow.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Removed @types/htmlbars-inline-precompile from devDependencies

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -81,7 +81,6 @@
     "@types/ember__service": "^4.0.9",
     "@types/ember__template": "^4.0.7",
     "@types/ember__utils": "^4.0.7",
-    "@types/htmlbars-inline-precompile": "^3.0.3",
     "@types/qunit": "^2.19.10",
     "concurrently": "^8.2.2",
     "ember-cli": "~5.7.0",

--- a/packages/ember-intl/types/global.d.ts
+++ b/packages/ember-intl/types/global.d.ts
@@ -1,6 +1,6 @@
 // Types for compiled templates
 declare module 'ember-intl/templates/*' {
-  import type { TemplateFactory } from 'htmlbars-inline-precompile';
+  import type { TemplateFactory } from 'ember-cli-htmlbars';
   const tmpl: TemplateFactory;
   export default tmpl;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,9 +878,6 @@ importers:
       '@types/ember__utils':
         specifier: ^4.0.7
         version: 4.0.7(@babel/core@7.24.0)
-      '@types/htmlbars-inline-precompile':
-        specifier: ^3.0.3
-        version: 3.0.3
       '@types/qunit':
         specifier: ^2.19.10
         version: 2.19.10
@@ -5036,10 +5033,6 @@ packages:
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 20.11.19
-    dev: true
-
-  /@types/htmlbars-inline-precompile@3.0.3:
-    resolution: {integrity: sha512-utarMsjpGrHc67F0o4AitUwNOW8YWeF2JfAixWQoZIOy/tyIOxw/qHHQS5AnuazDa1Rt2Mlr9OlHDFD72QJMrA==}
     dev: true
 
   /@types/http-errors@2.0.4:


### PR DESCRIPTION
## Why?

`@types/htmlbars-inline-precompile` was needed for `lint:types` to pass, only because `types/global.d.ts` hadn't been updated to show the new path `ember-cli-htmlbars`.
