### PR TITLE
Removed the usages of Ember Helper's recompute. Removed eventemitter3 as a dependency.

### DIFF
--- a/.changeset/mighty-donuts-move.md
+++ b/.changeset/mighty-donuts-move.md
@@ -1,0 +1,15 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+"my-app": patch
+"my-app-with-fallbacks": patch
+"my-app-with-lazy-loaded-translations": patch
+"my-app-with-namespace-from-folders": patch
+"my-classic-app": patch
+"my-classic-app-with-lazy-loaded-translations": patch
+"my-v1-addon": patch
+"my-v1-engine": patch
+"my-v2-addon": patch
+---
+
+Removed the usages of Ember Helper's recompute. Removed eventemitter3 as a dependency.

--- a/packages/ember-intl/addon/helpers/format-date.ts
+++ b/packages/ember-intl/addon/helpers/format-date.ts
@@ -18,14 +18,6 @@ interface FormatDateSignature {
 export default class FormatDateHelper extends Helper<FormatDateSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatDateSignature['Args']['Positional'],
     options: FormatDateSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/format-list.ts
+++ b/packages/ember-intl/addon/helpers/format-list.ts
@@ -18,14 +18,6 @@ interface FormatListSignature {
 export default class FormatListHelper extends Helper<FormatListSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatListSignature['Args']['Positional'],
     options: FormatListSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/format-message.ts
+++ b/packages/ember-intl/addon/helpers/format-message.ts
@@ -18,14 +18,6 @@ interface FormatMessageSignature {
 export default class FormatMessageHelper extends Helper<FormatMessageSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatMessageSignature['Args']['Positional'],
     options: FormatMessageSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/format-number.ts
+++ b/packages/ember-intl/addon/helpers/format-number.ts
@@ -18,14 +18,6 @@ interface FormatNumberSignature {
 export default class FormatNumberHelper extends Helper<FormatNumberSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatNumberSignature['Args']['Positional'],
     options: FormatNumberSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/format-relative.ts
+++ b/packages/ember-intl/addon/helpers/format-relative.ts
@@ -18,14 +18,6 @@ interface FormatRelativeSignature {
 export default class FormatRelativeHelper extends Helper<FormatRelativeSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatRelativeSignature['Args']['Positional'],
     options: FormatRelativeSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/format-time.ts
+++ b/packages/ember-intl/addon/helpers/format-time.ts
@@ -18,14 +18,6 @@ interface FormatTimeSignature {
 export default class FormatTimeHelper extends Helper<FormatTimeSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [value]: FormatTimeSignature['Args']['Positional'],
     options: FormatTimeSignature['Args']['Named'],

--- a/packages/ember-intl/addon/helpers/t.ts
+++ b/packages/ember-intl/addon/helpers/t.ts
@@ -18,14 +18,6 @@ interface TSignature {
 export default class THelper extends Helper<TSignature> {
   @service declare intl: IntlService;
 
-  constructor() {
-    // eslint-disable-next-line prefer-rest-params
-    super(...arguments);
-
-    // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-    this.intl.onLocaleChanged(this.recompute, this);
-  }
-
   compute(
     [key, positionalOptions]: TSignature['Args']['Positional'],
     namedOptions: TSignature['Args']['Named'],

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -1,10 +1,8 @@
 import { getOwner } from '@ember/application';
-import { registerDestructor } from '@ember/destroyable';
 import { cancel, next, type Timer as EmberRunTimer } from '@ember/runloop';
 import Service from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
-import EventEmitter from 'eventemitter3';
 
 import type {
   FormatDateParameters,
@@ -50,7 +48,6 @@ export default class IntlService extends Service {
   @tracked private _locale?: string[];
 
   private _cache = createIntlCache();
-  private _eventEmitter = new EventEmitter();
   private _formats?: Record<string, unknown>;
   private _timer?: EmberRunTimer;
 
@@ -259,8 +256,6 @@ export default class IntlService extends Service {
       // @ts-ignore: Argument of type 'Timer | undefined' is not assignable to parameter of type 'EmberRunTimer | undefined'
       // eslint-disable-next-line ember/no-runloop
       this._timer = next(() => {
-        this._eventEmitter.emit('localeChanged');
-
         this.updateDocumentLanguage();
       });
     }
@@ -350,14 +345,6 @@ export default class IntlService extends Service {
     }
 
     return this.getIntl(this._locale!)!;
-  }
-
-  private onLocaleChanged(fn: any, context: any): void {
-    this._eventEmitter.on('localeChanged', fn, context);
-
-    registerDestructor(context, () => {
-      this._eventEmitter.off('localeChanged', fn, context);
-    });
   }
 
   private updateDocumentLanguage(): void {

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -47,7 +47,6 @@
     "ember-auto-import": "^2.8.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-typescript": "^5.3.0",
-    "eventemitter3": "^5.0.1",
     "extend": "^3.0.2",
     "intl-messageformat": "^10.7.0",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1718,9 +1718,6 @@ importers:
       ember-cli-typescript:
         specifier: ^5.3.0
         version: 5.3.0
-      eventemitter3:
-        specifier: ^5.0.1
-        version: 5.0.1
       extend:
         specifier: ^3.0.2
         version: 3.0.2
@@ -6406,9 +6403,6 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
-  eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   events-to-array@1.1.2:
     resolution: {integrity: sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA==}
@@ -16493,7 +16487,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-bun-module: 1.1.0
@@ -16506,7 +16500,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -16553,7 +16547,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.9.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16721,8 +16715,6 @@ snapshots:
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
-
-  eventemitter3@5.0.1: {}
 
   events-to-array@1.1.2: {}
 

--- a/tests/ember-intl/tests/unit/services/intl-test.ts
+++ b/tests/ember-intl/tests/unit/services/intl-test.ts
@@ -1,4 +1,3 @@
-import Helper from '@ember/component/helper';
 import {
   settled,
   type TestContext as BaseTestContext,
@@ -397,31 +396,6 @@ module('Unit | Service | intl', function (hooks) {
   });
 
   module('setLocale()', function () {
-    test('triggers the localeChanged event', async function (this: TestContext, assert) {
-      const callback = () => {
-        assert.step('Callback');
-      };
-
-      const context = class THelper extends Helper {};
-
-      // @ts-expect-error: Property 'onLocaleChanged' is private and only accessible within class 'IntlService'.
-      this.intl.onLocaleChanged(callback, context);
-
-      assert.verifySteps([]);
-
-      this.intl.setLocale(['de-de', 'en-us']);
-
-      await settled();
-
-      assert.verifySteps(['Callback']);
-
-      this.intl.setLocale(['fr-fr', 'de-de', 'en-us']);
-
-      await settled();
-
-      assert.verifySteps(['Callback']);
-    });
-
     test("updates the document's lang attribute", async function (this: TestContext, assert) {
       function getLang() {
         return document.documentElement.getAttribute('lang');


### PR DESCRIPTION
## Why?

Since [`v2.0.1`](https://github.com/ember-intl/ember-intl/blob/2.0.1/addon/helpers/-format-base.js#L27), `ember-intl` has used Ember [Helper's `recompute()` method](https://api.emberjs.com/ember/6.0/classes/Helper/methods/recompute?anchor=recompute) to update translations and format items. If [the RFC draft #633](https://github.com/emberjs/rfcs/issues/633) is followed through, `ember-intl` would pose a technical risk to many projects.

@bertdeblock noticed that we may be able to remove the usages now (possibly since `v6.0.0-beta.1` that had released #1530, which introduces `@tracked`):

> That event-based approach was introduced before `@tracked` was a thing. `_locale` on the `intl` service is now `@tracked`, so you just have to consume it. The tests even pass without `this.intl.onLocaleChanged(this.recompute, this);`, so consuming `_locale` probably already happens somewhere during the compute chain for each helper.


## Solution?

Remove the usages from all helpers. If CI passes, we can merge the pull request. (I also checked that translations update when I change the locale in `docs/my-app`.)
