### PR TITLE
Removed 3 dependencies

### DIFF
--- a/.changeset/dry-houses-eat.md
+++ b/.changeset/dry-houses-eat.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Removed 3 dependencies

--- a/packages/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -24,6 +24,10 @@ function filterPatterns(locales) {
   return null;
 }
 
+function isApp(filePath) {
+  return !filePath.includes(`/${enums.addonNamespace}/`);
+}
+
 function normalizeLocale(locale) {
   if (typeof locale === 'string') {
     return locale.replace(/_/g, '-').trim().toLowerCase();
@@ -88,17 +92,16 @@ class TranslationReducer extends CachingWriter {
   }
 
   mergeTranslations(filePaths) {
-    const addonPrefix = `/${enums.addonNamespace}/`;
-
-    // List the addon's translation files first, then the app's.
-    // This way, the app can override an addon's translations.
     const orderedFilePaths = filePaths.sort(function (filePath1, filePath2) {
-      if (filePath1.includes(addonPrefix) && !filePath2.includes(addonPrefix)) {
-        return -1;
+      const isApp1 = isApp(filePath1);
+      const isApp2 = isApp(filePath2);
+
+      if (isApp1 && !isApp2) {
+        return 1;
       }
 
-      if (!filePath1.includes(addonPrefix) && filePath2.includes(addonPrefix)) {
-        return 1;
+      if (isApp2 && !isApp1) {
+        return -1;
       }
 
       return 0;

--- a/packages/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -116,7 +116,6 @@ class TranslationReducer extends CachingWriter {
 
       let translationObject = readAsObject(filePath);
 
-      // TODO: make the default in 6.0.0
       if (this.options.stripEmptyTranslations === true) {
         translationObject = stripEmptyTranslations(translationObject);
       }

--- a/packages/ember-intl/lib/broccoli/translation-reducer/index.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/index.js
@@ -13,6 +13,25 @@ const wrapWithNamespaceIfNeeded = require('./utils/wrap-with-namespace-if-needed
 const isKnownLanguage = require('./utils/is-known-language');
 const enums = require('../enums');
 
+function filterPatterns(locales) {
+  if (Array.isArray(locales)) {
+    return locales.map(
+      (locale) =>
+        new RegExp(`${normalizeLocale(locale)}.(json|yaml|yml)$`, 'i'),
+    );
+  }
+
+  return null;
+}
+
+function normalizeLocale(locale) {
+  if (typeof locale === 'string') {
+    return locale.replace(/_/g, '-').trim().toLowerCase();
+  }
+
+  return locale;
+}
+
 function readAsObject(filepath) {
   const data = readFileSync(filepath);
   const ext = extname(filepath);
@@ -27,25 +46,6 @@ function readAsObject(filepath) {
       return yaml.load(data);
     }
   }
-}
-
-function normalizeLocale(locale) {
-  if (typeof locale === 'string') {
-    return locale.replace(/_/g, '-').trim().toLowerCase();
-  }
-
-  return locale;
-}
-
-function filterPatterns(locales) {
-  if (Array.isArray(locales)) {
-    return locales.map(
-      (locale) =>
-        new RegExp(`${normalizeLocale(locale)}.(json|yaml|yml)$`, 'i'),
-    );
-  }
-
-  return null;
 }
 
 class TranslationReducer extends CachingWriter {

--- a/packages/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
+++ b/packages/ember-intl/lib/broccoli/translation-reducer/utils/wrap-with-namespace-if-needed.js
@@ -9,14 +9,14 @@ const enums = require('../../enums');
  *
  * @method wrapWithNamespaceIfNeeded
  * @param {Object} object
- * @param {String} filepath
+ * @param {String} filePath
  * @param {String} inputPath
  * @param {String[]} addonNames Names of the addons with translations
  * @return {Object} Returns the input object
  * @private
  */
-function wrapWithNamespaceIfNeeded(object, filepath, inputPath, addonNames) {
-  const normalizedFilePath = normalize(filepath);
+function wrapWithNamespaceIfNeeded(object, filePath, inputPath, addonNames) {
+  const normalizedFilePath = normalize(filePath);
   const normalizedInputPath = normalize(inputPath);
   const normalizedAddonNames = addonNames.map(normalize);
 

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -47,7 +47,6 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-typescript": "^5.3.0",
     "eventemitter3": "^5.0.1",
-    "extend": "^3.0.2",
     "intl-messageformat": "^10.5.11",
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.1.1"

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -41,7 +41,6 @@
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-source": "^3.0.1",
-    "broccoli-stew": "^3.0.0",
     "calculate-cache-key-for-tree": "^2.0.0",
     "cldr-core": "^44.1.0",
     "ember-auto-import": "^2.7.2",
@@ -49,7 +48,6 @@
     "ember-cli-typescript": "^5.3.0",
     "eventemitter3": "^5.0.1",
     "extend": "^3.0.2",
-    "fast-memoize": "^2.5.2",
     "intl-messageformat": "^10.5.11",
     "js-yaml": "^4.1.0",
     "json-stable-stringify": "^1.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,9 +1369,6 @@ importers:
       broccoli-source:
         specifier: ^3.0.1
         version: 3.0.1
-      broccoli-stew:
-        specifier: ^3.0.0
-        version: 3.0.0
       calculate-cache-key-for-tree:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1390,12 +1387,6 @@ importers:
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
-      extend:
-        specifier: ^3.0.2
-        version: 3.0.2
-      fast-memoize:
-        specifier: ^2.5.2
-        version: 2.5.2
       intl-messageformat:
         specifier: ^10.5.11
         version: 10.5.11
@@ -12386,10 +12377,6 @@ packages:
       is-extendable: 1.0.1
     dev: true
 
-  /extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-    dev: false
-
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
     dev: true
@@ -12446,10 +12433,6 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  /fast-memoize@2.5.2:
-    resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
-    dev: false
 
   /fast-ordered-set@1.0.3:
     resolution: {integrity: sha512-MxBW4URybFszOx1YlACEoK52P6lE3xiFcPaGCUZ7QQOZ6uJXKo++Se8wa31SjcZ+NC/fdAWX7UtKEfaGgHS2Vg==}


### PR DESCRIPTION
## Why?

Currently, `ember-intl` has 18 dependencies. By removing unused and unnecessary ones, we can maintain the project more easily.


## Solution?

To remove [`extend`](https://github.com/justmoon/node-extend), I first performed a few refactors to understand the file `lib/broccoli/translation-reducer/index.js` better. I relied on the tests in `docs/my-app` and `tests/ember-intl-node` when replacing `extend()` with `Object.assign()`.
