### PR TITLE
Removed incorrect passage in quickstart for addons. Updated the migration guide to v7.

### DIFF
--- a/.changeset/popular-fireants-double.md
+++ b/.changeset/popular-fireants-double.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": patch
+---
+
+Removed incorrect passage in quickstart for addons. Updated the migration guide to v7.

--- a/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/quickstart-addons.md
@@ -1,6 +1,6 @@
 # Quickstart (Addons)
 
-Addons need to publish a folder called `translations`. Note, `translations` is the name that your apps expect, unless configured otherwise.
+Addons need to publish a folder called `translations`.
 
 
 ## 1. Install ember-intl

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -62,7 +62,7 @@ export default class MyComponent extends Component {
   @service declare intl: Services['intl'];
 
   get outputForIntl(): string {
-    return this.intl.formatList(this.fruits);
+    return this.intl.formatList(this.args.fruits);
   }
 
   get outputForT(): string {
@@ -84,7 +84,7 @@ export default class MyComponent extends Component {
 
 The `@dependentKeyCompat` decorator was used to support the `@intl` and `@t` macros. Now that these macros are gone, so is `@dependentKeyCompat`.
 
-This change should fix the error `You attempted to update _locale [...] in the same computation.` that you might have seen in `ember-intl@v6`.
+This change should fix the error [`You attempted to update _locale [...] in the same computation.`](./v6#missing-setupintl-results-in-a-runtime-error) that you might have seen in `ember-intl@v6`.
 
 This change may be breaking if you have a computed property that lists `intl.locale` or `intl.primaryLocale` as a dependent key. You may try to glimmerize the classic component (recommended) or move the logic inside the computed property "outside."
 


### PR DESCRIPTION
## Why?

Patches the documentation site released in `7.0.0-beta.1`.
