### PR TITLE
Made getTranslation() public

### DIFF
--- a/.changeset/spotty-seals-shave.md
+++ b/.changeset/spotty-seals-shave.md
@@ -1,0 +1,7 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+"docs-app-for-ember-intl": patch
+---
+
+Made getTranslation() public

--- a/docs/ember-intl/app/templates/docs/helpers/t.md
+++ b/docs/ember-intl/app/templates/docs/helpers/t.md
@@ -78,7 +78,7 @@ Note, when an argument doesn't have a value, `@formatjs/intl` will throw a `FORM
 You have {numPhotos, plural, =0 {no photos} =1 {one photo} other {# photos}}.
 ```
 
-Please check that all arguments are well-defined when using the `{{t}}` helper. You might consider creating default values.
+Please check that all arguments are well-defined when using the `{{t}}` helper. You might consider [creating default values](../services/intl-part-2#gettranslation-).
 
 ```hbs
 {{#let (hash numPhotos=0) as |fallback|}}

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -20,7 +20,7 @@ The `intl` service provides just the essentials so that we can reduce the packag
 - The `format*()` methods return an empty string when `value` (the 1st positional argument) is `undefined` or `null`. `options.allowEmpty` and `options.resilient` have no effect and can be removed.
 - The `t()` method no longer uses `assert()` to check that `key` (the 1st positional argument) is `string`. `options.default` has no effect and can be replaced with an `if-else` statement.
 - The `locale` getter and setter have been removed. Use `setLocale()` to set the locale.
-- The `lookup()` method is private and has been renamed to `getTranslation()`.
+- The `lookup()` method has been renamed to `getTranslation()` and requires you to specify the locale.
 - The `translationsFor()` method has been removed.
 
 The service has 2 additional methods to help you configure `ember-intl`. For more information, see the [documentation for `intl` service](../services/intl-part-2).

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -87,6 +87,18 @@ if (this.intl.exists('components.example.option-1', 'de-de')) {
 ```
 
 
+### getTranslation()
+
+Returns the translation message for a given key and locale.
+
+```ts
+console.log(this.intl.getTranslation('hello.message', 'de-de'));
+// 'Hallo, {name}!'
+```
+
+This method could be used to create default values for arguments, so that users don't see the raw message when an argument doesn't have a value. To extract the message arguments, you can use [`@formatjs/icu-messageformat-parser`](https://formatjs.io/docs/icu-messageformat-parser/).
+
+
 ### setLocale()
 
 Specify which locales are active. Used in the `application` route's `beforeModel()` hook, or in a component that allows users to set their preferred language.

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -240,6 +240,16 @@ export default class IntlService extends Service {
     return formatTime(intlShape, value, options);
   }
 
+  getTranslation(key: string, locale: string): string | undefined {
+    const messages = this.getIntl(locale)?.messages;
+
+    if (!messages) {
+      return;
+    }
+
+    return messages[key] as string | undefined;
+  }
+
   setLocale(locale: string | string[]): void {
     const proposedLocale = convertToArray(locale);
 
@@ -347,20 +357,6 @@ export default class IntlService extends Service {
     }
 
     return this.getIntl(this._locale!)!;
-  }
-
-  private getTranslation(key: string, locale: string): string | undefined {
-    const messages = this.getIntl(locale)?.messages;
-
-    if (!messages) {
-      return;
-    }
-
-    const translation = (messages as unknown as Record<string, string>)[key] as
-      | string
-      | undefined;
-
-    return translation;
   }
 
   private onLocaleChanged(fn: any, context: any) {

--- a/tests/ember-intl/tests/unit/services/intl-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl-test.ts
@@ -251,6 +251,39 @@ module('Unit | Service | intl', function (hooks) {
     });
   });
 
+  module('getTranslation()', function () {
+    test('returns the translation message', function (this: TestContext, assert) {
+      assert.strictEqual(
+        this.intl.getTranslation('smoke-tests.hello.message', 'de-de'),
+        'Hallo, {name}!',
+      );
+
+      assert.strictEqual(
+        this.intl.getTranslation('smoke-tests.hello.message', 'en-us'),
+        'Hello, {name}!',
+      );
+    });
+
+    test('returns undefined if the locale has no translations', function (this: TestContext, assert) {
+      assert.strictEqual(
+        this.intl.getTranslation('smoke-tests.hello.message', 'fr-fr'),
+        undefined,
+      );
+    });
+
+    test("returns undefined if the key doesn't exist for the given locale", function (this: TestContext, assert) {
+      assert.strictEqual(
+        this.intl.getTranslation('smoke-tests.hello', 'de-de'),
+        undefined,
+      );
+
+      assert.strictEqual(
+        this.intl.getTranslation('smoke-tests.hello', 'en-us'),
+        undefined,
+      );
+    });
+  });
+
   module('setLocale()', function () {
     test('triggers the localeChanged event', async function (this: TestContext, assert) {
       const callback = () => {


### PR DESCRIPTION
## Why?

Through [a Discord conversation with `@pieter_v` and `@void_malex`](https://discord.com/channels/480462759797063690/487648547685269515/1248592137843376190), I learned that the `intl` service's `lookup()` (now called `getTranslation()`) might have been a public method because end-developers needed to provide translations a default value when an argument is missing a value. A pseudocode can look like this:

1. Given a translation message, extract the ICU arguments.
1. Create an empty object, which will map argument names to default values.
1. For each argument, define its default value.
1. Pass the final object to the `{{t}}` helper as the 2nd positional argument.


## Solution?

I made `getTranslation()` a public method for two reasons:

- In `7.0.0-beta.6`, I had preemptively turned `getTranslation()` into a private method, because I didn't know why end-developers would need translation messages in their apps (the usage hadn't been documented).
- There is no other simple way to get translation messages.
