### PR TITLE
Allowed end-developers to specify what to do when @formatjs errors

### DIFF
--- a/.changeset/three-steaks-sit.md
+++ b/.changeset/three-steaks-sit.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": minor
+"test-app-for-ember-intl": patch
+---
+
+Allowed end-developers to specify what to do when @formatjs errors

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -53,6 +53,19 @@ export default class IntlService extends Service {
   private _formats?: Record<string, unknown>;
   private _timer?: EmberRunTimer;
 
+  private _onFormatjsError(error: Parameters<OnFormatjsError>[0]): void {
+    switch (error.code) {
+      case 'MISSING_TRANSLATION': {
+        // Do nothing
+        break;
+      }
+
+      default: {
+        throw error;
+      }
+    }
+  }
+
   private _onMissingTranslation: OnMissingTranslation = (key, locales) => {
     const locale = locales.join(', ');
 
@@ -250,6 +263,10 @@ export default class IntlService extends Service {
     this.updateIntl(locale);
   }
 
+  setOnFormatjsError(onFormatjsError: OnFormatjsError): void {
+    this._onFormatjsError = onFormatjsError;
+  }
+
   setOnMissingTranslation(onMissingTranslation: OnMissingTranslation): void {
     this._onMissingTranslation = onMissingTranslation;
   }
@@ -306,7 +323,7 @@ export default class IntlService extends Service {
         locale: resolvedLocale,
         // @ts-expect-error: Type 'Record<string, unknown>' is not assignable
         messages,
-        onError: this.onFormatjsError,
+        onError: this._onFormatjsError,
       },
       this._cache,
     );
@@ -338,19 +355,6 @@ export default class IntlService extends Service {
       | undefined;
 
     return translation;
-  }
-
-  private onFormatjsError(error: Parameters<OnFormatjsError>[0]): void {
-    switch (error.code) {
-      case 'MISSING_TRANSLATION': {
-        // Do nothing
-        break;
-      }
-
-      default: {
-        throw error;
-      }
-    }
   }
 
   private onLocaleChanged(fn: any, context: any) {

--- a/tests/ember-intl/tests/unit/services/intl-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl-test.ts
@@ -298,6 +298,47 @@ module('Unit | Service | intl', function (hooks) {
     });
   });
 
+  module('setOnFormatjsError()', function () {
+    test('default implementation', function (this: TestContext, assert) {
+      assert.throws(
+        () => {
+          this.intl.t('smoke-tests.hello.message', {
+            locale: 'de-de',
+          });
+        },
+        (error: Error & { code: string }) => {
+          assert.step('@formatjs/intl throws an error');
+
+          return error.code === 'FORMAT_ERROR';
+        },
+      );
+
+      assert.verifySteps(['@formatjs/intl throws an error']);
+    });
+
+    test('custom implementation ignores an error', function (this: TestContext, assert) {
+      this.intl.setOnFormatjsError((error) => {
+        switch (error.code) {
+          case 'FORMAT_ERROR': {
+            // Do nothing
+            break;
+          }
+
+          default: {
+            throw error;
+          }
+        }
+      });
+
+      assert.strictEqual(
+        this.intl.t('smoke-tests.hello.message', {
+          locale: 'de-de',
+        }),
+        'Hallo, {name}!',
+      );
+    });
+  });
+
   module('setOnMissingTranslation()', function () {
     test('default implementation', function (this: TestContext, assert) {
       assert.strictEqual(


### PR DESCRIPTION
## Why?

Closes #1688 and #1853.

By default, `ember-intl` re-throws the error when one of `@formatjs/intl`'s `format*()` methods is used incorrectly. Now, end-developers use the `intl` service's `setOnFormatjsError()` to override the default implementation.

It will be recommended in the documentation site, to call this method in the `application` route's `beforeEach()` hook (i.e. along with `setLocale()`).
