### PR TITLE
Documented how the dummy app can provide translations

### DIFF
--- a/.changeset/wicked-lies-dress.md
+++ b/.changeset/wicked-lies-dress.md
@@ -1,0 +1,7 @@
+---
+"ember-intl": patch
+"my-v1-addon": patch
+"docs-app-for-ember-intl": patch
+---
+
+Documented how the dummy app can provide translations

--- a/docs/ember-intl/app/templates/docs/advanced/configuration.md
+++ b/docs/ember-intl/app/templates/docs/advanced/configuration.md
@@ -57,14 +57,12 @@ This does **not** prevent missing translation warnings or errors. It's meant as 
 
 ## inputPath
 
-Path where translations are stored. This is relative to the project root.
-
-For example, if your translations are stored as a npm/yarn dependency, then this path would look something like `'./node_modules/path/to/translations'`.
+Where translations are stored, relative to the project root. For example, to have the `dummy` app in a v1 addon provide translations (these aren't published):
 
 ```js
 {
   // Default: 'translations'
-  inputPath: 'my-translations',
+  inputPath: 'tests/dummy/translations',
 }
 ```
 

--- a/docs/my-v1-addon/tests/acceptance/index-test.ts
+++ b/docs/my-v1-addon/tests/acceptance/index-test.ts
@@ -1,0 +1,46 @@
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
+import { setLocale } from 'ember-intl/test-support';
+import { module, test } from 'qunit';
+
+function getGlobalLang(): string | null {
+  return document.querySelector('html')!.getAttribute('lang');
+}
+
+module('Acceptance | index', function (hooks) {
+  setupApplicationTest(hooks);
+
+  module('de-de', function () {
+    test('We can visit the page', async function (assert) {
+      await visit('/');
+      await setLocale('de-de');
+
+      assert.strictEqual(getGlobalLang(), 'de-de');
+
+      assert.dom('[data-test-output="Title"]').hasText('Willkommen!');
+
+      assert
+        .dom('[data-test-output="Description"]')
+        .hasText(
+          'Das hier ist ein v1 Addon, um ember-intl zu testen. Vielleicht wolltest du die App in docs/my-app ausführen?',
+        );
+    });
+  });
+
+  module('en-us', function () {
+    test('We can visit the page', async function (assert) {
+      await visit('/');
+      await setLocale('en-us');
+
+      assert.strictEqual(getGlobalLang(), 'en-us');
+
+      assert.dom('[data-test-output="Title"]').hasText('Welcome!');
+
+      assert
+        .dom('[data-test-output="Description"]')
+        .hasText(
+          'This is a test v1 addon for ember-intl. Did you want to run the app in docs/my-app instead?',
+        );
+    });
+  });
+});

--- a/docs/my-v1-addon/tests/dummy/app/routes/application.ts
+++ b/docs/my-v1-addon/tests/dummy/app/routes/application.ts
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  beforeModel() {
+    this.intl.setLocale(['de-de', 'en-us']);
+  }
+}

--- a/docs/my-v1-addon/tests/dummy/app/templates/index.hbs
+++ b/docs/my-v1-addon/tests/dummy/app/templates/index.hbs
@@ -1,12 +1,11 @@
 <div>
-  <h1>Welcome!</h1>
+  <h1 data-test-output="Title">
+    {{t "routes.index.title"}}
+  </h1>
 
   <div>
-    <p>
-      This is a test v1 addon for
-      <code>ember-intl</code>. Did you want to run the app in
-      <code>docs/my-app</code>
-      instead?
+    <p data-test-output="Description">
+      {{t "routes.index.description" htmlSafe=true}}
     </p>
   </div>
 </div>

--- a/docs/my-v1-addon/tests/dummy/config/ember-intl.js
+++ b/docs/my-v1-addon/tests/dummy/config/ember-intl.js
@@ -23,7 +23,7 @@ module.exports = function (/* environment */) {
      * @type {String}
      * @default "'translations'"
      */
-    inputPath: 'translations',
+    inputPath: 'tests/dummy/translations',
 
     /**
      * Prevents the translations from being bundled with the application code.

--- a/docs/my-v1-addon/tests/dummy/translations/de-de.yml
+++ b/docs/my-v1-addon/tests/dummy/translations/de-de.yml
@@ -1,0 +1,4 @@
+routes:
+  index:
+    description: "Das hier ist ein v1 Addon, um <code>ember-intl</code> zu testen. Vielleicht wolltest du die App in <code>docs/my-app</code> ausführen?"
+    title: Willkommen!

--- a/docs/my-v1-addon/tests/dummy/translations/en-us.yml
+++ b/docs/my-v1-addon/tests/dummy/translations/en-us.yml
@@ -1,0 +1,4 @@
+routes:
+  index:
+    description: This is a test v1 addon for <code>ember-intl</code>. Did you want to run the app in <code>docs/my-app</code> instead?
+    title: Welcome!

--- a/packages/ember-intl/blueprints/ember-intl/files/__config__/ember-intl.js
+++ b/packages/ember-intl/blueprints/ember-intl/files/__config__/ember-intl.js
@@ -44,7 +44,7 @@ module.exports = function (/* environment */) {
      * @type {String}
      * @default "'translations'"
      */
-    inputPath: 'translations',
+    inputPath: '<%= configInputPath %>',
 
     /**
      * Prevents the translations from being bundled with the application code.

--- a/packages/ember-intl/blueprints/ember-intl/index.js
+++ b/packages/ember-intl/blueprints/ember-intl/index.js
@@ -26,6 +26,16 @@ module.exports = {
     };
   },
 
+  locals(options) {
+    const configInputPath = options.inAddon
+      ? 'tests/dummy/translations'
+      : 'translations';
+
+    return {
+      configInputPath,
+    };
+  },
+
   afterInstall() {
     this.ui.writeLine(
       [


### PR DESCRIPTION
## Why?

Follows up on #1904 by (1) updating the blueprints for `ember-intl` and (2) writing tests and updating the documentation site. Note, the `dummy` app's translations are not published along with the v1 addon.
