### PR TITLE
Update instructions for lazy-loading translations for Embroider apps

### DIFF
--- a/.changeset/young-bulldogs-hope.md
+++ b/.changeset/young-bulldogs-hope.md
@@ -1,0 +1,6 @@
+---
+"my-app-with-lazy-loaded-translations": minor
+"docs-app-for-ember-intl": patch
+---
+
+Used asset/source to retrieve the translation JSONs

--- a/docs/my-app-with-lazy-loaded-translations/app/routes/application.ts
+++ b/docs/my-app-with-lazy-loaded-translations/app/routes/application.ts
@@ -16,9 +16,7 @@ export default class ApplicationRoute extends Route {
 
   private async loadTranslations(locale: 'de-de' | 'en-us') {
     const { default: resource } = await import(`/translations/${locale}.json`);
-
-    const response = await fetch(resource);
-    const translations = await response.json();
+    const translations = JSON.parse(resource);
 
     this.intl.addTranslations(locale, translations);
   }

--- a/docs/my-app-with-lazy-loaded-translations/ember-cli-build.js
+++ b/docs/my-app-with-lazy-loaded-translations/ember-cli-build.js
@@ -28,11 +28,8 @@ module.exports = function (defaults) {
         module: {
           rules: [
             {
-              generator: {
-                filename: '[path][name]-[hash][ext][query]',
-              },
               test: /(node_modules\/\.embroider\/rewritten-app\/translations\/)(.*\.json)$/,
-              type: 'asset/resource',
+              type: 'asset/source',
             },
           ],
         },


### PR DESCRIPTION
## Why?

Documents the latest findings, reported in https://github.com/ember-intl/ember-intl/issues/1829#issuecomment-2368364173. By replacing `asset/resource` with `asset/source`, we can avoid calling `fetch()`.
