### PR TITLE
Refactored _onFormatjsError

### DIFF
--- a/.changeset/nasty-melons-judge.md
+++ b/.changeset/nasty-melons-judge.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Consumed OnFormatjsError type directly

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -54,7 +54,7 @@ export default class IntlService extends Service {
   private _formats?: Record<string, unknown>;
   private _timer?: EmberRunTimer;
 
-  private _onFormatjsError(error: Parameters<OnFormatjsError>[0]): void {
+  private _onFormatjsError: OnFormatjsError = (error) => {
     switch (error.code) {
       case 'MISSING_TRANSLATION': {
         // Do nothing
@@ -65,7 +65,7 @@ export default class IntlService extends Service {
         throw error;
       }
     }
-  }
+  };
 
   private _onMissingTranslation: OnMissingTranslation = (key, locales) => {
     const locale = locales.join(', ');


### PR DESCRIPTION
## Why?

By consuming the `OnFormatjsError` type directly, we can make the code a bit easier to understand.
