### PR TITLE
Created a page that explains how to use ember-intl's helpers in <template> tag

### DIFF
--- a/.changeset/real-years-jog.md
+++ b/.changeset/real-years-jog.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": minor
+---
+
+Created a page that explains how to use ember-intl's helpers in <template> tag

--- a/docs/ember-intl/app/router.js
+++ b/docs/ember-intl/app/router.js
@@ -30,6 +30,7 @@ Router.map(function () {
       this.route('format-time');
       this.route('introduction');
       this.route('t');
+      this.route('template-tag');
     });
 
     this.route('migration', function () {

--- a/docs/ember-intl/app/templates/docs.hbs
+++ b/docs/ember-intl/app/templates/docs.hbs
@@ -59,6 +59,11 @@
       @route="docs.helpers.t"
     />
 
+    <nav.item
+      @label="<template> tag"
+      @route="docs.helpers.template-tag"
+    />
+
     <nav.section @label="Services" />
 
     <nav.item

--- a/docs/ember-intl/app/templates/docs/helpers/template-tag.md
+++ b/docs/ember-intl/app/templates/docs/helpers/template-tag.md
@@ -1,0 +1,11 @@
+# &#60;template&#62; tag
+
+`ember-intl` is compatible with [ember-template-imports](https://github.com/ember-template-imports/ember-template-imports) and you can use all helpers by importing them from the index file like so:
+
+```gjs
+import { formatNumber } from 'ember-intl';
+
+<template>
+  {{formatNumber 12345}}
+</template>
+```

--- a/docs/ember-intl/app/templates/docs/helpers/template-tag.md
+++ b/docs/ember-intl/app/templates/docs/helpers/template-tag.md
@@ -1,11 +1,26 @@
 # &#60;template&#62; tag
 
-`ember-intl` is compatible with [ember-template-imports](https://github.com/ember-template-imports/ember-template-imports) and you can use all helpers by importing them from the index file like so:
+You can use the helpers from `ember-intl` in a [`<template>` tag](https://github.com/ember-template-imports/ember-template-imports). The helpers have a camel-cased name and can be imported from the `index` file.
 
-```gjs
-import { formatNumber } from 'ember-intl';
+```ts
+import {
+  formatDate,
+  formatList,
+  formatMessage,
+  formatNumber,
+  formatRelative,
+  formatTime,
+  t,
+} from 'ember-intl';
 
+const today = new Date();
+
+// Some examples
 <template>
+  {{formatDate today}}
+
   {{formatNumber 12345}}
+
+  {{t "hello.message"}}
 </template>
 ```


### PR DESCRIPTION
- Add documentation on how to use `ember-intl` together with `<template>` tag

## Why?

- All the examples in the documentation show classic way of using helpers from the global scope
- Template imports require two bits of new knowledge:
  - Invocation is now `camelCased` instead of `kebab-cased`. Although this is generic knowledge from template tags, the docs of ember-intl were lacking to provide *an* example.
  - Where to import the files from? This can be from virtually anywhere, so having this documented is IMO a big win.


## Solution?

- New `Helpers / <template> tag` documentation page

