### PR TITLE
Documented setLocale() with multiple locales

### DIFF
--- a/.changeset/early-pigs-love.md
+++ b/.changeset/early-pigs-love.md
@@ -1,0 +1,12 @@
+---
+"my-app-with-lazy-loaded-translations": patch
+"my-app-with-namespace-from-folders": patch
+"my-app-with-fallbacks": patch
+"my-classic-app": patch
+"my-v2-addon": patch
+"my-app": patch
+"my-v1-addon": patch
+"my-v1-engine": patch
+---
+
+Documented setLocale() with multiple locales

--- a/docs/my-app-with-fallbacks/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-fallbacks/tests/acceptance/index-test.ts
@@ -36,7 +36,7 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="App"]')
         .hasText(
-          '🐹🐹🐹 Missing: components.component-from-app.message (de-de) 🐹🐹🐹',
+          '🐹🐹🐹 Missing: components.component-from-app.message (de-de, en-us) 🐹🐹🐹',
         );
 
       assert
@@ -50,7 +50,7 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de) 🐹🐹🐹',
+          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de, en-us) 🐹🐹🐹',
         );
 
       assert

--- a/docs/my-app-with-fallbacks/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-fallbacks/tests/acceptance/index-test.ts
@@ -5,6 +5,10 @@ import {
 } from 'my-app-with-fallbacks/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -12,6 +16,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -63,6 +69,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert
         .dom('[data-test-output="Title"]')

--- a/docs/my-app-with-lazy-loaded-translations/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-lazy-loaded-translations/tests/acceptance/index-test.ts
@@ -48,7 +48,7 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          'Missing translation "routes.index.key-without-translation" for locale "de-de"',
+          'Missing translation "routes.index.key-without-translation" for locale "de-de, en-us"',
         );
 
       assert

--- a/docs/my-app-with-lazy-loaded-translations/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-lazy-loaded-translations/tests/acceptance/index-test.ts
@@ -5,6 +5,10 @@ import {
 } from 'my-app-with-lazy-loaded-translations/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -12,6 +16,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -61,6 +67,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert.dom('[data-test-output="Title"]').hasText('Welcome to ember-intl');
 

--- a/docs/my-app-with-namespace-from-folders/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-namespace-from-folders/tests/acceptance/index-test.ts
@@ -40,19 +40,19 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="V1 Addon"]')
         .hasText(
-          'Missing translation "components.component-from-v1-addon.message" for locale "de-de"',
+          'Missing translation "components.component-from-v1-addon.message" for locale "de-de, en-us"',
         );
 
       assert
         .dom('[data-test-output="V2 Addon"]')
         .hasText(
-          'Missing translation "components.component-from-v2-addon.message" for locale "de-de"',
+          'Missing translation "components.component-from-v2-addon.message" for locale "de-de, en-us"',
         );
 
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          'Missing translation "routes.index.key-without-translation" for locale "de-de"',
+          'Missing translation "routes.index.key-without-translation" for locale "de-de, en-us"',
         );
 
       assert

--- a/docs/my-app-with-namespace-from-folders/tests/acceptance/index-test.ts
+++ b/docs/my-app-with-namespace-from-folders/tests/acceptance/index-test.ts
@@ -5,6 +5,10 @@ import {
 } from 'my-app-with-namespace-from-folders/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -12,6 +16,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -65,6 +71,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert.dom('[data-test-output="Title"]').hasText('Welcome to ember-intl');
 

--- a/docs/my-app/tests/acceptance/index-test.ts
+++ b/docs/my-app/tests/acceptance/index-test.ts
@@ -2,6 +2,10 @@ import { visit } from '@ember/test-helpers';
 import { selectLocale, setupApplicationTest } from 'my-app/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -9,6 +13,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -58,6 +64,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert.dom('[data-test-output="Title"]').hasText('Welcome to ember-intl');
 

--- a/docs/my-app/tests/acceptance/index-test.ts
+++ b/docs/my-app/tests/acceptance/index-test.ts
@@ -45,7 +45,7 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          'Missing translation "routes.index.key-without-translation" for locale "de-de"',
+          'Missing translation "routes.index.key-without-translation" for locale "de-de, en-us"',
         );
 
       assert

--- a/docs/my-classic-app/tests/acceptance/index-test.ts
+++ b/docs/my-classic-app/tests/acceptance/index-test.ts
@@ -5,6 +5,10 @@ import {
 } from 'my-classic-app/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -12,6 +16,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -61,6 +67,8 @@ module('Acceptance | index', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert.dom('[data-test-output="Title"]').hasText('Welcome to ember-intl');
 

--- a/docs/my-classic-app/tests/acceptance/index-test.ts
+++ b/docs/my-classic-app/tests/acceptance/index-test.ts
@@ -48,7 +48,7 @@ module('Acceptance | index', function (hooks) {
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de) 🐹🐹🐹',
+          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de, en-us) 🐹🐹🐹',
         );
 
       assert

--- a/docs/my-classic-app/tests/acceptance/my-v1-engine-test.ts
+++ b/docs/my-classic-app/tests/acceptance/my-v1-engine-test.ts
@@ -5,6 +5,10 @@ import {
 } from 'my-classic-app/tests/helpers';
 import { module, test } from 'qunit';
 
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
 module('Acceptance | my-v1-engine', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -12,6 +16,8 @@ module('Acceptance | my-v1-engine', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/my-v1-engine');
       await selectLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
 
       assert
         .dom('[data-test-output="Title"]')
@@ -39,6 +45,8 @@ module('Acceptance | my-v1-engine', function (hooks) {
     test('We can visit the page', async function (assert) {
       await visit('/my-v1-engine');
       await selectLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
 
       assert
         .dom('[data-test-output="Title"]')

--- a/docs/my-classic-app/tests/acceptance/my-v1-engine-test.ts
+++ b/docs/my-classic-app/tests/acceptance/my-v1-engine-test.ts
@@ -26,7 +26,7 @@ module('Acceptance | my-v1-engine', function (hooks) {
       assert
         .dom('[data-test-output="Key Missing"]')
         .hasText(
-          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de) 🐹🐹🐹',
+          '🐹🐹🐹 Missing: routes.index.key-without-translation (de-de, en-us) 🐹🐹🐹',
         );
 
       assert

--- a/docs/my-v2-addon/src/components/select-locale.hbs
+++ b/docs/my-v2-addon/src/components/select-locale.hbs
@@ -5,7 +5,7 @@
 <select
   data-test-select-locale
   id={{this.fieldId}}
-  {{on "change" this.updateLocale}}
+  {{on "change" this.updateValue}}
 >
   {{!
     BUG: We can't conditionally render the `selected` attribute

--- a/docs/my-v2-addon/src/components/select-locale.ts
+++ b/docs/my-v2-addon/src/components/select-locale.ts
@@ -43,12 +43,29 @@ export default class SelectLocaleComponent extends Component<SelectLocaleSignatu
     ];
   }
 
-  @action updateLocale(event: Event): void {
+  updateLocale(value: SupportedLocale): void {
+    let locale: string[];
+
+    switch (value) {
+      case 'de-de': {
+        locale = ['de-de', 'en-us'];
+        break;
+      }
+
+      case 'en-us': {
+        locale = ['en-us'];
+        break;
+      }
+    }
+
+    // @ts-expect-error: Property 'setLocale' does not exist on type 'Service'
+    this.intl.setLocale(locale);
+  }
+
+  @action updateValue(event: Event): void {
     const value = (event.target as HTMLSelectElement).value as SupportedLocale;
 
     this.value = value;
-
-    // @ts-expect-error: Property 'setLocale' does not exist on type 'Service'
-    this.intl.setLocale([value]);
+    this.updateLocale(value);
   }
 }


### PR DESCRIPTION
## What changed?

I updated the `<SelectLocale>` component in `my-v2-addon` so that we can check in CI how listing multiple locales in `setLocale()` affects:

- Global `lang` attribute
- Fallback translation
- Error message for missing translation
