### PR TITLE
Deprecated defining formats in app/formats.js

### DIFF
--- a/.changeset/bright-clowns-trade.md
+++ b/.changeset/bright-clowns-trade.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": minor
+"docs-app-for-ember-intl": minor
+---
+
+Created setFormats()

--- a/docs/ember-intl/app/ember-intl.ts
+++ b/docs/ember-intl/app/ember-intl.ts
@@ -1,5 +1,7 @@
-export default {
-  date: {
+import type { Formats } from 'ember-intl';
+
+export const formats: Formats = {
+  'format-date': {
     'user-friendly': {
       day: 'numeric',
       month: 'long',
@@ -7,14 +9,14 @@ export default {
     },
   },
 
-  dateTimeRange: {
+  'format-date-range': {
     'user-friendly': {
       day: 'numeric',
       month: 'short',
     },
   },
 
-  number: {
+  'format-number': {
     compact: {
       notation: 'compact',
     },
@@ -28,13 +30,13 @@ export default {
     },
   },
 
-  relative: {
+  'format-relative-time': {
     compact: {
       style: 'narrow',
     },
   },
 
-  time: {
+  'format-time': {
     hhmmss: {
       hour: 'numeric',
       minute: 'numeric',

--- a/docs/ember-intl/app/routes/application.ts
+++ b/docs/ember-intl/app/routes/application.ts
@@ -1,11 +1,13 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { formats } from 'docs-app-for-ember-intl/ember-intl';
 import type { IntlService } from 'ember-intl';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: IntlService;
 
   beforeModel() {
+    this.intl.setFormats(formats);
     this.intl.setLocale(['en-us']);
   }
 }

--- a/docs/ember-intl/app/templates/docs/services/intl-part-2.md
+++ b/docs/ember-intl/app/templates/docs/services/intl-part-2.md
@@ -99,6 +99,42 @@ console.log(this.intl.getTranslation('hello.message', 'de-de'));
 This method could be used to create default values for arguments, so that users don't see the raw message when an argument doesn't have a value. To extract the message arguments, you can use [`@formatjs/icu-messageformat-parser`](https://formatjs.github.io/docs/icu-messageformat-parser/).
 
 
+### setFormats()
+
+Specify your reusable formats (defined in `app/ember-intl.{js,ts}`).
+
+```ts
+/* app/ember-intl.ts */
+import type { Formats } from 'ember-intl';
+
+export const formats: Formats = {
+  'format-time': {
+    hhmmss: {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    },
+  },
+};
+```
+
+```ts
+/* app/routes/application.ts */
+import Route from '@ember/routing/route';
+import { type Registry as Services, service } from '@ember/service';
+import { formats } from 'my-app/ember-intl';
+
+export default class ApplicationRoute extends Route {
+  @service declare intl: Services['intl'];
+
+  async beforeModel() {
+    this.intl.setFormats(formats);
+    this.intl.setLocale(['de-de']);
+  }
+}
+```
+
+
 ### setLocale()
 
 Specify which locales are active. Used in the `application` route's `beforeModel()` hook, or in a component that allows users to set their preferred language.

--- a/packages/ember-intl/addon/-private/formatjs/formats.ts
+++ b/packages/ember-intl/addon/-private/formatjs/formats.ts
@@ -1,0 +1,23 @@
+import type { CustomFormats as FormatjsFormats } from '@formatjs/intl';
+
+export type Formats = Partial<{
+  'format-date': FormatjsFormats['date'];
+  'format-date-range': FormatjsFormats['dateTimeRange'];
+  'format-number': FormatjsFormats['number'];
+  'format-relative-time': FormatjsFormats['relative'];
+  'format-time': FormatjsFormats['time'];
+}>;
+
+export type { FormatjsFormats };
+
+export function convertToFormatjsFormats(formats: Formats): FormatjsFormats {
+  const formatjsFormats: FormatjsFormats = {
+    dateTimeRange: formats['format-date-range'],
+    date: formats['format-date'],
+    number: formats['format-number'],
+    relative: formats['format-relative-time'],
+    time: formats['format-time'],
+  };
+
+  return formatjsFormats;
+}

--- a/packages/ember-intl/addon/-private/formatjs/index.ts
+++ b/packages/ember-intl/addon/-private/formatjs/index.ts
@@ -6,5 +6,6 @@ export * from './format-number';
 export * from './format-relative';
 export * from './format-relative-time';
 export * from './format-time';
+export * from './formats';
 export type { IntlShape, OnErrorFn } from '@formatjs/intl';
 export { createIntl, createIntlCache } from '@formatjs/intl';

--- a/packages/ember-intl/addon/index.ts
+++ b/packages/ember-intl/addon/index.ts
@@ -7,4 +7,4 @@ export { default as formatRelative } from './helpers/format-relative';
 export { default as formatRelativeTime } from './helpers/format-relative-time';
 export { default as formatTime } from './helpers/format-time';
 export { default as t } from './helpers/t';
-export type { default as IntlService } from './services/intl';
+export type { Formats, default as IntlService } from './services/intl';

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -96,7 +96,15 @@ export default class IntlService extends Service {
     // eslint-disable-next-line prefer-rest-params
     super(...arguments);
 
-    this.getDefaultFormats();
+    const hasNewConfiguration = Boolean(
+      // @ts-expect-error: Property 'resolveRegistration' does not exist on type 'Owner'
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      getOwner(this).resolveRegistration('ember-intl:main'),
+    );
+
+    if (!hasNewConfiguration) {
+      this.getDefaultFormats();
+    }
 
     // Hydrate
     translations.forEach(([locale, translations]: [string, Translations]) => {

--- a/packages/ember-intl/addon/services/intl.ts
+++ b/packages/ember-intl/addon/services/intl.ts
@@ -315,6 +315,13 @@ export default class IntlService extends Service {
     return formatTime(intlShape, value, options);
   }
 
+  /**
+   * @deprecated
+   *
+   * Formats, defined in the file `app/formats.js`, will have no effect in
+   * `ember-intl@8.0.0`. Please define formats in `app/ember-intl.{js,ts}`,
+   * then call `setFormats()` before loading your translations.
+   */
   private getDefaultFormats(): void {
     // @ts-expect-error: Property 'resolveRegistration' does not exist on type 'Owner'
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call


### PR DESCRIPTION
## Why?

Closes #1942.

The use of `app/formats.js` is problematic if `ember-intl` were to become a v2 addon. Currently, the `intl` service has [an order dependency in `constructor()`](https://github.com/ember-intl/ember-intl/blob/v7.2.0/packages/ember-intl/addon/services/intl.ts#L99) and needs [`getOwner(this).resolveRegistration('formats:main')`](https://github.com/ember-intl/ember-intl/blob/v7.2.0/packages/ember-intl/addon/services/intl.ts#L313) to read the file defined in the consuming app.

In addition, the parent key names in `app/formats.js` (i.e. `date`, `dateTimeRange`, `number`, `relative`, and `time`) refer to the names that `@formatjs/intl` uses. In other words, the file `app/formats.js` leaks implementation details.


## Solution?

For simplicity, I went with @bertdeblock's idea of calling a method (named `setFormats()`), instead of asking people to install and configure `@embroider/macros`. The formats (parent keys have been renamed) are to be defined in `app/ember-intl.{js,ts}`.

```ts
/* app/ember-intl.ts */
import type { Formats } from 'ember-intl';

export const formats: Formats = {
  'format-time': {
    hhmmss: {
      hour: 'numeric',
      minute: 'numeric',
      second: 'numeric',
    },
  },
};
```

A few things to note:

- With the new formats, the key names match the names of `ember-intl`'s helpers.
- `ember-intl` provides `Formats`, the expected type for formats, in the barrel file. People can use it to check for typos and incorrect values.
- Currently, the path `app/ember-intl.{js,ts}` doesn't matter, because people will explicitly import their `formats`, then pass it to `ember-intl` via `setFormats()`.
- `setFormats()` is expected to be called in `app/routes/application.{js,ts}`, along with `setLocale()`, etc. Currently, the order doesn't matter: `setFormats()` can appear before or after `setLocale()`.

People can move away from `app/formats.js` today. See https://github.com/ember-intl/ember-intl/pull/1972/commits/08bcaa7c6a52fe28cf203c1cd18c88cf92bc47c2 for an example.
