### PR TITLE
Fixed typos and provided migration examples

### DIFF
--- a/.changeset/tiny-seals-draw.md
+++ b/.changeset/tiny-seals-draw.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"docs-app-for-ember-intl": patch
+---
+
+Fixed typos and provided migration examples

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 - [7.x (stable)](https://ember-intl.github.io/ember-intl/)
 - [6.x (legacy)](https://ember-intl.github.io/ember-intl/versions/v6.5.5/)
+- [Changelog](https://github.com/ember-intl/ember-intl/blob/main/packages/ember-intl/CHANGELOG.md)
 
 
 ## Compatibility

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -17,13 +17,117 @@ The following versions are supported when issues arise.
 
 The `intl` service provides just the essentials so that we can reduce the package size and maintain the project easily. The service has been rewritten to provide native types. We highly recommend that you use TypeScript and Glint.
 
-- The `format*()` methods return an empty string when `value` (the 1st positional argument) is `undefined` or `null`. `options.allowEmpty` and `options.resilient` have no effect and can be removed.
-- The `t()` method no longer uses `assert()` to check that `key` (the 1st positional argument) is `string`. `options.default` has no effect and can be replaced with an `if-else` statement.
+- The `format*()` methods return an empty string when `value` (the 1st positional argument) is `undefined` or `null`. (In `v6`, the methods had relied on `isEmpty()` from `@ember/utils`, potentially allowing more values for `value` to return an empty string.)
+
+- The `format*()` methods don't make use of `options.allowEmpty`. Remove the option at invocation sites.
+
+```diff
+{{! Display an empty string while @message is loaded, i.e. @message.timestamp is undefined or null }}
+- {{format-date @message.timestamp allowEmpty=true}}
++ {{format-date @message.timestamp}}
+```
+
+- The `t()` method no longer uses `assert()` to check that `key` (the 1st positional argument) is `string`.
+
+- The `t()` method doesn't make use of `options.default`. Remove the option at invocation sites. In the backing class, use early exit(s) and the `intl` service's `exists()` to make the logic clear.
+
+```diff
+- {{t
+-   (concat "components.message.status-" @message.status)
+-   default="components.message.status-unknown"
+- }}
++ {{this.messageStatus}}
+```
+
+```diff
+import { type Registry as Services, service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class MessageComponent extends Component {
+  @service declare intl: Services['intl'];
+
++   get messageStatus(): string {
++     const { status } = this.args.message;
++ 
++     if (this.intl.exists(`components.message.status-${status}`)) {
++       return this.intl.t(`components.message.status-${status}`);
++     }
++ 
++     return this.intl.t('components.message.status-unknown');
++   }
+}
+```
+
+- The `t()` method doesn't make use of `options.resilient`. Remove the option at invocation sites. In the backing class, use early exit(s) and the `intl` service's `exists()` to make the logic clear.
+
+```diff
+- {{t
+-   (concat "components.message.status-" @message.status)
+-   resilient=true
+- }}
++ {{this.messageStatus}}
+```
+
+```diff
+import { type Registry as Services, service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class MessageComponent extends Component {
+  @service declare intl: Services['intl'];
+
++   get messageStatus(): string | undefined {
++     const { status } = this.args.message;
++ 
++     if (this.intl.exists(`components.message.status-${status}`)) {
++       return this.intl.t(`components.message.status-${status}`);
++     }
++   }
+}
+```
+
 - The `locale` getter and setter have been removed. Use `setLocale()` to set the locale.
-- The `lookup()` method has been renamed to `getTranslation()` and requires you to specify the locale.
+
+```diff
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  beforeModel() {
+-     this.intl.locale = ['en-us'];
++     this.intl.setLocale(['en-us']);
+  }
+}
+```
+
+- The `lookup()` method, which iterated through the `locales` getter when a locale hadn't been specified, has been removed. `v7` provides a simpler method called `getTranslation()`, one that requires you to specify the locale.
+
+If you need the translation message for the primary locale:
+
+```diff
+- const translation = this.intl.lookup('hello.message');
++ const translation = this.intl.getTranslation('hello.message', this.intl.primaryLocale);
+```
+
+If you need to replicate how `lookup()` iterated through `locales`:
+
+```ts
+let translation?: string;
+
+for (const locale of this.intl.locales) {
+  const candidate = this.intl.getTranslation('hello.message', locale);
+
+  if (candidate) {
+    translation = candidate;
+    break;
+  }
+}
+````
+
 - The `translationsFor()` method has been removed.
 
-The service has 2 additional methods to help you configure `ember-intl`. For more information, see the [documentation for `intl` service](../services/intl-part-2).
+The service provides 2 new methods to help you configure `ember-intl`. For more information, see the [documentation for `intl` service](../services/intl-part-2).
 
 - `setOnFormatjsError()` lets you define what to do when `@formatjs/intl` errors.
 - `setOnMissingTranslation()` lets you define what to display when a translation is missing. The file `app/utils/intl/missing-message.js` has no effect and can be removed.

--- a/docs/ember-intl/app/templates/docs/services/intl-part-1.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-1.md
@@ -24,7 +24,7 @@ Every `format*()` method returns an empty string when `value` (the 1st positiona
 
 Uses [`Intl.DateTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) to format a date.
 
-The 1st argument `key` is required and expects a `Date`, `number` (Unix timestamp), or `string` (ISO 8601). You can pass options for `Intl.DateTimeFormat` in the 2nd argument.
+The 1st argument `value` is required and expects a `Date`, `number` (Unix timestamp), or `string` (ISO 8601). You can pass options for `Intl.DateTimeFormat` in the 2nd argument.
 
 ```ts
 const output = this.intl.formatDate('2014-01-23T18:00:44');
@@ -110,7 +110,7 @@ const output = this.intl.formatRelative(-1);
 
 Behaves like `formatDate()`, except the possible formats are defined in `time` in `app/format.js`.
 
-The 1st argument `key` is required and expects a `Date`, `number` (Unix timestamp), or `string` (ISO 8601). You can pass options for `Intl.DateTimeFormat` in the 2nd argument.
+The 1st argument `value` is required and expects a `Date`, `number` (Unix timestamp), or `string` (ISO 8601). You can pass options for `Intl.DateTimeFormat` in the 2nd argument.
 
 ```ts
 const output = this.intl.formatTime('2014-01-23T18:00:44');

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -47,7 +47,7 @@ export default class ApplicationRoute extends Route {
       this.loadTranslations('en-us'),
     ]);
 
-    this.intl.setLocale(['en-us']);
+    this.intl.setLocale(['de-de', 'en-us']);
   }
 
   private async loadTranslations(locale: 'de-de' | 'en-us') {

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -23,6 +23,7 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 - [7.x (stable)](https://ember-intl.github.io/ember-intl/)
 - [6.x (legacy)](https://ember-intl.github.io/ember-intl/versions/v6.5.5/)
+- [Changelog](https://github.com/ember-intl/ember-intl/blob/main/packages/ember-intl/CHANGELOG.md)
 
 
 ## Compatibility


### PR DESCRIPTION
## Why?

In a [Discord conversation](https://discord.com/channels/480462759797063690/487648547685269515/1250554679243309068), I learned that the v7 migration guide doesn't provide enough examples to help people update `ember-intl`. I also fixed a few incorrect passages.
