### PR TITLE
fix: remove `ember-cli-typescript` and move `typescript` to devDeps

### DIFF
--- a/.changeset/clean-streets-search.md
+++ b/.changeset/clean-streets-search.md
@@ -1,0 +1,5 @@
+---
+"ember-intl": patch
+---
+
+Removed ember-cli-typescript from dependencies and moved typescript to devDependencies

--- a/packages/ember-intl/ember-cli-build.js
+++ b/packages/ember-intl/ember-cli-build.js
@@ -7,6 +7,10 @@ module.exports = function (defaults) {
   const { project } = defaults;
 
   const options = {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+
     autoImport: {
       webpack: {
         node: {

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -32,6 +32,12 @@ module.exports = {
   name: 'ember-intl',
   configOptions: null,
 
+  options: {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  },
+
   included(parent) {
     this._super.included.apply(this, arguments);
 

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -48,7 +48,6 @@
     "cldr-core": "^47.0.0",
     "ember-auto-import": "^2.10.1",
     "ember-cli-babel": "^8.2.0",
-    "ember-cli-typescript": "^5.3.0",
     "extend": "^3.0.2",
     "intl-messageformat": "^10.7.16",
     "js-yaml": "^4.1.0",
@@ -91,14 +90,10 @@
     "webpack": "^5.101.3"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.4 || ^3.2.0 || ^4.0.0 || ^5.0.0",
-    "typescript": "^5.0.0"
+    "@ember/test-helpers": "^2.9.4 || ^3.2.0 || ^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@ember/test-helpers": {
-      "optional": true
-    },
-    "typescript": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1966,9 +1966,6 @@ importers:
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.4)
-      ember-cli-typescript:
-        specifier: ^5.3.0
-        version: 5.3.0
       extend:
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
## Why?

<!-- Please provide a brief description of the problem. -->

It took us some time to figure out why our builds are failing for incorrect dependency chain. We were able to pinpoint to `typescript` being in peerDeps in the `ember-intl` package. I am not sure if there is a good reason to keep it as such, but it should normally be under `devDeps`.


## Solution?

<!-- Please provide a brief description of the solution. -->

* move `typescript` to `devDeps` 
* bonus, removed `ember-cli-typescript` and add config to handle typescript processing on `ember-cli-babel` level

