### PR TITLE
Remove broccoli merge files

### DIFF
--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -5,8 +5,6 @@
 const { existsSync } = require('node:fs');
 const { dirname, isAbsolute, join } = require('node:path');
 const mergeTrees = require('broccoli-merge-trees');
-const { BroccoliMergeFiles } = require('broccoli-merge-files');
-const stringify = require('json-stable-stringify');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
 
 const buildTranslationTree = require('./lib/broccoli/build-translation-tree');
@@ -100,21 +98,7 @@ module.exports = {
         },
       });
 
-      const flattenedTranslationTree = new BroccoliMergeFiles(
-        [translationTree],
-        {
-          outputFileName: 'translations.js',
-          merge: (entries) => {
-            const output = entries.map(([locale, translations]) => {
-              return [locale, JSON.parse(translations)];
-            });
-
-            return 'export default ' + stringify(output);
-          },
-        },
-      );
-
-      trees.push(flattenedTranslationTree);
+      trees.push(translationTree);
     }
 
     return this._super.treeForAddon.call(

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -75,7 +75,6 @@ module.exports = {
       stripEmptyTranslations,
       wrapTranslationsWithNamespace,
       verbose: !this.isSilent,
-      filename: options.filename,
       outputPath: 'outputPath' in options ? options.outputPath : outputPath,
       addonsWithTranslations,
       log: (...args) => {
@@ -93,9 +92,6 @@ module.exports = {
     if (!this.configOptions.publicOnly) {
       const translationTree = this.generateTranslationTree({
         outputPath: '',
-        filename(key) {
-          return key;
-        },
       });
 
       trees.push(translationTree);

--- a/packages/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -232,15 +232,20 @@ class TranslationReducer extends CachingWriter {
           translations[locale],
         );
       }
-
-      writeFileSync(
-        `${filepath}/${this.generateFilename(locale)}`,
-        stringify(translations[locale]),
-        {
-          encoding: 'utf8',
-        },
-      );
     }
+
+    const restructuredTranslations = [];
+    for (const [locale, hash] of Object.entries(translations)) {
+      restructuredTranslations.push([locale, hash]);
+    }
+
+    writeFileSync(
+      `${filepath}/translations.js`,
+      'export default ' + stringify(restructuredTranslations),
+      {
+        encoding: 'utf8',
+      },
+    );
   }
 
   validateMessages(messages, locale) {

--- a/packages/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -138,14 +138,6 @@ class TranslationReducer extends CachingWriter {
     }, {});
   }
 
-  generateFilename(locale) {
-    if (typeof this.options.filename === 'function') {
-      return this.options.filename(locale);
-    }
-
-    return `${locale}.json`;
-  }
-
   handleLintResult(result) {
     const { icuMismatch, missingTranslations } = result;
     const throwingMessages = [];

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -39,7 +39,6 @@
     "@formatjs/intl": "^2.10.0",
     "broccoli-caching-writer": "^3.0.3",
     "broccoli-funnel": "^3.0.8",
-    "broccoli-merge-files": "^0.8.0",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-source": "^3.0.1",
     "broccoli-stew": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -757,9 +757,6 @@ importers:
       broccoli-funnel:
         specifier: ^3.0.8
         version: 3.0.8
-      broccoli-merge-files:
-        specifier: ^0.8.0
-        version: 0.8.0
       broccoli-merge-trees:
         specifier: ^4.2.0
         version: 4.2.0
@@ -7269,16 +7266,6 @@ packages:
       glob: 5.0.15
       mkdirp: 0.5.6
 
-  /broccoli-merge-files@0.8.0:
-    resolution: {integrity: sha512-S6dXHECbDkr7YMuCitAAQT8EZeW/kXom0Y8+QmQfiSkWspkKDGrr4vXgEZJjWqfa/FSx/Y18NEEOuMmbIW+XNQ==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      broccoli-plugin: 1.3.1
-      fast-glob: 3.3.2
-      lodash.defaults: 4.2.0
-      p-event: 2.3.1
-    dev: false
-
   /broccoli-merge-trees@1.2.4:
     resolution: {integrity: sha512-RXJAleytlED0dxXGEo2EXwrg5cCesY8LQzzGRogwGQmluoz+ijzxajpyWAW6wu/AyuQZj1vgnIqnld8jvuuXtQ==}
     dependencies:
@@ -13767,10 +13754,6 @@ packages:
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  /lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-    dev: false
-
   /lodash.defaultsdeep@4.6.1:
     resolution: {integrity: sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==}
     dev: true
@@ -14834,13 +14817,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /p-event@2.3.1:
-    resolution: {integrity: sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==}
-    engines: {node: '>=6'}
-    dependencies:
-      p-timeout: 2.0.1
-    dev: false
-
   /p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -14851,6 +14827,7 @@ packages:
   /p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
+    dev: true
 
   /p-finally@2.0.1:
     resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
@@ -14929,13 +14906,6 @@ packages:
     dependencies:
       aggregate-error: 3.1.0
     dev: true
-
-  /p-timeout@2.0.1:
-    resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
-    engines: {node: '>=4'}
-    dependencies:
-      p-finally: 1.0.0
-    dev: false
 
   /p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}

--- a/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/base-case-test.js
+++ b/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/base-case-test.js
@@ -20,8 +20,8 @@ describe('lib | broccoli | translation-reducer | index | base case', function ()
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
         });
       } finally {
         await output.dispose();

--- a/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/excludeLocales-test.js
+++ b/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/excludeLocales-test.js
@@ -22,7 +22,8 @@ describe('lib | broccoli | translation-reducer | index | excludeLocales', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}]]',
         });
       } finally {
         await output.dispose();
@@ -50,7 +51,9 @@ describe('lib | broccoli | translation-reducer | index | excludeLocales', functi
       try {
         await output.build();
 
-        expect(output.read()).to.deep.equal({});
+        expect(output.read()).to.deep.equal({
+          'translations.js': 'export default []',
+        });
       } finally {
         await output.dispose();
       }
@@ -79,7 +82,8 @@ describe('lib | broccoli | translation-reducer | index | excludeLocales', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}]]',
         });
       } finally {
         await output.dispose();

--- a/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/fallbackLocale-test.js
+++ b/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/fallbackLocale-test.js
@@ -22,8 +22,8 @@ describe('lib | broccoli | translation-reducer | index | fallbackLocale', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
         });
       } finally {
         await output.dispose();
@@ -52,8 +52,8 @@ describe('lib | broccoli | translation-reducer | index | fallbackLocale', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
         });
       } finally {
         await output.dispose();

--- a/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/includeLocales-test.js
+++ b/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/includeLocales-test.js
@@ -22,7 +22,8 @@ describe('lib | broccoli | translation-reducer | index | includeLocales', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'translations.js':
+            'export default [["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
         });
       } finally {
         await output.dispose();
@@ -51,8 +52,8 @@ describe('lib | broccoli | translation-reducer | index | includeLocales', functi
         await output.build();
 
         expect(output.read()).to.deep.equal({
-          'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-          'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+          'translations.js':
+            'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
         });
       } finally {
         await output.dispose();

--- a/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/outputPath-test.js
+++ b/tests/ember-intl-node/tests/lib/broccoli/translation-reducer/index/outputPath-test.js
@@ -25,8 +25,8 @@ describe('lib | broccoli | translation-reducer | index | outputPath', function (
           custom: {
             output: {
               path: {
-                'de-de.json': `{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}`,
-                'en-us.json': `{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}`,
+                'translations.js':
+                  'export default [["de-de",{"nested":{"key":"Hallo {name}!"},"no-arguments":"Hallo Welt!"}],["en-us",{"nested":{"key":"Hello {name}!"},"no-arguments":"Hello world!"}]]',
               },
             },
           },


### PR DESCRIPTION
## Why?

There are multiple vulnerabilities being brought in by broccoli-merge-files. See: https://github.com/ember-intl/ember-intl/issues/1858

The overrides done here: https://github.com/ember-intl/ember-intl/pull/1791 actually do not assist consumers of this package, because they will be creating their own lockfile (with any package manager not just pnpm) which will not respect those overrides.

This branch is created off the v6.5.3 tag and it would be awesome if we could get it in as a patch version of 6.x, as waiting for a 7.0 release may be a while off and these are getting flagged in security systems right now. 

## Solution?

It turns out this dependency wasn't doing much for us as removing it was fairly trivial. Given that it appears that project may be abandoned, and there have been previous security issues related to it, I think it makes sense to just not use it.

The translation reducer class already exists to apply the logic around filtering/removing/defaulting translations and then creating intermediate json files that broccoli-merge-files then combined into one. Now the intermediate json files are not created, and instead the final `translations.js` is created without broccoli-merge-files. 

Note: There were 8 failing tests relating to date formatting that existed prior to any changes I made. I fixed all other broken tests though that this refactor caused.

Would be amazing if we could get this in and released! This addon has been extremely helpful for our team. 

