### PR TITLE
Added CHANGELOG.md and tsconfig.json to .npmignore

### DIFF
--- a/packages/ember-intl/.npmignore
+++ b/packages/ember-intl/.npmignore
@@ -19,14 +19,16 @@
 /.stylelintrc.js
 /.template-lintrc.js
 /.watchmanconfig
+/CHANGELOG.md
 /CONTRIBUTING.md
 /ember-cli-build.js
 /pnpm-lock.yaml
 /testem.js
 /tests/
+/tsconfig.declarations.json
+/tsconfig.json
 /yarn-error.log
 /yarn.lock
-/jsconfig.json
 .gitkeep
 
 # ember-try


### PR DESCRIPTION
## Why?

After releasing [`7.0.0-beta.1`](https://www.npmjs.com/package/ember-intl/v/7.0.0-beta.1?activeTab=code), I realized that `CHANGELOG.md` and `tsconfig.json` are shipped to end-developers. These shouldn't be needed for their development.

By removing these, `ember-intl` will be considered (by `npm`, etc.) to have a smaller package size (from ~126kB to ~106kB).
