### PR TITLE
Recommended installing ember-intl in addons as a peer dependency

### DIFF
--- a/.changeset/warm-bananas-wear.md
+++ b/.changeset/warm-bananas-wear.md
@@ -1,0 +1,5 @@
+---
+"docs-app-for-ember-intl": minor
+---
+
+Recommended installing ember-intl in addons as a peer dependency

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _Internationalization for Ember projects_
 
 ## Documentation
 
-Visit https://ember-intl.github.io/.
+Visit https://ember-intl.github.io/ember-intl.
 
 
 ## Compatibility

--- a/docs/ember-intl/README.md
+++ b/docs/ember-intl/README.md
@@ -6,7 +6,7 @@
 
 ## What is it?
 
-`docs-app-for-ember-intl` provides the documentation site for `ember-intl`. The app is deployed on https://ember-intl.github.io/.
+`docs-app-for-ember-intl` provides the documentation site for `ember-intl`. Markdown files for documentation live in the `src/docs` folder. The app is deployed on https://ember-intl.github.io/ember-intl.
 
 
 ## Local development

--- a/docs/ember-intl/src/docs/advanced/organizing-translations.md
+++ b/docs/ember-intl/src/docs/advanced/organizing-translations.md
@@ -97,4 +97,4 @@ title: Willkommen bei ember-intl
 
 > [!NOTE]
 > 
-> Spaces in a folder name are converted to underscores.
+> A folder name cannot include a space. Use a hyphen or an underscore instead.

--- a/docs/ember-intl/src/docs/helpers/format-display-name.md
+++ b/docs/ember-intl/src/docs/helpers/format-display-name.md
@@ -14,7 +14,7 @@ Uses [`Intl.DisplayNames`](https://developer.mozilla.org/docs/Web/JavaScript/Ref
 
 > [!IMPORTANT]
 > 
-> `type` is a required option because `Intl` doesn't specify the default value. The possible values are `"calendar"`, `"currency"`, `"dateTimeField"`, `"language"`, `"region"`, and `"script"`.
+> `type` is a required option because `Intl` doesn't specify the default value. The possible values are `'calendar'`, `'currency'`, `'dateTimeField'`, `'language'`, `'region'`, and `'script'`.
 
 
 ## Options

--- a/docs/ember-intl/src/docs/quickstart-addons.md
+++ b/docs/ember-intl/src/docs/quickstart-addons.md
@@ -2,15 +2,16 @@
 
 ## 1. Install ember-intl {#1-install-ember-intl}
 
-> [!NOTE]
+> [!TIP]
 >
-> In addons, ember-intl should be installed as a peer dependency. This is because it provides a service and a helper to the app namespace. It is important
-> that only a single copy of ember-intl is present in the final app, otherwise your addon may be run with an incompatible `intl` service or `t` helper
+> `ember-intl` adds helpers and a service to an app's namespace. To ensure that the app ends up with a single copy of `ember-intl`, we recommend installing `ember-intl` in the addon as a peer dependency, not as a dependency. The addon may decide which major version(s) of `ember-intl` to support at a given time.
+>
+> To lint and test files within the addon package, install `ember-intl` as a development dependency as well. `pnpm` provides the option `--save-peer` to do both installations at once.
 
 
 ### v1 addons {#1-install-ember-intl-v1-addons}
 
-Use your package manager to install `ember-intl` as a peer dependency. Install `@ember-intl/v1-compat` (as a development dependency) if the `dummy` app needs translations for documentation or testing.
+Use your package manager to install `ember-intl` as a peer and development dependency. If the `dummy` app needs translations for documentation or testing, install `@ember-intl/v1-compat` as a development dependency.
 
 ```sh {:no-line-numbers}
 pnpm add --save-peer ember-intl
@@ -30,7 +31,7 @@ There's nothing more to do for publishing your addon with translations. Ember au
 
 ### v2 addons {#1-install-ember-intl-v2-addons}
 
-Use your package manager to install `ember-intl` as a peer dependency.
+Use your package manager to install `ember-intl` as a peer and development dependency.
 
 ```sh {:no-line-numbers}
 pnpm add --save-peer ember-intl

--- a/docs/ember-intl/src/docs/quickstart-addons.md
+++ b/docs/ember-intl/src/docs/quickstart-addons.md
@@ -2,12 +2,18 @@
 
 ## 1. Install ember-intl {#1-install-ember-intl}
 
+> [!NOTE]
+>
+> In addons, ember-intl should be installed as a peer dependency. This is because it provides a service and a helper to the app namespace. It is important
+> that only a single copy of ember-intl is present in the final app, otherwise your addon may be run with an incompatible `intl` service or `t` helper
+
+
 ### v1 addons {#1-install-ember-intl-v1-addons}
 
-Use your package manager to install `ember-intl` (as a dependency or peer dependency). Install `@ember-intl/v1-compat` (as a development dependency) if the `dummy` app needs translations for documentation or testing.
+Use your package manager to install `ember-intl` as a peer dependency. Install `@ember-intl/v1-compat` (as a development dependency) if the `dummy` app needs translations for documentation or testing.
 
 ```sh {:no-line-numbers}
-pnpm add ember-intl
+pnpm add --save-peer ember-intl
 pnpm add -D @ember-intl/v1-compat
 ```
 
@@ -24,10 +30,10 @@ There's nothing more to do for publishing your addon with translations. Ember au
 
 ### v2 addons {#1-install-ember-intl-v2-addons}
 
-Use your package manager to install `ember-intl` (as a dependency or peer dependency).
+Use your package manager to install `ember-intl` as a peer dependency.
 
 ```sh {:no-line-numbers}
-pnpm add ember-intl
+pnpm add --save-peer ember-intl
 ```
 
 If your addon provides translations, create the folder `translations` as a sibling to `src`.


### PR DESCRIPTION
## Why?

After [a discussion with the maintainer](https://discord.com/channels/480462759797063690/487648547685269515/1545050435164045344), it became clear that ember-intl expects to be run in an app where only one version is present, due to the potential for clashes when 2 versions of the `intl` service would exist in the app.

This is not particularly unique to ember-intl, but it is one of the few addons that have explicit docs for usage in other addons.

## Solution?

Remove the mention of installing it as a dep, adjust the example `pnpm` invocations, and add a brief explainer at the top of the file