### PR TITLE
Pinned ember-beta and ember-canary

### DIFF
--- a/tests/ember-intl/config/ember-try.js
+++ b/tests/ember-intl/config/ember-try.js
@@ -48,7 +48,8 @@ module.exports = async function () {
         name: 'ember-beta',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('beta'),
+            // 'ember-source': await getChannelURL('beta'),
+            'ember-source': '5.9.0-beta.1',
           },
         },
       },
@@ -56,7 +57,8 @@ module.exports = async function () {
         name: 'ember-canary',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('canary'),
+            // 'ember-source': await getChannelURL('canary'),
+            'ember-source': '5.10.0-alpha.1',
           },
         },
       },


### PR DESCRIPTION
## Why?

`ember-beta` and `ember-canary` scenarios failed in #1873. The error messages are similar to those that I had seen in [`ember-container-query`](https://github.com/ijlee2/ember-container-query/pull/227/commits/6cfe84f840e30170ecd33eee8dfd229161d24a4d).

<details>

<summary>Logs for <code>ember-beta</code></summary>

```sh
Run pnpm test:ember-compatibility ember-beta --- pnpm test
  pnpm test:ember-compatibility ember-beta --- pnpm test
  shell: /usr/bin/bash -e {0}
  env:
    NODE_VERSION: 18
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin

> test-app-for-ember-intl@1.3.10 test:ember-compatibility /home/runner/work/ember-intl/ember-intl/tests/ember-intl
> ./node_modules/.bin/ember try:one "ember-beta" "---" "pnpm" "test"

ERR_PNPM_NO_MATCHING_VERSION No matching version found for ember-source@5.9.0-beta.1.beta

This error happened while installing a direct dependency of /home/runner/work/ember-intl/ember-intl/docs/my-v2-addon

The latest release of ember-source is "5.8.0".

Other releases are:
  * beta: 5.9.0-beta.1
  * lts: 5.4.0
  * old: 5.4.1
  * release-3-1: 3.1.4
  * alpha: 5.10.0-alpha.4
```

</details>

<details>

<summary>Logs for <code>ember-canary</code></summary>

```sh
Run pnpm test:ember-compatibility ember-canary --- pnpm test
  pnpm test:ember-compatibility ember-canary --- pnpm test
  shell: /usr/bin/bash -e {0}
  env:
    NODE_VERSION: 18
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin

> test-app-for-ember-intl@1.3.10 test:ember-compatibility /home/runner/work/ember-intl/ember-intl/tests/ember-intl
> ./node_modules/.bin/ember try:one "ember-canary" "---" "pnpm" "test"

ERR_PNPM_NO_MATCHING_VERSION No matching version found for ember-source@5.10.0-alpha.1.canary

This error happened while installing a direct dependency of /home/runner/work/ember-intl/ember-intl/docs/my-v2-addon

The latest release of ember-source is "5.8.0".

Other releases are:
  * beta: 5.9.0-beta.1
  * lts: 5.4.0
  * old: 5.4.1
  * release-3-1: 3.1.4
  * alpha: 5.10.0-alpha.4
```


## Solution?

<!-- Please provide a brief description of the solution. -->

