### PR TITLE
Patched #1877 and #1882

### DIFF
--- a/.changeset/soft-ducks-leave.md
+++ b/.changeset/soft-ducks-leave.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+---
+
+Patched #1877 and #1882

--- a/packages/ember-intl/addon-test-support/set-locale.ts
+++ b/packages/ember-intl/addon-test-support/set-locale.ts
@@ -6,9 +6,9 @@ import type { IntlService } from 'ember-intl';
  * Updates the locale as if the user had changed their preferred language.
  *
  * @function setLocale
- * @param {string|string[]} locale
+ * @param {string} locale
  */
-export async function setLocale(locale: string | string[]): Promise<void> {
+export async function setLocale(locale: string): Promise<void> {
   const context = getContext();
 
   assert(

--- a/packages/ember-intl/lib/utils/find-engine.js
+++ b/packages/ember-intl/lib/utils/find-engine.js
@@ -1,6 +1,6 @@
 function findEngine(addon) {
   do {
-    const isEngine = addon.pkg?.keywords.includes('ember-engine');
+    const isEngine = addon.pkg?.keywords?.includes('ember-engine');
 
     if (isEngine) {
       return addon;

--- a/tests/ember-intl/tests/acceptance/smoke-tests-test.ts
+++ b/tests/ember-intl/tests/acceptance/smoke-tests-test.ts
@@ -9,7 +9,7 @@ module('Acceptance | smoke-tests', function (hooks) {
   module('de-de', function () {
     test('We can see translations', async function (assert) {
       await visit('/smoke-tests');
-      await setLocale(['de-de']);
+      await setLocale('de-de');
 
       assert
         .dom('[data-test-field="Format Number"]')


### PR DESCRIPTION
## Why?

Patches #1877 and #1882.

Changing the expected type of the test helper `setLocale()` may be a soft-breaking change, but should be easily fixable in consuming projects. The documentation site has shown usage with the string type.
