### PR TITLE
Dropped Ember 3.28 support

### DIFF
--- a/.changeset/warm-tips-count.md
+++ b/.changeset/warm-tips-count.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": major
+"test-app-for-ember-intl": major
+---
+
+Dropped Ember 3.28 support

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -106,7 +106,6 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - 'ember-lts-3.28'
           - 'ember-lts-4.12'
           - 'ember-lts-5.12'
           - 'ember-test-helpers-v3'

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 ## Compatibility
 
-* Ember.js v3.28 or above
+* Ember.js v4.12 or above
 * Node.js v20 or above

--- a/packages/ember-intl/README.md
+++ b/packages/ember-intl/README.md
@@ -28,5 +28,5 @@ See https://ember-intl.github.io/ember-intl/docs/quickstart.
 
 ## Compatibility
 
-* Ember.js v3.28 or above
+* Ember.js v4.12 or above
 * Node.js v20 or above

--- a/packages/ember-intl/addon/-private/utils/service.ts
+++ b/packages/ember-intl/addon/-private/utils/service.ts
@@ -1,3 +1,0 @@
-import * as s from '@ember/service';
-
-export default s.service ?? s.inject;

--- a/packages/ember-intl/addon/helpers/format-date-range.ts
+++ b/packages/ember-intl/addon/helpers/format-date-range.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatDateRange']>;

--- a/packages/ember-intl/addon/helpers/format-date.ts
+++ b/packages/ember-intl/addon/helpers/format-date.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatDate']>;

--- a/packages/ember-intl/addon/helpers/format-list.ts
+++ b/packages/ember-intl/addon/helpers/format-list.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatList']>;

--- a/packages/ember-intl/addon/helpers/format-message.ts
+++ b/packages/ember-intl/addon/helpers/format-message.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatMessage']>;

--- a/packages/ember-intl/addon/helpers/format-number.ts
+++ b/packages/ember-intl/addon/helpers/format-number.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatNumber']>;

--- a/packages/ember-intl/addon/helpers/format-relative-time.ts
+++ b/packages/ember-intl/addon/helpers/format-relative-time.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatRelativeTime']>;

--- a/packages/ember-intl/addon/helpers/format-relative.ts
+++ b/packages/ember-intl/addon/helpers/format-relative.ts
@@ -1,7 +1,7 @@
 import Helper from '@ember/component/helper';
 import { deprecate } from '@ember/debug';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatRelative']>;

--- a/packages/ember-intl/addon/helpers/format-time.ts
+++ b/packages/ember-intl/addon/helpers/format-time.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type FormatParameters = Parameters<IntlService['formatTime']>;

--- a/packages/ember-intl/addon/helpers/t.ts
+++ b/packages/ember-intl/addon/helpers/t.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
-import service from '../-private/utils/service';
 import type IntlService from '../services/intl';
 
 type TParameters = Parameters<IntlService['t']>;

--- a/tests/ember-intl/app/controllers/smoke-tests.ts
+++ b/tests/ember-intl/app/controllers/smoke-tests.ts
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
-import * as s from '@ember/service';
+import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
-
-const service = s.service ?? s.inject;
 
 export default class SmokeController extends Controller {
   @service declare intl: IntlService;

--- a/tests/ember-intl/app/routes/application.ts
+++ b/tests/ember-intl/app/routes/application.ts
@@ -1,9 +1,7 @@
 import Route from '@ember/routing/route';
-import * as s from '@ember/service';
+import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
 import { formats } from 'test-app-for-ember-intl/ember-intl';
-
-const service = s.service ?? s.inject;
 
 export default class ApplicationRoute extends Route {
   @service declare intl: IntlService;

--- a/tests/ember-intl/config/ember-try.js
+++ b/tests/ember-intl/config/ember-try.js
@@ -9,21 +9,6 @@ module.exports = async function () {
     packageManager: 'pnpm',
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '2.9.4',
-            '@types/ember__test-helpers': '2.9.1',
-            '@types/ember-qunit': '6.1.1',
-            'ember-cli': '~3.28.0',
-            'ember-page-title': '8.2.3',
-            'ember-qunit': '6.0.0',
-            'ember-resolver': '11.0.1',
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {

--- a/tests/ember-intl/tests/helpers/autotracking/currency.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/currency.ts
@@ -1,7 +1,4 @@
-import type { Registry as Services } from '@ember/service';
-import * as s from '@ember/service';
-
-const service = s.service ?? s.inject;
+import { type Registry as Services, service } from '@ember/service';
 
 export class Currency {
   @service declare intl: Services['intl'];

--- a/tests/ember-intl/tests/helpers/autotracking/population.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/population.ts
@@ -1,7 +1,4 @@
-import type { Registry as Services } from '@ember/service';
-import * as s from '@ember/service';
-
-const service = s.service ?? s.inject;
+import { type Registry as Services, service } from '@ember/service';
 
 export class Population {
   @service declare intl: Services['intl'];

--- a/tests/ember-intl/tests/helpers/autotracking/royalty.ts
+++ b/tests/ember-intl/tests/helpers/autotracking/royalty.ts
@@ -1,7 +1,4 @@
-import type { Registry as Services } from '@ember/service';
-import * as s from '@ember/service';
-
-const service = s.service ?? s.inject;
+import { type Registry as Services, service } from '@ember/service';
 
 export class Royalty {
   @service declare intl: Services['intl'];


### PR DESCRIPTION
## Background

Ember 3.28 LTS reached EOL (end of life) on January 2, 2023. By raising the minimum supported version to 4.12, we can fix [the deprecation of `inject`](https://deprecations.emberjs.com/id/importing-inject-from-ember-service) and continue to update Ember dependencies in this repo.
