### PR TITLE
Silence missing translations output on build by default

### DIFF
--- a/.changeset/healthy-waves-march.md
+++ b/.changeset/healthy-waves-march.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Silence missing translations output on build by default

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -25,6 +25,7 @@ const defaultConfig = {
   },
   stripEmptyTranslations: false,
   wrapTranslationsWithNamespace: false,
+  verbose: false,
 };
 
 module.exports = {
@@ -93,6 +94,7 @@ module.exports = {
       requiresTranslation,
       stripEmptyTranslations,
       wrapTranslationsWithNamespace,
+      verbose,
     } = this.configOptions;
 
     const [translationTree, addonsWithTranslations] = buildTranslationTree(
@@ -115,8 +117,8 @@ module.exports = {
       outputPath: options.outputPath ?? outputPath,
       requiresTranslation,
       stripEmptyTranslations,
-      verbose: !this.isSilent,
       wrapTranslationsWithNamespace,
+      verbose,
     });
   },
 

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -24,8 +24,8 @@ const defaultConfig = {
     return true;
   },
   stripEmptyTranslations: false,
-  wrapTranslationsWithNamespace: false,
   verbose: false,
+  wrapTranslationsWithNamespace: false,
 };
 
 module.exports = {
@@ -93,8 +93,8 @@ module.exports = {
       outputPath,
       requiresTranslation,
       stripEmptyTranslations,
-      wrapTranslationsWithNamespace,
       verbose,
+      wrapTranslationsWithNamespace,
     } = this.configOptions;
 
     const [translationTree, addonsWithTranslations] = buildTranslationTree(
@@ -117,8 +117,8 @@ module.exports = {
       outputPath: options.outputPath ?? outputPath,
       requiresTranslation,
       stripEmptyTranslations,
-      wrapTranslationsWithNamespace,
       verbose,
+      wrapTranslationsWithNamespace,
     });
   },
 


### PR DESCRIPTION
## Why?

Resolves: https://github.com/ember-intl/ember-intl/issues/1908


## Solution?

Set its default to false

