### PR TITLE
Documented how to migrate away from translationsFor()

### DIFF
--- a/.changeset/little-tips-laugh.md
+++ b/.changeset/little-tips-laugh.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": patch
+---
+
+Documented how to migrate away from translationsFor()

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -123,9 +123,19 @@ for (const locale of this.intl.locales) {
     break;
   }
 }
-````
+```
 
-- The `translationsFor()` method has been removed.
+- The `translationsFor()` method has been removed. If you need to check the existence of translations, use `exists()` instead.
+
+```diff
+- if (this.intl.translationsFor('de-de')) {
++ if (this.intl.exists('some-key', 'de-de')) {
+  return;
+}
+
+// ... (e.g. load translations)
+```
+
 
 The service provides 2 new methods to help you configure `ember-intl`. For more information, see the [documentation for `intl` service](../services/intl-part-2).
 


### PR DESCRIPTION
## Why?

Documents a case that I learned from a team at EmberFest.
