### PR TITLE
Documented how to fingerprint translation files for Embroider apps

### DIFF
--- a/.changeset/brown-meals-grow.md
+++ b/.changeset/brown-meals-grow.md
@@ -1,0 +1,7 @@
+---
+"my-app-with-lazy-loaded-translations": minor
+"my-classic-app-with-lazy-loaded-translations": patch
+"docs-app-for-ember-intl": patch
+---
+
+Documented how to fingerprint translation files for Embroider apps

--- a/docs/ember-intl/app/templates/docs/advanced/lazy-loading-translations.md
+++ b/docs/ember-intl/app/templates/docs/advanced/lazy-loading-translations.md
@@ -3,17 +3,25 @@
 By default, translations in the `translations` folder are bundled with `app.js`. For large apps, you may prefer to have translations in the `dist` folder and load them at runtime.
 
 
-## Writing translations to `dist`
+## 1. Configure ember-intl
 
-In `config/ember-intl.js`, set `publicOnly` to `true`. Translations will no longer be bundled with `app.js`.
+In `config/ember-intl.js`, set `publicOnly` to `true`.
+
+```js
+module.exports = function (/* environment */) {
+  return {
+    publicOnly: true,
+  };
+};
+```
 
 
-## Load translations at runtime
+## 2. Load translations at runtime
 
 Use native `fetch` to load a translation file.
 
 ```ts
-/* routes/application.ts */
+/* app/routes/application.ts */
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 
@@ -38,12 +46,24 @@ export default class ApplicationRoute extends Route {
 }
 ```
 
+After you run `ember serve` or `ember build -prod`, you will find translations (as JSON files) in the `dist/translations` folder.
 
-## Fingerprinting
+```sh
+my-app
+└── dist
+    └── translations
+        ├── de-de.json
+        └── en-us.json
+```
 
-**WARNING: For classic apps only**
 
-In `ember-cli-build.js`, add `'json'` to [`fingerprint.extensions`](https://github.com/ember-cli/broccoli-asset-rev).
+## 3. Fingerprint translations
+
+### Classic build
+
+In Ember apps with a classic build, we use [`broccoli-asset-rev`](https://github.com/ember-cli/broccoli-asset-rev) to fingerprint files.
+
+Open `ember-cli-build.js`, then add `'json'` to `fingerprint.extensions`. The following example shows 6 default values for `fingerprint.extensions` plus `'json'`.
 
 ```js
 const app = new EmberApp(defaults, {
@@ -53,33 +73,123 @@ const app = new EmberApp(defaults, {
 });
 ```
 
-When the path to a translation file is static (e.g. `translations/en-us.json` instead of `translations/${locale}.json`), `broccoli-asset-rev` will pick it up and rewrite it in place already.
+Recall `loadTranslations()` from Step 2. Had the paths to translation files been static (i.e. had we written `await fetch('/translations/de-de.json')` and `await fetch('/translations/en-us.json')`, `broccoli-asset-rev` would have been able to find the files and hash their names. End of Step 3.
 
-If interpolation is required, you can load `assetMap` and enable fingerprinting for it.
+However, since the paths are dynamic, we need to get the correct path from the asset map:
 
-```js
+```diff
 const app = new EmberApp(defaults, {
   fingerprint: {
     extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'json'],
-    fingerprintAssetMap: true,
-    generateAssetMap: true,
++     fingerprintAssetMap: true,
++     generateAssetMap: true,
   },
 });
 ```
 
-Then, fetch `assetMap` in the production environment:
+```ts
+private async loadTranslations(locale: 'de-de' | 'en-us') {
+  const filePath = `translations/${locale}.json`;
+  let resource: string;
 
-```js
-import ENV from 'my-app/config/environment';
+  if (ENV.environment === 'production') {
+    const response = await fetch('/assets/assetMap.json');
+    const assetMap = await response.json();
 
-let filePath = `translations/${locale}.json`;
+    resource = `/${assetMap.assets[filePath]}`;
+  } else {
+    resource = `/${filePath}`;
+  }
 
-if (ENV.environment === 'production') {
-  const response = await fetch('/assets/assetMap.json');
-  const assetMap = await response.json();
+  const response = await fetch(resource);
+  const translations = await response.json();
 
-  filePath = assetMap.assets[filePath];
+  this.intl.addTranslations(locale, translations);
 }
+```
 
-const translations = await fetch(`/${filePath}`);
+Now, file names will be hashed only in production.
+
+```sh
+# Development
+my-app
+└── dist
+    └── translations
+        ├── de-de.json
+        └── en-us.json
+```
+
+```sh
+# Production
+my-app
+└── dist
+    └── translations
+        ├── de-de-825f3177f5b85adcb9029643007ebcf9.json
+        └── en-us-b1cfad13180d11102395dd387f10f673.json
+```
+
+
+### Embroider build (Webpack)
+
+**WARNING: The original files will remain in the `dist/translations` folder, but shouldn't affect production. Please let us know if you know how to remove these.**
+
+In `ember-cli-build.js`, configure Webpack to [treat translations as assets](https://webpack.js.org/guides/asset-modules/).
+
+```js
+'use strict';
+
+const { Webpack } = require('@embroider/webpack');
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // ...
+  });
+
+  const options = {
+    packagerOptions: {
+      webpackConfig: {
+        module: {
+          rules: [
+            {
+              generator: {
+                filename: '[path][name]-[hash][ext][query]',
+              },
+              test: /(node_modules\/\.embroider\/rewritten-app\/translations\/)(.*\.json)$/,
+              type: 'asset/resource',
+            },
+          ],
+        },
+      },
+    },
+    // ...
+  };
+
+  return require('@embroider/compat').compatBuild(app, Webpack, options);
+};
+```
+
+Afterwards, in `loadTranslations()` from Step 2, use dynamic import to get the asset URL.
+
+```ts
+private async loadTranslations(locale: 'de-de' | 'en-us') {
+  const { default: resource } = await import(`/translations/${locale}.json`);
+
+  const response = await fetch(resource);
+  const translations = await response.json();
+
+  this.intl.addTranslations(locale, translations);
+}
+```
+
+File names will be hashed in development and production.
+
+```sh
+my-app
+└── dist
+    └── translations
+        ├── de-de-12356e988bf952560f6e.json
+        ├── de-de.json
+        ├── en-us-31e4a23c9d04705ba9bf.json
+        └── en-us.json
 ```

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -34,7 +34,7 @@ console.log(this.intl.primaryLocale);
 Register translations for a particular locale. Used to lazy-load translations.
 
 ```ts
-/* routes/application.ts */
+/* app/routes/application.ts */
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 
@@ -104,7 +104,7 @@ This method could be used to create default values for arguments, so that users 
 Specify which locales are active. Used in the `application` route's `beforeModel()` hook, or in a component that allows users to set their preferred language.
 
 ```ts
-/* routes/application.ts */
+/* app/routes/application.ts */
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 
@@ -139,7 +139,7 @@ Specify what to do when `@formatjs/intl` errors. Your callback function has acce
 The following example ignores `FORMAT_ERROR` (incorrect or missing argument values), in addition to `MISSING_TRANSLATION` (default implementation of `ember-intl`).
 
 ```ts
-/* routes/application.ts */
+/* app/routes/application.ts */
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 
@@ -172,7 +172,7 @@ export default class ApplicationRoute extends Route {
 Specify what to display when a translation is missing. Your callback function has access to `key`, `locales`, and `options` (data).
 
 ```ts
-/* routes/application.ts */
+/* app/routes/application.ts */
 import Route from '@ember/routing/route';
 import { type Registry as Services, service } from '@ember/service';
 

--- a/docs/my-app-with-lazy-loaded-translations/app/routes/application.ts
+++ b/docs/my-app-with-lazy-loaded-translations/app/routes/application.ts
@@ -15,7 +15,9 @@ export default class ApplicationRoute extends Route {
   }
 
   private async loadTranslations(locale: 'de-de' | 'en-us') {
-    const response = await fetch(`/translations/${locale}.json`);
+    const { default: resource } = await import(`/translations/${locale}.json`);
+
+    const response = await fetch(resource);
     const translations = await response.json();
 
     this.intl.addTranslations(locale, translations);

--- a/docs/my-app-with-lazy-loaded-translations/ember-cli-build.js
+++ b/docs/my-app-with-lazy-loaded-translations/ember-cli-build.js
@@ -23,6 +23,21 @@ module.exports = function (defaults) {
   });
 
   const options = {
+    packagerOptions: {
+      webpackConfig: {
+        module: {
+          rules: [
+            {
+              generator: {
+                filename: '[path][name]-[hash][ext][query]',
+              },
+              test: /(node_modules\/\.embroider\/rewritten-app\/translations\/)(.*\.json)$/,
+              type: 'asset/resource',
+            },
+          ],
+        },
+      },
+    },
     skipBabel: [
       {
         package: 'qunit',

--- a/docs/my-classic-app-with-lazy-loaded-translations/app/routes/application.ts
+++ b/docs/my-classic-app-with-lazy-loaded-translations/app/routes/application.ts
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
+import ENV from 'my-classic-app-with-lazy-loaded-translations/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: IntlService;
@@ -15,7 +16,19 @@ export default class ApplicationRoute extends Route {
   }
 
   private async loadTranslations(locale: 'de-de' | 'en-us') {
-    const response = await fetch(`/translations/${locale}.json`);
+    const filePath = `translations/${locale}.json`;
+    let resource: string;
+
+    if (ENV.environment === 'production') {
+      const response = await fetch('/assets/assetMap.json');
+      const assetMap = await response.json();
+
+      resource = `/${assetMap.assets[filePath]}`;
+    } else {
+      resource = `/${filePath}`;
+    }
+
+    const response = await fetch(resource);
     const translations = await response.json();
 
     this.intl.addTranslations(locale, translations);


### PR DESCRIPTION
## Why?

Closes #1829. We can look into how to remove the original files in `dist/translations` at a later time.


## References

- https://webpack.js.org/guides/asset-modules/
- https://webpack.js.org/configuration/module/#rulegenerator

