### PR TITLE
Replaced ember-lts-5.4 and ember-lts-5.8 with ember-lts-5.12

### DIFF
--- a/.changeset/forty-tomatoes-enjoy.md
+++ b/.changeset/forty-tomatoes-enjoy.md
@@ -1,0 +1,6 @@
+---
+"test-app-for-ember-intl": patch
+"ember-intl": patch
+---
+
+Replaced ember-lts-5.4 and ember-lts-5.8 with ember-lts-5.12

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,8 +104,7 @@ jobs:
         scenario:
           - 'ember-lts-3.28'
           - 'ember-lts-4.12'
-          - 'ember-lts-5.4'
-          - 'ember-lts-5.8'
+          - 'ember-lts-5.12'
           - 'ember-test-helpers-v3'
           - 'ember-release'
           - 'ember-beta'

--- a/tests/ember-intl/config/ember-try.js
+++ b/tests/ember-intl/config/ember-try.js
@@ -31,18 +31,10 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-lts-5.4',
+        name: 'ember-lts-5.12',
         npm: {
           devDependencies: {
-            'ember-source': '~5.4.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-5.8',
-        npm: {
-          devDependencies: {
-            'ember-source': '~5.8.0',
+            'ember-source': '~5.12.0',
           },
         },
       },


### PR DESCRIPTION
## Why?

A continuation of #1933, where I updated `ember-source` for docs-apps and test-apps from `5.12.0` to `6.0.1`.


## Solution?

For simplicity, replace `ember-lts-5.4` and `ember-lts-5.8` with `ember-lts-5.12`. That is, we assume that, if `test-app` passes on `5.12`, then it will for `5.4` and `5.8`.
