### PR TITLE
Documented usage of test helper t()

### DIFF
--- a/.changeset/bitter-pets-sit.md
+++ b/.changeset/bitter-pets-sit.md
@@ -1,0 +1,5 @@
+---
+"test-app-for-ember-intl": patch
+---
+
+Documented usage of test helper t()

--- a/tests/ember-intl/tests/integration/helpers/t/translation-has-html-code-test.ts
+++ b/tests/ember-intl/tests/integration/helpers/t/translation-has-html-code-test.ts
@@ -4,7 +4,7 @@ import {
   type TestContext as BaseTestContext,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setLocale, setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl, t } from 'ember-intl/test-support';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app-for-ember-intl/tests/helpers';
 
@@ -44,11 +44,20 @@ module(
         </div>
       `);
 
+      const testHelperT = t('royalty.message', {
+        name: 'Zoey',
+        points: 31415,
+      });
+
       assert
         .dom('[data-test-output]')
+        .hasHtml(
+          '&lt;div class="message"&gt;Hello, Zoey! You have 31,415 royalty points.&lt;/div&gt;',
+        )
         .hasText(
           '<div class="message">Hello, Zoey! You have 31,415 royalty points.</div>',
-        );
+        )
+        .hasText(testHelperT);
 
       assert.dom('[data-test-output] > div').doesNotExist();
     });
@@ -91,8 +100,18 @@ module(
         </div>
       `);
 
+      const testHelperT = t('royalty.message', {
+        htmlSafe: true,
+        name: this.name,
+        points: 31415,
+      });
+
       assert
         .dom('[data-test-output]')
+        .hasHtml(
+          '<div class="message">Hello, <span class="emphasize">Zoey</span>! You have 31,415 royalty points.</div>',
+        )
+        .hasHtml(testHelperT.toString())
         .hasText('Hello, Zoey! You have 31,415 royalty points.');
 
       assert.dom('[data-test-output] > div').hasClass('message');


### PR DESCRIPTION
## Why?

Partly addresses #1957.


## Solution?

I documented how developers may use the test helper `t()` when a translation includes HTML. However, do note that, since `v6.4.0`, the documentation [has discouraged the use of the test helper `t()`](https://ember-intl.github.io/ember-intl/versions/v7.1.6/docs/test-helpers/t#alternative-approaches).

While calling `.toString()` isn't ideal, I don't think the `intl` service should return the (actual) type of `SafeString` (I see this as leaking an implementation detail in Ember). Since `.hasHtml(testHelperT.toString())` passed `lint:types` in this pull request, I currently think that the issue in #1957 is IDE-dependent (difficult to support).
