### PR TITLE
Made pnpm settings stricter

### DIFF
--- a/.changeset/hot-drinks-nail.md
+++ b/.changeset/hot-drinks-nail.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Made pnpm settings stricter

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
-strict-peer-dependencies=false
+# https://github.com/emberjs/rfcs/pull/907
+auto-install-peers=false
+resolve-peers-from-workspace-root=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 patchedDependencies:
@@ -25,9 +25,6 @@ importers:
 
   configs/ember-template-lint:
     dependencies:
-      ember-template-lint:
-        specifier: ^6.0.0
-        version: 6.0.0
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.0.0(ember-template-lint@6.0.0)(prettier@3.3.3)
@@ -70,7 +67,7 @@ importers:
         version: 17.10.2(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
+        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
       eslint-plugin-qunit:
         specifier: ^8.1.2
         version: 8.1.2(eslint@8.57.0)
@@ -80,9 +77,6 @@ importers:
       eslint-plugin-typescript-sort-keys:
         specifier: ^3.2.0
         version: 3.2.0(@typescript-eslint/parser@8.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
-      typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
     devDependencies:
       '@shared-configs/eslint-config-node':
         specifier: workspace:*
@@ -125,16 +119,13 @@ importers:
         version: 17.10.2(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
+        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@8.57.0)
       eslint-plugin-typescript-sort-keys:
         specifier: ^3.2.0
         version: 3.2.0(@typescript-eslint/parser@8.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
-      typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
     devDependencies:
       '@shared-configs/prettier':
         specifier: workspace:*
@@ -186,9 +177,6 @@ importers:
 
   configs/stylelint:
     dependencies:
-      stylelint:
-        specifier: ^16.8.1
-        version: 16.8.2(typescript@5.5.4)
       stylelint-config-standard:
         specifier: ^36.0.1
         version: 36.0.1(stylelint@16.8.2(typescript@5.5.4))
@@ -232,9 +220,6 @@ importers:
       '@tsconfig/strictest':
         specifier: ^2.0.5
         version: 2.0.5
-      typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
     devDependencies:
       '@shared-configs/prettier':
         specifier: workspace:*
@@ -322,7 +307,7 @@ importers:
         version: 5.11.0(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-addon-docs:
         specifier: ^7.0.1
-        version: 7.0.1(patch_hash=inqlm4xka5za5cdcffvvo33jci)(l63fr2uijiryqofzbktzujvibe)
+        version: 7.0.1(patch_hash=inqlm4xka5za5cdcffvvo33jci)(jhbpi3a36colf7odfjpe6am4ni)
       ember-cli-addon-docs-yuidoc:
         specifier: ^1.1.0
         version: 1.1.0
@@ -3691,9 +3676,6 @@ packages:
   '@types/eslint@8.56.10':
     resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
 
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
@@ -4019,11 +4001,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -5778,7 +5755,6 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       ember-data: '>= 3.0.0'
-      ember-fetch: ^8.1.1
       ember-source: '>= 4.0.0'
 
   ember-cli-app-version@7.0.0:
@@ -13268,12 +13244,6 @@ snapshots:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
 
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.5
-      '@types/json-schema': 7.0.15
-    optional: true
-
   '@types/estree@1.0.5': {}
 
   '@types/express-serve-static-core@4.19.3':
@@ -13674,8 +13644,8 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
-    optionalDependencies:
+  ajv-formats@2.1.1:
+    dependencies:
       ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -16094,7 +16064,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-addon-docs@7.0.1(patch_hash=inqlm4xka5za5cdcffvvo33jci)(l63fr2uijiryqofzbktzujvibe):
+  ember-cli-addon-docs@7.0.1(patch_hash=inqlm4xka5za5cdcffvvo33jci)(jhbpi3a36colf7odfjpe6am4ni):
     dependencies:
       '@csstools/postcss-sass': 5.1.1(postcss@8.4.41)
       '@ember/render-modifiers': 2.1.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.11.0(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.94.0))
@@ -16172,6 +16142,7 @@ snapshots:
       - '@glint/template'
       - bufferutil
       - canvas
+      - encoding
       - supports-color
       - utf-8-validate
       - webpack
@@ -17494,14 +17465,14 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-prettier@5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
+  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
     dependencies:
       eslint: 8.57.0
       prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.9.1
     optionalDependencies:
-      '@types/eslint': 9.6.1
+      '@types/eslint': 8.56.10
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
   eslint-plugin-qunit@8.1.2(eslint@8.57.0):
@@ -20667,7 +20638,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
   select@1.1.2: {}


### PR DESCRIPTION
## Why?

Following [RFC#907](https://github.com/emberjs/rfcs/pull/907), we'll want to set `auto-install-peers` and `resolve-peers-from-workspace-root` to `false` (`pnpm@9` sets these to `true` by default).


