### PR TITLE
Updated URLs from formatjs website

### DIFF
--- a/.changeset/eighty-brooms-live.md
+++ b/.changeset/eighty-brooms-live.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"docs-app-for-ember-intl": patch
+---
+
+Updated URLs from formatjs website

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 ## Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
-* 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 📚 Built on standards: [ICU message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 * 🌐 Support for 150+ languages.
 * ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
 * ✅ Test helpers to check locale-dependent templates.

--- a/docs/ember-intl/app/templates/docs/advanced/runtime-requirements.md
+++ b/docs/ember-intl/app/templates/docs/advanced/runtime-requirements.md
@@ -2,43 +2,43 @@
 
 `ember-intl` relies on these `Intl` APIs:
 
-- [Intl.getCanonicalLocales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales): Polyfill: [@formatjs/intl-getcanonicallocales](https://formatjs.io/docs/polyfills/intl-getcanonicallocales).
+- [Intl.getCanonicalLocales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales): Polyfill: [@formatjs/intl-getcanonicallocales](https://formatjs.github.io/docs/polyfills/intl-getcanonicallocales/).
 
 <a href="https://caniuse.com/#search=getCanonicalLocales">
   <img src={{root-url "images/getcanonicallocales.png"}} />
 </a>
 
-- [Intl.Locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale): Polyfill: [@formatjs/intl-locale](https://formatjs.io/docs/polyfills/intl-locale).
+- [Intl.Locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale): Polyfill: [@formatjs/intl-locale](https://formatjs.github.io/docs/polyfills/intl-locale/).
 
 <a href="https://caniuse.com/mdn-javascript_builtins_intl_locale_maximize">
   <img src={{root-url "images/locale.png"}} />
 </a>
 
-- [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat): Available on IE11+. Polyfill: [@formatjs/intl-numberformat](https://formatjs.io/docs/polyfills/intl-numberformat).
+- [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat): Available on IE11+. Polyfill: [@formatjs/intl-numberformat](https://formatjs.github.io/docs/polyfills/intl-numberformat/).
 
 <a href="https://caniuse.com/#feat=mdn-javascript_builtins_intl_numberformat">
   <img src={{root-url "images/numberformat.png"}} />
 </a>
 
-- [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat): Available on IE11+. Polyfill: [@formatjs/intl-datetimeformat](https://formatjs.io/docs/polyfills/intl-datetimeformat).
+- [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat): Available on IE11+. Polyfill: [@formatjs/intl-datetimeformat](https://formatjs.github.io/docs/polyfills/intl-datetimeformat/).
 
 <a href="https://caniuse.com/#feat=mdn-javascript_builtins_intl_datetimeformat">
   <img src={{root-url "images/datetimeformat.png"}} />
 </a>
 
-- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): Polyfill: [`@formatjs/intl-pluralrules`](https://formatjs.io/docs/polyfills/intl-pluralrules).
+- [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules): Polyfill: [`@formatjs/intl-pluralrules`](https://formatjs.github.io/docs/polyfills/intl-pluralrules/).
 
 <a href="https://caniuse.com/#feat=intl-pluralrules">
   <img src={{root-url "images/pluralrules.png"}} />
 </a>
 
-- [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): Polyfill: [`@formatjs/intl-relativetimeformat`](https://formatjs.io/docs/polyfills/intl-relativetimeformat).
+- [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat): Polyfill: [`@formatjs/intl-relativetimeformat`](https://formatjs.github.io/docs/polyfills/intl-relativetimeformat/).
 
 <a href="https://caniuse.com/#feat=mdn-javascript_builtins_intl_relativetimeformat">
   <img src={{root-url 'images/relativetimeformat.png'}} />
 </a>
 
-- [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat): Polyfill: [`@formatjs/intl-listformat`](https://formatjs.io/docs/polyfills/intl-listformat).
+- [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat): Polyfill: [`@formatjs/intl-listformat`](https://formatjs.github.io/docs/polyfills/intl-listformat/).
 
 
 ## Basic Polyfilling Strategies

--- a/docs/ember-intl/app/templates/docs/getting-started/index.md
+++ b/docs/ember-intl/app/templates/docs/getting-started/index.md
@@ -9,7 +9,7 @@
 ## Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
-* 📚 Built on standards: <a class="external-link" href="https://formatjs.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
+* 📚 Built on standards: <a class="external-link" href="https://formatjs.github.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
 * 🌐 Support for 150+ languages.
 * ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
 * ✅ Test helpers to check locale-dependent templates.

--- a/docs/ember-intl/app/templates/docs/helpers/format-message.md
+++ b/docs/ember-intl/app/templates/docs/helpers/format-message.md
@@ -1,6 +1,6 @@
 # &#123;&#123;format-message&#125;&#125;
 
-Formats a string with the [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax).
+Formats a string with the [ICU message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/).
 
 <DocsDemo as |demo|>
   <LocaleSwitcher />

--- a/docs/ember-intl/app/templates/docs/helpers/t.md
+++ b/docs/ember-intl/app/templates/docs/helpers/t.md
@@ -1,6 +1,6 @@
 # &#123;&#123;t&#125;&#125;
 
-The `{{t}}` helper finds the translation message corresponding to a key, then [populates the message with data](https://formatjs.io/docs/core-concepts/icu-syntax). The helper returns the resulting string.
+The `{{t}}` helper finds the translation message corresponding to a key, then [populates the message with data](https://formatjs.github.io/docs/core-concepts/icu-syntax/). The helper returns the resulting string.
 
 <DocsDemo as |demo|>
   <LocaleSwitcher />
@@ -30,7 +30,7 @@ The `{{t}}` helper finds the translation message corresponding to a key, then [p
 
 ## Passing data
 
-We use the [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) to pass data to translations. Data can also be formatted when you specify their type.
+We use the [ICU message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/) to pass data to translations. Data can also be formatted when you specify their type.
 
 ```yml
 # A simple argument

--- a/docs/ember-intl/app/templates/docs/services/intl-part-1.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-1.md
@@ -61,7 +61,7 @@ const output = this.intl.formatList(['apples', 'bananas', 'oranges']);
 
 ### formatMessage()
 
-Formats a string with the [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax).
+Formats a string with the [ICU message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/).
 
 The 1st argument `value` is required and expects a `MessageDescriptor` or `string`. You can pass data for the message in the 2nd argument.
 
@@ -135,7 +135,7 @@ const output = this.intl.formatTime('2014-01-23T18:00:44');
 
 ### t()
 
-Finds the translation message corresponding to a key, then [populates the message with data](https://formatjs.io/docs/core-concepts/icu-syntax) (optional).
+Finds the translation message corresponding to a key, then [populates the message with data](https://formatjs.github.io/docs/core-concepts/icu-syntax/) (optional).
 
 The 1st argument `key` is required and expects a `string` (non-empty). You can pass data for the translation message in the 2nd argument.
 

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -96,7 +96,7 @@ console.log(this.intl.getTranslation('hello.message', 'de-de'));
 // 'Hallo, {name}!'
 ```
 
-This method could be used to create default values for arguments, so that users don't see the raw message when an argument doesn't have a value. To extract the message arguments, you can use [`@formatjs/icu-messageformat-parser`](https://formatjs.io/docs/icu-messageformat-parser/).
+This method could be used to create default values for arguments, so that users don't see the raw message when an argument doesn't have a value. To extract the message arguments, you can use [`@formatjs/icu-messageformat-parser`](https://formatjs.github.io/docs/icu-messageformat-parser/).
 
 
 ### setLocale()
@@ -134,7 +134,7 @@ this.intl.setLocale(['de-AT', 'de-DE', 'en-US']);
 
 ### setOnFormatjsError()
 
-Specify what to do when `@formatjs/intl` errors. Your callback function has access to `error`, [one that is provided by `@formatjs/intl`](https://formatjs.io/docs/guides/develop#error-codes).
+Specify what to do when `@formatjs/intl` errors. Your callback function has access to `error`, [one that is provided by `@formatjs/intl`](https://formatjs.github.io/docs/guides/develop#error-codes).
 
 The following example ignores `FORMAT_ERROR` (incorrect or missing argument values), in addition to `MISSING_TRANSLATION` (default implementation of `ember-intl`).
 

--- a/docs/ember-intl/app/templates/index.md
+++ b/docs/ember-intl/app/templates/index.md
@@ -12,7 +12,7 @@
         🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
       </li>
       <li>
-        📚 Built on standards: <a class="external-link" href="https://formatjs.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
+        📚 Built on standards: <a class="external-link" href="https://formatjs.github.io/docs/core-concepts/icu-syntax/" target="_blank" rel="noopener noreferrer">ICU message syntax</a> and <a class="external-link" href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl" target="_blank" rel="noopener noreferrer">Internationalization API</a>.
       </li>
       <li>
         🌐 Support for 150+ languages.

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -13,7 +13,7 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 ## Features
 
 * 🐹 Compatible with Ember apps, v1 addons (including engines), and v2 addons.
-* 📚 Built on standards: [ICU message syntax](https://formatjs.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+* 📚 Built on standards: [ICU message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/) and [Internationalization API](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl).
 * 🌐 Support for 150+ languages.
 * ⚙️ Locale-aware helpers and `intl` service, to help you display translations, numbers, dates, etc.
 * ✅ Test helpers to check locale-dependent templates.


### PR DESCRIPTION
## Why?

In early- to mid-November 2024, `formatjs` changed its base URL to `formatjs.github.io`. All links that `ember-intl` provides redirect the user to the homepage.
