### PR TITLE
Removed inject as service (while still supporting ember-source@3.28)

### DIFF
--- a/.changeset/hungry-singers-help.md
+++ b/.changeset/hungry-singers-help.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": patch
+"test-app-for-ember-intl": patch
+---
+
+Removed inject as service (while still supporting ember-source@3.28)

--- a/packages/ember-intl/addon/-private/utils/service.ts
+++ b/packages/ember-intl/addon/-private/utils/service.ts
@@ -1,0 +1,3 @@
+import * as s from '@ember/service';
+
+export default s.service ?? s.inject;

--- a/packages/ember-intl/addon/helpers/format-date-range.ts
+++ b/packages/ember-intl/addon/helpers/format-date-range.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatDateRange']>;

--- a/packages/ember-intl/addon/helpers/format-date.ts
+++ b/packages/ember-intl/addon/helpers/format-date.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatDate']>;

--- a/packages/ember-intl/addon/helpers/format-list.ts
+++ b/packages/ember-intl/addon/helpers/format-list.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatList']>;

--- a/packages/ember-intl/addon/helpers/format-message.ts
+++ b/packages/ember-intl/addon/helpers/format-message.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatMessage']>;

--- a/packages/ember-intl/addon/helpers/format-number.ts
+++ b/packages/ember-intl/addon/helpers/format-number.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatNumber']>;

--- a/packages/ember-intl/addon/helpers/format-relative.ts
+++ b/packages/ember-intl/addon/helpers/format-relative.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatRelative']>;

--- a/packages/ember-intl/addon/helpers/format-time.ts
+++ b/packages/ember-intl/addon/helpers/format-time.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatTime']>;

--- a/packages/ember-intl/addon/helpers/t.ts
+++ b/packages/ember-intl/addon/helpers/t.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
 
+import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type TParameters = Parameters<IntlService['t']>;

--- a/packages/ember-intl/tests/dummy/app/routes/application.ts
+++ b/packages/ember-intl/tests/dummy/app/routes/application.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
 
 export default class ApplicationRoute extends Route {

--- a/tests/ember-intl/app/controllers/smoke-tests.ts
+++ b/tests/ember-intl/app/controllers/smoke-tests.ts
@@ -1,6 +1,8 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import type { IntlService } from 'ember-intl';
+
+const service = s.service ?? s.inject;
 
 export default class SmokeController extends Controller {
   @service declare intl: IntlService;

--- a/tests/ember-intl/app/routes/application.ts
+++ b/tests/ember-intl/app/routes/application.ts
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import * as s from '@ember/service';
 import type { IntlService } from 'ember-intl';
+
+const service = s.service ?? s.inject;
 
 export default class ApplicationRoute extends Route {
   @service declare intl: IntlService;

--- a/tests/ember-intl/tests/helpers/autotracking/currency.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/currency.ts
@@ -1,4 +1,7 @@
-import { inject as service, type Registry as Services } from '@ember/service';
+import type { Registry as Services } from '@ember/service';
+import * as s from '@ember/service';
+
+const service = s.service ?? s.inject;
 
 export class Currency {
   @service declare intl: Services['intl'];

--- a/tests/ember-intl/tests/helpers/autotracking/population.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/population.ts
@@ -1,4 +1,7 @@
-import { inject as service, type Registry as Services } from '@ember/service';
+import type { Registry as Services } from '@ember/service';
+import * as s from '@ember/service';
+
+const service = s.service ?? s.inject;
 
 export class Population {
   @service declare intl: Services['intl'];

--- a/tests/ember-intl/tests/helpers/autotracking/royalty.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/royalty.ts
@@ -1,4 +1,7 @@
-import { inject as service, type Registry as Services } from '@ember/service';
+import type { Registry as Services } from '@ember/service';
+import * as s from '@ember/service';
+
+const service = s.service ?? s.inject;
 
 export class Royalty {
   @service declare intl: Services['intl'];


### PR DESCRIPTION
## Why?

In ember v6.3 there was added deprecation for service import from inject https://deprecations.emberjs.com/id/importing-inject-from-ember-service/

This changes allows us to hold support for `ember-source` <= 4.0 ([see changelog](https://github.com/emberjs/ember.js/blob/main/CHANGELOG.md#v410-december-28-2021)) and removes deprecation in newer versions

