### PR TITLE
Required locale in addTranslations()

### DIFF
--- a/.changeset/beige-bears-fold.md
+++ b/.changeset/beige-bears-fold.md
@@ -1,0 +1,7 @@
+---
+"ember-intl": major
+"test-app-for-ember-intl": patch
+"docs-app-for-ember-intl": patch
+---
+
+Required locale in addTranslations()

--- a/docs/ember-intl/app/templates/docs/guide/testing.md
+++ b/docs/ember-intl/app/templates/docs/guide/testing.md
@@ -96,11 +96,9 @@ module('Integration | Component | hello', function (hooks) {
 ```
 
 
-## addTranslations([locale], translations)
+## addTranslations(locale, translations)
 
 Updates the translations as if you had somehow added them (e.g. via lazy loading).
-
-The first parameter, `locale`, is optional and defaults to the last currently active locale. For example, if the current locales are `['en-ca', 'en-gb', 'en-us']`, then the translations will be added to `'en-us'` by default.
 
 ```ts
 import { render } from '@ember/test-helpers';
@@ -123,7 +121,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
       .doesNotIncludeText('Hello, Zoey!')
       .hasText('t:lazy-hello.message:("name":"Zoey")');
 
-    await addTranslations({
+    await addTranslations('en-us', {
       'lazy-hello': {
         message: 'Hello, {name}!',
       },

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -202,3 +202,30 @@ module('Integration | Component | hello', function (hooks) {
   });
 });
 ```
+
+Similarly, `addTranslations()` now requires the locale.
+
+```diff
+module('Integration | Component | lazy-hello', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  test('Lazily loaded translations', async function (assert) {
+    await render(hbs`
+      <LazyHello @name="Zoey" />
+    `);
+
+    assert
+      .dom('[data-test-message]')
+      .hasText('t:lazy-hello.message:("name":"Zoey")');
+
+-     await addTranslations({
++     await addTranslations('en-us', {
+      'lazy-hello': {
+        message: 'Hello, {name}!',
+      },
+    });
+
+    assert.dom('[data-test-message]').hasText('Hello, Zoey!')
+  });
+});

--- a/packages/ember-intl/addon-test-support/add-translations.ts
+++ b/packages/ember-intl/addon-test-support/add-translations.ts
@@ -3,37 +3,17 @@ import { getContext, settled, type TestContext } from '@ember/test-helpers';
 import type { IntlService } from 'ember-intl';
 import type { Translations } from 'ember-intl/types';
 
-function pickLastLocale(locale: string | string[]): string {
-  if (typeof locale === 'string') {
-    return locale;
-  }
-
-  return locale[locale.length - 1]!;
-}
-
 /**
  * Updates the translations as if you had somehow added them (e.g.
  * via lazy loading).
  *
- * The first parameter, `locale`, is optional and defaults to the last
- * currently active locale. For example, if the current locales are
- * `['en-ca', 'en-gb', 'en-us']`, then the translations will be added
- * to `'en-us'` by default.
- *
  * @function addTranslations
- * @param {string} [locale]
+ * @param {string} locale
  * @param {object} translations
  */
 export async function addTranslations(
-  translations: Translations,
-): Promise<void>;
-export async function addTranslations(
   locale: string,
   translations: Translations,
-): Promise<void>;
-export async function addTranslations(
-  localeOrTranslations: string | Translations,
-  translations?: Translations,
 ): Promise<void> {
   const { owner } = getContext() as TestContext;
 
@@ -44,18 +24,7 @@ export async function addTranslations(
 
   const intl = owner.lookup('service:intl') as IntlService;
 
-  let _locale: string;
-  let _translations: Translations;
-
-  if (typeof localeOrTranslations === 'object') {
-    _locale = pickLastLocale(intl.locale);
-    _translations = localeOrTranslations;
-  } else {
-    _locale = localeOrTranslations;
-    _translations = translations!;
-  }
-
-  intl.addTranslations(_locale, _translations);
+  intl.addTranslations(locale, translations);
 
   await settled();
 }

--- a/packages/ember-intl/addon-test-support/setup-intl.ts
+++ b/packages/ember-intl/addon-test-support/setup-intl.ts
@@ -47,7 +47,7 @@ export interface SetupIntlOptions {
  */
 export function setupIntl(
   hooks: NestedHooks,
-  locale: string | string[],
+  locale: string,
   translations?: Translations,
   options?: SetupIntlOptions,
 ): void {
@@ -73,7 +73,7 @@ export function setupIntl(
     this.intl.setLocale(locale);
 
     if (translations) {
-      addTranslations(translations);
+      addTranslations(locale, translations);
     }
 
     await settled();

--- a/tests/ember-intl/tests/integration/components/lazy-hello-test.ts
+++ b/tests/ember-intl/tests/integration/components/lazy-hello-test.ts
@@ -11,7 +11,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
     setupIntl(nestedHooks, 'en-us');
 
     test('Translations are loaded before the component is rendered', async function (assert) {
-      await addTranslations({
+      await addTranslations('en-us', {
         'lazy-hello': {
           message: 'Hello, {name}!',
         },
@@ -54,7 +54,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
           'Before translations are loaded, we can write assertions against the test helper t().',
         );
 
-      await addTranslations({
+      await addTranslations('en-us', {
         'lazy-hello': {
           message: 'Hello, {name}!',
         },
@@ -81,7 +81,7 @@ module('Integration | Component | lazy-hello', function (hooks) {
         <LazyHello @name="Zoey" />
       `);
 
-      addTranslations({
+      addTranslations('en-us', {
         'lazy-hello': {
           message: 'Hello, {name}!',
         },

--- a/tests/ember-intl/tests/integration/test-helpers/index-test.ts
+++ b/tests/ember-intl/tests/integration/test-helpers/index-test.ts
@@ -31,6 +31,7 @@ module('Integration | Test Helpers', function (hooks) {
         't:some.translation:()',
         '`t` method serializes translation without variables',
       );
+
       assert.strictEqual(
         this.intl.t('some.translation', { foo: 'bar' }),
         't:some.translation:("foo":"bar")',
@@ -48,47 +49,49 @@ module('Integration | Test Helpers', function (hooks) {
         '`t` helper serializes translation with variables',
       );
 
-      const germanLocale = 'de-de';
       assert.notDeepEqual(
         this.intl.locale,
-        [germanLocale],
-        `locale was not '${germanLocale} before switching to it`,
+        ['de-de'],
+        'locale was not de-de before switching to it',
       );
 
       await setLocale('de-de');
+
       assert.deepEqual(
         this.intl.locale,
-        [germanLocale],
+        ['de-de'],
         `locale was switched with 'setLocale'`,
       );
 
-      await addTranslations({
+      await addTranslations('de-de', {
         some: {
           german: {
             translation: 'Guten Tag.',
           },
         },
       });
+
       assert.strictEqual(
         this.intl.t('some.german.translation'),
         'Guten Tag.',
         'addTranslations: adds translations to currently active locale, if invoked without explicit locale',
       );
 
-      const englishLocale = 'en-us';
-      await addTranslations(englishLocale, {
+      await addTranslations('en-us', {
         some: {
           english: {
             translation: 'Good day, sir.',
           },
         },
       });
+
       assert.notOk(
         this.intl.exists('some.english.translation'),
         'addTranslations: if explicit locale give, does not add the translations to currently active locale',
       );
 
-      await setLocale(englishLocale);
+      await setLocale('en-us');
+
       assert.strictEqual(
         this.intl.t('some.english.translation'),
         'Good day, sir.',
@@ -121,9 +124,7 @@ module('Integration | Test Helpers', function (hooks) {
     });
 
     module('With a non-default locale', function (hooks) {
-      const germanLocale = 'de-de';
-
-      setupIntl(hooks, germanLocale, {
+      setupIntl(hooks, 'de-de', {
         some: {
           translation: 'Der Kuchen ist eine Lüge.',
         },
@@ -138,7 +139,7 @@ module('Integration | Test Helpers', function (hooks) {
 
         assert.deepEqual(
           this.intl.locale,
-          [germanLocale],
+          ['de-de'],
           'locale has been switched',
         );
 
@@ -157,9 +158,7 @@ module('Integration | Test Helpers', function (hooks) {
       setupIntl(hooks, 'en-us');
 
       test('hooks were properly executed and translations have been added (1)', async function (this: TestContext, assert) {
-        const ENGLISH_LOCALE = 'en-us';
-
-        await addTranslations(ENGLISH_LOCALE, {
+        await addTranslations('en-us', {
           some: {
             translation: 'The {foo} is a lie.',
             nested_translation: '{count, plural, =1 {Cake} other {Cakes}}',


### PR DESCRIPTION
## Why?

Follows up on #1847.

We can solve a few issues when we ask end-developers to specify the locale in `addTranslations()`:

- Reduce call variations from 2 to 1 (reduces the package size and maintenance cost).
- Encourage people to write code that is explicit (helps onboard new developers).
