### PR TITLE
DOCS: Fix migration test sample

### DIFF
--- a/.changeset/fifty-seals-rush.md
+++ b/.changeset/fifty-seals-rush.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": patch
+---
+
+Fix migration test sample

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -197,7 +197,7 @@ module('Integration | Component | hello', function (hooks) {
         <Hello @name="Zoey" />
       `);
 
-      assert.dom('[data-test-message]').hasText('Hallo, Zoey!');
+      assert.dom('[data-test-message]').hasText('Hello, Zoey!');
     });
   });
 });


### PR DESCRIPTION
In migration sample there the assert in language `en` is not correct. It should be `Hello` instead of `Hallo`