### PR TITLE
Dropped @ember/test-helpers@v3 support

### DIFF
--- a/.changeset/spotty-camels-marry.md
+++ b/.changeset/spotty-camels-marry.md
@@ -1,0 +1,6 @@
+---
+"ember-intl": major
+"test-app-for-ember-intl": major
+---
+
+Dropped @ember/test-helpers@v3 support

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -108,7 +108,6 @@ jobs:
         scenario:
           - 'ember-lts-4.12'
           - 'ember-lts-5.12'
-          - 'ember-test-helpers-v3'
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'

--- a/packages/ember-intl/package.json
+++ b/packages/ember-intl/package.json
@@ -91,7 +91,7 @@
     "webpack": "^5.101.3"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.9.4 || ^3.2.0 || ^4.0.0 || ^5.0.0"
+    "@ember/test-helpers": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@ember/test-helpers": {

--- a/tests/ember-intl/config/ember-try.js
+++ b/tests/ember-intl/config/ember-try.js
@@ -25,14 +25,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-test-helpers-v3',
-        npm: {
-          devDependencies: {
-            '@ember/test-helpers': '^3.3.1',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Why?

Follows up on https://github.com/ember-intl/ember-intl/pull/1918#discussion_r1741493260 and #1996. `ember-intl@v7` had allowed `@ember/test-helpers@v3` due to Ember 3.28 support.
