### PR TITLE
Warn instead of error for MISSING_DATA

### DIFF
--- a/.changeset/fresh-pianos-carry.md
+++ b/.changeset/fresh-pianos-carry.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Warn MISSING_DATA issues instead of erroring

--- a/docs/ember-intl/app/templates/docs/migration/v7.md
+++ b/docs/ember-intl/app/templates/docs/migration/v7.md
@@ -125,6 +125,8 @@ for (const locale of this.intl.locales) {
 }
 ```
 
+- The `onIntlError()` method has been removed. See `setOnFormatjsError()` below.
+
 - The `translationsFor()` method has been removed. If you need to check the existence of translations, use `exists()` instead.
 
 ```diff

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -136,7 +136,9 @@ this.intl.setLocale(['de-AT', 'de-DE', 'en-US']);
 
 Specify what to do when `@formatjs/intl` errors. Your callback function has access to `error`, [one that is provided by `@formatjs/intl`](https://formatjs.github.io/docs/guides/develop#error-codes).
 
-The following example ignores `FORMAT_ERROR` (incorrect or missing argument values), in addition to `MISSING_TRANSLATION` (default implementation of `ember-intl`).
+By default, `ember-intl` warns `MISSING_DATA` (browser doesn't support an Intl API) and ignores `MISSING_TRANSLATION` (translation message doesn't exist).
+
+Suppose you want to ignore `FORMAT_ERROR` (incorrect or missing argument values) and `MISSING_TRANSLATION`:
 
 ```ts
 /* app/routes/application.ts */

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -61,6 +61,13 @@ export default class IntlService extends Service {
         break;
       }
 
+      // Some locales are not technically supported in Chromium but continue to work.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+      case 'MISSING_DATA': {
+        console.warn(error.message);
+        break;
+      }
+
       default: {
         throw error;
       }

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -56,15 +56,14 @@ export default class IntlService extends Service {
   private _onFormatjsError: OnFormatjsError = (error) => {
     switch (error.code) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-      case 'MISSING_TRANSLATION': {
-        // Do nothing
+      case 'MISSING_DATA': {
+        console.warn(error.message);
         break;
       }
 
-      // Some locales are not technically supported in Chromium but continue to work.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-      case 'MISSING_DATA': {
-        console.warn(error.message);
+      case 'MISSING_TRANSLATION': {
+        // Do nothing
         break;
       }
 


### PR DESCRIPTION
## Why?

Chromium stopped supporting eu-es and is-is locales, which we localize for. This has been the case for a long time and yet our localization has still worked in those locales.
This should really be a warning instead of breaking a whole app. 
See this issue for more info: https://github.com/formatjs/formatjs/issues/4352 

We've been working around this by overriding the `onIntlError` method in our wrapper service, but as of v7.1.6 that method has been removed and the error handling can't be hooked into more. You can use `setOnFormatjsError` but the errors for the aforementioned locales throw during the translation load in `intl`'s constructor so we cannot set it early enough. 

If you would rather a configurable override be added instead, I am happy to change gears to that, but I saw others having this same exact issue and thought it best to change this.

## Solution?

Log a warning in the console instead of throwing an error. 

